### PR TITLE
fix(web): show subscribe feedback and stop /confirm 500 on mail failure

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -104,6 +104,26 @@
       font-size: 0.9375rem;
       margin-bottom: 1.75rem;
     }
+    .notice {
+      border: 1px solid var(--border);
+      border-radius: var(--radius-input);
+      padding: 0.9rem 1.1rem;
+      font-size: 0.9375rem;
+      margin: 0 0 1.75rem;
+    }
+    .notice-success {
+      background: color-mix(in srgb, #16a34a 12%, var(--card));
+      border-color: color-mix(in srgb, #16a34a 35%, var(--border));
+      border-left: 3px solid #16a34a;
+      color: var(--text);
+    }
+    .notice-error {
+      background: color-mix(in srgb, #dc2626 12%, var(--card));
+      border-color: color-mix(in srgb, #dc2626 35%, var(--border));
+      border-left: 3px solid #dc2626;
+      color: var(--text);
+    }
+    .notice strong { font-weight: 600; }
     form > label {
       display: block;
       margin: 1.15rem 0 0.4rem;

--- a/app/templates/confirmed.html
+++ b/app/templates/confirmed.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}{% if lang == 'en' %}Subscription confirmed{% else %}Anmeldung bestätigt{% endif %} · Termine-Notifier{% endblock %}
+{% block content %}
+  <div class="notice notice-success" role="status">
+    {% if lang == 'en' %}
+      <strong>Subscription confirmed!</strong>
+    {% else %}
+      <strong>Anmeldung bestätigt!</strong>
+    {% endif %}
+  </div>
+
+  <h1>
+    {% if lang == 'en' %}You're all set{% else %}Alles erledigt{% endif %}
+  </h1>
+
+  <p>
+    {% if lang == 'en' %}
+      We'll email you as soon as a matching appointment becomes available.
+      You can change your filters or unsubscribe any time using the management
+      link we just sent you.
+    {% else %}
+      Wir benachrichtigen dich per E-Mail, sobald ein passender Termin frei
+      wird. Über den soeben verschickten Verwaltungs-Link kannst du deine
+      Filter jederzeit ändern oder dich abmelden.
+    {% endif %}
+  </p>
+{% endblock %}

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -1,5 +1,35 @@
 {% extends "base.html" %}
 {% block content %}
+  {% if confirmed == 'pending' %}
+    <div class="notice notice-success" role="status">
+      {% if lang == 'en' %}
+        <strong>Almost done!</strong> We've sent a confirmation email to your
+        inbox. Please open it and click the confirmation link to activate your
+        subscription — you won't receive any appointment alerts until you do.
+        (Check your spam folder if it hasn't arrived.)
+      {% else %}
+        <strong>Fast geschafft!</strong> Wir haben dir eine Bestätigungs-E-Mail
+        geschickt. Bitte öffne dein Postfach und klicke auf den
+        Bestätigungslink, um dein Abonnement zu aktivieren — vorher erhältst du
+        keine Termin-Benachrichtigungen. (Schau ggf. im Spam-Ordner nach.)
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if error == 'mail' %}
+    <div class="notice notice-error" role="alert">
+      {% if lang == 'en' %}
+        <strong>Hmm, that didn't go through.</strong> We couldn't send the
+        confirmation email just now. Please check your address and try again in
+        a few minutes.
+      {% else %}
+        <strong>Das hat leider nicht geklappt.</strong> Wir konnten gerade
+        keine Bestätigungs-E-Mail senden. Bitte überprüfe deine Adresse und
+        versuche es in ein paar Minuten erneut.
+      {% endif %}
+    </div>
+  {% endif %}
+
   <h1>
     {% if lang == 'en' %}Never miss a Leipzig appointment again
     {% else %}Nie wieder freie Bürgerbüro-Termine verpassen{% endif %}

--- a/app/web.py
+++ b/app/web.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 import os
 from datetime import time as time_cls
 from flask import Flask, request, render_template, redirect
@@ -11,6 +12,8 @@ from app.ratelimit import GLOBAL_IP_LIMITER, email_rate_limit_ok
 from app.tokens import sign, verify, InvalidToken
 from app.planning import would_exceed_cap
 from app.mail import send as mail_send, _idem_key
+
+log = logging.getLogger(__name__)
 
 
 def _parse_hhmm(s: str) -> time_cls:
@@ -76,10 +79,17 @@ def create_app() -> Flask:
         if lang not in ("de", "en"):
             lang = "de"
         city = request.args.get("city", "leipzig")
+        # `confirmed=pending` / `subscribe_error=mail` are set by the /subscribe
+        # redirect so the form can show a "check your inbox" banner or a
+        # retryable error instead of silently re-rendering.
+        confirmed = request.args.get("confirmed")
+        error = request.args.get("subscribe_error")
         catalog = load_catalog(city)
         return render_template("form.html",
                                lang=lang,
                                city=city,
+                               confirmed=confirmed,
+                               error=error,
                                appointment_types=catalog.appointment_types,
                                locations=catalog.locations,
                                kofi_url=app.config["TERMINE_CONFIG"].kofi_url)
@@ -139,7 +149,16 @@ def create_app() -> Flask:
             sub_id = insert_pending(conn, email=email, city=city,
                                     language=lang, filter_=f,
                                     ttl_days=cfg.subscription_ttl_days)
-        _send_confirmation_email(conn, sub_id, email, lang, cfg)
+        # The confirmation email is the ONLY way the user can complete signup,
+        # so — unlike the manage-link email in /confirm — we must NOT claim
+        # success if it fails. Surface a retryable error instead of a 500 and
+        # drop the orphaned pending row so it can't linger unconfirmable.
+        try:
+            _send_confirmation_email(conn, sub_id, email, lang, cfg)
+        except Exception:
+            log.exception("confirmation email failed for sub %s", sub_id)
+            soft_delete(conn, sub_id)
+            return redirect("/?subscribe_error=mail")
         return redirect("/?confirmed=pending")
 
     @app.route("/confirm/<token>")
@@ -153,8 +172,22 @@ def create_app() -> Flask:
             return ("Invalid token", 400)
         conn = connect(cfg.db_path)
         confirm(conn, sub_id)
-        _send_manage_link_email(conn, sub_id, cfg)
-        return ("Subscription confirmed.", 200)
+        row = conn.execute("SELECT language FROM subscriptions WHERE id=?",
+                           (sub_id,)).fetchone()
+        lang = row["language"] if row else "de"
+        # The management-link email is a convenience, NOT part of confirmation.
+        # The subscription is already confirmed above (autocommit), so a
+        # mail-provider failure must never turn this into a 500 — log it and
+        # still show the user their success page.
+        try:
+            _send_manage_link_email(conn, sub_id, cfg)
+        except Exception:
+            log.exception(
+                "manage-link email failed for sub %s; confirmation still succeeded",
+                sub_id,
+            )
+        return render_template("confirmed.html", lang=lang,
+                               kofi_url=cfg.kofi_url), 200
 
     @app.route("/unsubscribe/<token>")
     def unsubscribe_route(token):

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -43,6 +43,29 @@ def test_subscribe_success_with_mocked_mail(client):
     assert r.status_code in (200, 302)
     send.assert_called_once()
 
+def test_subscribe_mail_failure_does_not_500(client):
+    """If the confirmation email fails to send, /subscribe must NOT 500 and
+    must NOT pretend success. It surfaces a retryable error and drops the
+    orphaned (unconfirmable) pending row. Regression test for the same
+    unguarded-mail-send class of bug as /confirm."""
+    import os
+    from unittest.mock import patch
+    from app.db import connect
+    # Distinct IP + email so the session-global IP limiter and the DB row
+    # query don't collide with other subscribe tests.
+    email = "mailfail@example.com"
+    with patch("app.web._send_confirmation_email",
+               side_effect=RuntimeError("mail provider exploded")):
+        r = client.post("/subscribe", data=_form(email=email),
+                        headers={"X-Forwarded-For": "9.9.9.9"})
+    assert r.status_code == 302, r.data[:300]
+    assert "subscribe_error=mail" in r.headers.get("Location", "")
+    # The pending row must not linger as an unconfirmable orphan.
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT deleted_at FROM subscriptions WHERE email=?",
+                       (email,)).fetchone()
+    assert row is not None and row["deleted_at"] is not None
+
 def test_honeypot_silently_drops_and_does_not_email(client):
     from unittest.mock import patch
     f = _form()

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -46,6 +46,27 @@ def test_confirm_marks_subscription_confirmed(client):
         r2 = c.get(f"/confirm/{tok}")
     assert r2.status_code in (200, 302)
 
+def test_confirm_survives_manage_link_email_failure(client):
+    """A failure sending the (secondary) management-link email must NOT turn a
+    successful confirmation into a 500. The subscription is already confirmed;
+    the manage-link email is a convenience. Regression test for the production
+    'Internal Server Error' on /confirm."""
+    from unittest.mock import patch
+    c, sid = client
+    tok = _sign(sid, "confirm")
+    with patch("app.web._send_manage_link_email",
+               side_effect=RuntimeError("mail provider exploded")):
+        r = c.get(f"/confirm/{tok}")
+    assert r.status_code == 200, r.data[:300]
+    # The subscription must actually be confirmed despite the email failure.
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT confirmed_at FROM subscriptions WHERE id=?",
+                       (sid,)).fetchone()
+    assert row["confirmed_at"] is not None
+    # And the page must show a human-readable confirmation (sub is German).
+    assert b"best\xc3\xa4tigt" in r.data.lower()  # "bestätigt"
+
+
 def test_unsubscribe_soft_deletes(client):
     from unittest.mock import patch
     c, sid = client

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -47,3 +47,36 @@ def test_form_offers_de_and_en(client):
     r_en = client.get("/?lang=en")
     assert r_de.status_code == 200 and r_en.status_code == 200
     assert b"Anmelden" in r_de.data or b"abonnieren" in r_de.data.lower()
+
+def test_pending_banner_shown_after_subscribe(client):
+    """/subscribe redirects to /?confirmed=pending. That page MUST tell the
+    user to check their inbox and confirm — otherwise the redirect looks like
+    the form just reloaded with no feedback. Regression test."""
+    r_de = client.get("/?confirmed=pending&lang=de")
+    assert r_de.status_code == 200
+    assert "fast geschafft" in r_de.data.decode().lower()
+    r_en = client.get("/?confirmed=pending&lang=en")
+    assert "almost done" in r_en.data.decode().lower()
+
+def test_no_pending_banner_on_bare_form(client):
+    """The pending banner must only appear after subscribing, not on the
+    bare form."""
+    body = client.get("/").data.decode().lower()
+    assert "fast geschafft" not in body
+    body_en = client.get("/?lang=en").data.decode().lower()
+    assert "almost done" not in body_en
+
+def test_subscribe_error_banner_shown(client):
+    """When a confirmation email could not be sent, /?subscribe_error=mail
+    shows a localized, retryable error banner."""
+    r_de = client.get("/?subscribe_error=mail&lang=de")
+    assert r_de.status_code == 200
+    assert "erneut" in r_de.data.decode().lower()
+    r_en = client.get("/?subscribe_error=mail&lang=en")
+    assert "try again" in r_en.data.decode().lower()
+
+def test_no_error_banner_on_bare_form(client):
+    body = client.get("/").data.decode().lower()
+    assert "leider nicht geklappt" not in body
+    body_en = client.get("/?lang=en").data.decode().lower()
+    assert "didn't go through" not in body_en


### PR DESCRIPTION
## What & why

Two user-facing bugs in the **subscribe → confirm** flow, plus a hardening pass on the same root cause.

### 1. Clicking *Subscribe* just reloaded the form (no feedback)
`/subscribe` redirects to `/?confirmed=pending`, but `index()` never read the param and `form.html` had no banner — so the 302 landed on an identical empty form. **Fix:** localized "check your inbox, click the confirmation link" banner.

### 2. The `/confirm` link returned **HTTP 500**
`confirm_route()` confirms the subscription (commits immediately under autocommit), then calls `_send_manage_link_email()` — a live Mailjet call — **with no error handling**. Any provider hiccup 500'd an *already-successful* confirmation. **Fix:** wrap the manage-link email in `try/except` + `log.exception`, render a proper localized `confirmed.html`.

### 3. Hardened the same pattern in `/subscribe`
`_send_confirmation_email` was *also* unguarded — and there the email is the only way to complete signup. **Fix:** on failure, log, drop the orphaned (unconfirmable) pending row, and show a retryable error banner instead of a 500.

## Tests
+6 regression tests (banner shown/absent, `/confirm` survives a mail failure, `/subscribe` survives a mail failure). Full suite: **102 passed, 3 skipped**.

## Deploy note
Web image bakes code in via `COPY` (no bind mount), so after merge the Pi needs a **rebuild**: `git pull && docker compose up -d --build web`.
