### PR TITLE
fix(web): preserve query params (incl. admin token) on language switch

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -225,8 +225,8 @@
 <body>
   <div class="container">
     <nav class="lang-switcher" aria-label="{% if lang == 'en' %}Language{% else %}Sprache{% endif %}">
-      <a href="?lang=de" class="lang-pill {% if lang != 'en' %}active{% endif %}" hreflang="de">DE</a>
-      <a href="?lang=en" class="lang-pill {% if lang == 'en' %}active{% endif %}" hreflang="en">EN</a>
+      <a href="{{ switch_lang_url('de') }}" class="lang-pill {% if lang != 'en' %}active{% endif %}" hreflang="de">DE</a>
+      <a href="{{ switch_lang_url('en') }}" class="lang-pill {% if lang == 'en' %}active{% endif %}" hreflang="en">EN</a>
     </nav>
     <main class="card">
       {% block content %}{% endblock %}

--- a/app/web.py
+++ b/app/web.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 import os
 from datetime import time as time_cls
+from urllib.parse import urlencode
 from flask import Flask, request, render_template, redirect
 from app.config import load_config
 from app.db import connect, init_schema, transaction
@@ -65,6 +66,18 @@ def create_app() -> Flask:
     # Load config ONCE at startup. Missing env vars surface here, not on
     # the first real request.
     app.config["TERMINE_CONFIG"] = load_config()
+
+    @app.context_processor
+    def _template_helpers():
+        # Build the language-switch URL by preserving the current query string
+        # and overriding only `lang`. A bare `?lang=xx` would drop every other
+        # param — most importantly the admin `?token=`, which then 401s, and
+        # the form's `city` / `confirmed` / `subscribe_error`.
+        def switch_lang_url(target_lang: str) -> str:
+            args = request.args.to_dict(flat=True)
+            args["lang"] = target_lang
+            return f"{request.path}?{urlencode(args)}"
+        return {"switch_lang_url": switch_lang_url}
 
     @app.route("/healthz")
     def healthz():

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -48,6 +48,28 @@ def test_form_offers_de_and_en(client):
     assert r_de.status_code == 200 and r_en.status_code == 200
     assert b"Anmelden" in r_de.data or b"abonnieren" in r_de.data.lower()
 
+def _en_switch_href(html):
+    import re
+    m = re.search(r'href="([^"]*)"[^>]*hreflang="en"', html)
+    assert m, "EN language-switch link not found"
+    return m.group(1)
+
+def test_lang_switch_preserves_admin_token(client):
+    """Clicking EN/DE on /admin must keep the ?token= param, or the switch
+    navigates to an unauthenticated URL and 401s. Regression test."""
+    tok = "a" * 32  # matches ADMIN_TOKEN in the fixture
+    r = client.get(f"/admin?token={tok}")
+    assert r.status_code == 200, r.data[:200]
+    en_href = _en_switch_href(r.data.decode())
+    assert "lang=en" in en_href
+    assert f"token={tok}" in en_href
+
+def test_lang_switch_preserves_form_query_params(client):
+    """Switching language on the post-subscribe page must keep ?confirmed so
+    the banner (and city) survive the switch."""
+    en_href = _en_switch_href(client.get("/?confirmed=pending&lang=de").data.decode())
+    assert "confirmed=pending" in en_href and "lang=en" in en_href
+
 def test_pending_banner_shown_after_subscribe(client):
     """/subscribe redirects to /?confirmed=pending. That page MUST tell the
     user to check their inbox and confirm — otherwise the redirect looks like


### PR DESCRIPTION
## Bug
On `/admin?token=…`, clicking **EN/DE** returned **401 Unauthorized** — the language switcher linked to a bare `?lang=xx`, which replaces the whole query string and drops the `token`. The same flaw silently dropped the public form's `city` / `confirmed` / `subscribe_error` params (e.g. the post-subscribe banner disappears on a language switch).

## Fix
A `switch_lang_url()` template helper (Flask context processor) rebuilds the link from the **current** query string, overriding only `lang`:

```python
def switch_lang_url(target_lang):
    args = request.args.to_dict(flat=True)
    args["lang"] = target_lang
    return f"{request.path}?{urlencode(args)}"
```

`base.html` now uses `{{ switch_lang_url('de') }}` / `{{ switch_lang_url('en') }}`.

Rendered result: `/admin?token=…&lang=en` (token survives), `/?confirmed=pending&city=leipzig&lang=en`.

## Tests
+2 regression tests (admin token preserved, form params preserved). Full suite: **104 passed, 3 skipped**.

## Deploy
Same as before — after merge, on the Pi: `git pull && docker compose up -d --build web`.
