### PR TITLE
fix(web): hide the no-op language switcher on the admin page

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -224,10 +224,14 @@
 </head>
 <body>
   <div class="container">
+    {# Hidden on non-localized pages (e.g. the English-only admin view) via
+       show_lang_switcher=False; defaults to shown everywhere else. #}
+    {% if show_lang_switcher | default(true) %}
     <nav class="lang-switcher" aria-label="{% if lang == 'en' %}Language{% else %}Sprache{% endif %}">
       <a href="{{ switch_lang_url('de') }}" class="lang-pill {% if lang != 'en' %}active{% endif %}" hreflang="de">DE</a>
       <a href="{{ switch_lang_url('en') }}" class="lang-pill {% if lang == 'en' %}active{% endif %}" hreflang="en">EN</a>
     </nav>
+    {% endif %}
     <main class="card">
       {% block content %}{% endblock %}
     </main>

--- a/app/web.py
+++ b/app/web.py
@@ -296,7 +296,10 @@ def create_app() -> Flask:
             return ("Unauthorized", 401)
         from app.admin import stats
         conn = connect(cfg.db_path)
-        return render_template("admin.html", stats=stats(conn))
+        # Admin is an internal, English-only stats page — hide the (no-op)
+        # DE/EN switcher that base.html otherwise renders.
+        return render_template("admin.html", stats=stats(conn),
+                               show_lang_switcher=False)
 
     @app.route("/datenschutz")
     def datenschutz_route():

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -54,21 +54,22 @@ def _en_switch_href(html):
     assert m, "EN language-switch link not found"
     return m.group(1)
 
-def test_lang_switch_preserves_admin_token(client):
-    """Clicking EN/DE on /admin must keep the ?token= param, or the switch
-    navigates to an unauthenticated URL and 401s. Regression test."""
-    tok = "a" * 32  # matches ADMIN_TOKEN in the fixture
-    r = client.get(f"/admin?token={tok}")
-    assert r.status_code == 200, r.data[:200]
-    en_href = _en_switch_href(r.data.decode())
-    assert "lang=en" in en_href
-    assert f"token={tok}" in en_href
-
 def test_lang_switch_preserves_form_query_params(client):
     """Switching language on the post-subscribe page must keep ?confirmed so
     the banner (and city) survive the switch."""
     en_href = _en_switch_href(client.get("/?confirmed=pending&lang=de").data.decode())
     assert "confirmed=pending" in en_href and "lang=en" in en_href
+
+def test_admin_has_no_language_switcher(client):
+    """The admin page is an internal, English-only stats page. The inherited
+    DE/EN toggle does nothing there, so it must be hidden."""
+    r = client.get("/admin?token=" + "a" * 32)
+    assert r.status_code == 200
+    assert 'hreflang="en"' not in r.data.decode()  # switcher link absent
+
+def test_form_keeps_language_switcher(client):
+    """The public form must still offer the language switcher."""
+    assert 'hreflang="en"' in client.get("/").data.decode()
 
 def test_pending_banner_shown_after_subscribe(client):
     """/subscribe redirects to /?confirmed=pending. That page MUST tell the


### PR DESCRIPTION
## Bug
On `/admin`, the DE/EN toggle did nothing — both variants rendered identical English, so it looked like you "couldn't switch to German". The admin route never reads `lang` and `admin.html` has no German text (it lists raw metric keys); the switcher was only there because it's inherited from `base.html`. The earlier 401 masked this.

## Fix
Gate the switcher in `base.html` behind `{% if show_lang_switcher | default(true) %}` (shown everywhere by default) and pass `show_lang_switcher=False` from the admin route. The public form keeps its working, query-preserving switcher.

Removes the now-obsolete `test_lang_switch_preserves_admin_token` (the switcher no longer exists on `/admin`); the helper's param-preservation stays covered by `test_lang_switch_preserves_form_query_params`.

## Verify (rendered)
- `/admin?token=…` and `/admin?token=…&lang=en` → switcher absent
- `/` → switcher present

Full suite: **105 passed, 3 skipped**.

## Deploy
After merge, on the Pi: `git pull && docker compose up -d --build web`.
