### PR TITLE
feat(admin): track upstream poll/request counts + surface ops metrics

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sqlite3
+from datetime import datetime
 
 
 def stats(conn: sqlite3.Connection) -> dict:
@@ -41,6 +42,27 @@ def stats(conn: sqlite3.Connection) -> dict:
         "WHERE zero_match_since IS NOT NULL"
     ).fetchall()
     canary = {r["city"]: r["zero_match_since"] for r in canary_rows}
+    # Upstream poll/request counters + last-polled, per city. Defensive: a DB
+    # that hasn't been migrated to the counter columns yet reports zeros.
+    today = datetime.utcnow().date().isoformat()
+    upstream_by_city: dict[str, dict] = {}
+    last_polled_at_by_city: dict[str, str] = {}
+    try:
+        for r in conn.execute(
+            "SELECT city, polls_today, polls_total, requests_today, "
+            "requests_total, counts_date, last_polled_at FROM city_state"
+        ).fetchall():
+            fresh = r["counts_date"] == today
+            upstream_by_city[r["city"]] = {
+                "polls_today": r["polls_today"] if fresh else 0,
+                "polls_total": r["polls_total"],
+                "requests_today": r["requests_today"] if fresh else 0,
+                "requests_total": r["requests_total"],
+            }
+            if r["last_polled_at"]:
+                last_polled_at_by_city[r["city"]] = r["last_polled_at"]
+    except sqlite3.OperationalError:
+        pass  # pre-migration DB; counters not available yet
     return {
         "active_subscriptions":
             scalar("SELECT COUNT(*) FROM subscriptions WHERE deleted_at IS NULL "
@@ -61,6 +83,12 @@ def stats(conn: sqlite3.Connection) -> dict:
             scalar("SELECT COUNT(*) FROM sent_idempotency "
                    "WHERE sent_at > datetime('now','-7 days') "
                    "AND provider != 'pending'"),
+        "upstream_by_city": upstream_by_city,
+        "last_polled_at_by_city": last_polled_at_by_city,
+        "slots_cached": scalar("SELECT COUNT(*) FROM slots_cache"),
+        "emails_sent_total":
+            scalar("SELECT COUNT(*) FROM sent_idempotency WHERE provider != 'pending'"),
+        "last_failure_alert_at": meta_val("last_failure_alert_at"),
         "last_housekeeping_at": meta_val("last_housekeeping_at"),
         "last_backup_at":       meta_val("last_backup_at"),
     }

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -7,6 +7,7 @@ from app.planning import build_plans
 from app.repo import (active_subscriptions, has_seen_slot, record_seen_slot,
                        set_last_notified)
 from app.scrapers import get_scraper
+from app.http_session import CountingSession
 from app.models import Subscription, Slot, PollPlan
 
 # Imported here so tests can monkey-patch it.
@@ -22,45 +23,75 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
     subs = active_subscriptions(conn)
     if not subs:
         return
-    http = http or requests.Session()
+    http = http or CountingSession()
     plans = build_plans([(s.city, s.sub_filter) for s in subs],
                         max_plans_per_city=max_plans_per_city)
-    # Collect slots per plan + per-city canary tracking
+    # Collect slots per plan + per-city canary tracking + upstream-call counters
     slots_by_plan: dict[str, list[Slot]] = {}
     cities_with_any_slot: set[str] = set()
     cities_polled: set[str] = set()
+    polls_delta: dict[str, int] = {}
+    requests_delta: dict[str, int] = {}
     for p in plans:
         cities_polled.add(p.city)
+        # Snapshot the HTTP-request counter so we can attribute the requests
+        # this single poll makes to its city (a CountingSession exposes it; a
+        # plain/mocked session does not, in which case we just skip HTTP counts).
+        before = getattr(http, "request_count", None)
         try:
             slots_by_plan[p.key()] = get_scraper(p.city).poll(p, http=http)
             if slots_by_plan[p.key()]:
                 cities_with_any_slot.add(p.city)
         except Exception:
             slots_by_plan[p.key()] = []
-    # Update per-city canary state in the typed city_state table.
-    # Clear `zero_match_since` when at least one plan returned slots;
-    # set it on the first all-zero cycle.
+        polls_delta[p.city] = polls_delta.get(p.city, 0) + 1
+        if before is not None:
+            requests_delta[p.city] = (requests_delta.get(p.city, 0)
+                                      + (http.request_count - before))
+    # Update per-city canary state + upstream counters in the typed city_state
+    # table. Clear `zero_match_since` when at least one plan returned slots;
+    # set it on the first all-zero cycle. The canary write and the counter
+    # write touch the same row, so wrap them in one transaction — otherwise a
+    # concurrent admin reader could observe a half-updated row (fresh
+    # last_polled_at with stale counters, or vice versa).
+    from app.db import transaction
     now_iso = datetime.utcnow().isoformat()
-    for city in cities_polled:
-        # Ensure the row exists.
-        conn.execute(
-            "INSERT INTO city_state (city) VALUES (?) "
-            "ON CONFLICT (city) DO NOTHING",
-            (city,),
-        )
-        if city in cities_with_any_slot:
+    today = now_iso[:10]  # UTC date the *_today counters belong to
+    with transaction(conn):
+        for city in cities_polled:
+            # Ensure the row exists.
             conn.execute(
-                "UPDATE city_state SET zero_match_since=NULL, "
-                "last_polled_at=? WHERE city=?",
-                (now_iso, city),
+                "INSERT INTO city_state (city) VALUES (?) "
+                "ON CONFLICT (city) DO NOTHING",
+                (city,),
             )
-        else:
+            if city in cities_with_any_slot:
+                conn.execute(
+                    "UPDATE city_state SET zero_match_since=NULL, "
+                    "last_polled_at=? WHERE city=?",
+                    (now_iso, city),
+                )
+            else:
+                conn.execute(
+                    "UPDATE city_state "
+                    "SET zero_match_since=COALESCE(zero_match_since, ?), "
+                    "    last_polled_at=? "
+                    "WHERE city=?",
+                    (now_iso, now_iso, city),
+                )
+            # Upstream poll/request counters. The CASE resets the *_today values
+            # lazily when the UTC day rolls over; the all-time totals keep growing.
+            pd = polls_delta.get(city, 0)
+            rd = requests_delta.get(city, 0)
             conn.execute(
-                "UPDATE city_state "
-                "SET zero_match_since=COALESCE(zero_match_since, ?), "
-                "    last_polled_at=? "
-                "WHERE city=?",
-                (now_iso, now_iso, city),
+                "UPDATE city_state SET "
+                "  polls_today    = (CASE WHEN counts_date = ? THEN polls_today    ELSE 0 END) + ?, "
+                "  requests_today = (CASE WHEN counts_date = ? THEN requests_today ELSE 0 END) + ?, "
+                "  polls_total    = polls_total    + ?, "
+                "  requests_total = requests_total + ?, "
+                "  counts_date    = ? "
+                "WHERE city = ?",
+                (today, pd, today, rd, pd, rd, today, city),
             )
     now = datetime.utcnow()
     rate_cutoff = now - timedelta(minutes=rate_limit_minutes)
@@ -86,7 +117,6 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
         # sends across retries; this transaction ensures that IF the email
         # was sent, the seen_slots + last_notified_at writes are visible
         # together — preventing a crash from re-presenting the same slots.
-        from app.db import transaction
         # Cache each slot's city + upstream URL so /go/<token> works for
         # any city without hardcoding Leipzig. The scrapers know their
         # own upstream URL format; ask them via the catalog.

--- a/app/db.py
+++ b/app/db.py
@@ -3,7 +3,7 @@ import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS subscriptions (
@@ -51,7 +51,11 @@ CREATE TABLE IF NOT EXISTS city_state (
   zero_match_since      TIMESTAMP,
   last_canary_alert_at  TIMESTAMP,
   requests_today        INTEGER NOT NULL DEFAULT 0,
-  last_polled_at        TIMESTAMP
+  last_polled_at        TIMESTAMP,
+  polls_today           INTEGER NOT NULL DEFAULT 0,
+  polls_total           INTEGER NOT NULL DEFAULT 0,
+  requests_total        INTEGER NOT NULL DEFAULT 0,
+  counts_date           TEXT
 );
 
 CREATE TABLE IF NOT EXISTS slots_cache (
@@ -92,8 +96,33 @@ def transaction(conn: sqlite3.Connection):
     else:
         conn.execute("COMMIT")
 
+def _add_missing_columns(conn: sqlite3.Connection, table: str,
+                         columns: dict[str, str]) -> None:
+    """Idempotently add columns that an existing table may predate.
+
+    `CREATE TABLE IF NOT EXISTS` never alters an already-present table, so
+    schema additions to a live DB need explicit `ALTER TABLE ADD COLUMN`. The
+    duplicate-column `try/except` makes this safe even if two processes (poller
+    and web) run init_schema concurrently.
+    """
+    existing = {r["name"] for r in conn.execute(f"PRAGMA table_info({table})")}
+    for name, decl in columns.items():
+        if name in existing:
+            continue
+        try:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {decl}")
+        except sqlite3.OperationalError:
+            pass  # added concurrently by another process
+
 def init_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(SCHEMA_SQL)
+    # Upgrade pre-existing city_state rows that predate the poll/request counters.
+    _add_missing_columns(conn, "city_state", {
+        "polls_today":    "INTEGER NOT NULL DEFAULT 0",
+        "polls_total":    "INTEGER NOT NULL DEFAULT 0",
+        "requests_total": "INTEGER NOT NULL DEFAULT 0",
+        "counts_date":    "TEXT",
+    })
     conn.execute(
         "INSERT INTO meta (key, value) VALUES ('schema_version', ?) "
         "ON CONFLICT (key) DO UPDATE SET value=excluded.value, "

--- a/app/http_session.py
+++ b/app/http_session.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import requests
+
+
+class CountingSession(requests.Session):
+    """A `requests.Session` that counts every HTTP request made through it.
+
+    Used to measure how many calls we make to upstream (Leipzig) endpoints.
+    `Session.get`/`post`/etc. all funnel through `request()`, so overriding it
+    captures everything. Mailjet/Resend sends use their own `requests.post`,
+    not this session, so they are deliberately not counted.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.request_count = 0
+
+    def request(self, *args, **kwargs):  # type: ignore[override]
+        self.request_count += 1
+        return super().request(*args, **kwargs)

--- a/app/poller.py
+++ b/app/poller.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 import os
 import time as time_mod
 from datetime import datetime, timedelta
-import requests
 from app.config import load_config
 from app.db import connect, init_schema
 from app.cycle import run_cycle
+from app.http_session import CountingSession
 from app.housekeeping import run_once as housekeeping_run
 
 def main() -> None:
     cfg = load_config()
     conn = connect(cfg.db_path)
     init_schema(conn)
-    http = requests.Session()
+    http = CountingSession()
     consecutive_failures = 0
     while True:
         # Sleep until next minute boundary

--- a/docs/specs/2026-06-03-admin-ops-metrics-design.md
+++ b/docs/specs/2026-06-03-admin-ops-metrics-design.md
@@ -1,0 +1,70 @@
+# Admin ops metrics — design
+
+**Date:** 2026-06-03
+**Status:** approved
+
+## Goal
+
+Surface more operational visibility on `/admin`, primarily **how many requests
+we send upstream to Leipzig** (relevant to the IP-block runbook / ≤10 req/min
+posture), plus a few cheap already-available metrics.
+
+## Background
+
+- `city_state.requests_today` exists in the schema but is **never written** — it
+  always reads 0.
+- `last_polled_at` is written per city per cycle (`cycle.py`).
+- One `poll()` to Leipzig makes **2–4 HTTP requests** (acquire WSID → CSRF →
+  POST services → POST locations; a WSID cache amortises the session GETs).
+- `init_schema` runs in the **poller** at startup, not in web. Poller uses a
+  plain `requests.Session`.
+
+## Decisions (from brainstorming)
+
+- Count **both** poll cycles and underlying HTTP requests, shown separately.
+- Keep **both** a `today` value and an **all-time** total, per city.
+- Also surface: last poll time per city, slots currently cached, emails sent
+  all-time, last poller failure alert.
+
+## Design
+
+### Schema (`city_state`)
+Reuse existing `requests_today`; add `polls_today`, `polls_total`,
+`requests_total` (all `INTEGER NOT NULL DEFAULT 0`) and `counts_date TEXT`
+(the UTC date the `*_today` values belong to). Bump `SCHEMA_VERSION` → 2.
+
+Migration: idempotent `ALTER TABLE ADD COLUMN` guarded by `PRAGMA table_info`
+plus a duplicate-column `try/except` (so concurrent poller/web startup can't
+crash). Fresh installs get the columns from `SCHEMA_SQL`.
+
+### Counting
+- `app/http_session.py`: `CountingSession(requests.Session)` increments
+  `request_count` on every `request()` — counts **only** upstream Leipzig calls
+  (Mailjet uses a separate path).
+- Poller uses `CountingSession` (reused across cycles, as today).
+- `run_cycle` attributes, per plan, `+1 poll` and `+Δrequest_count` to that
+  plan's city, then persists with one set-based UPDATE that **resets the
+  `*_today` values when `counts_date` rolls over** (lazy daily reset on write;
+  no dependency on housekeeping timing). "Today" = UTC date.
+
+### Admin stats (`app/admin.py`)
+Add `upstream_by_city` (`{city: {polls_today, polls_total, requests_today,
+requests_total}}`, today values shown as 0 when `counts_date` ≠ today),
+`last_polled_at_by_city`, `slots_cached`, `emails_sent_total`,
+`last_failure_alert_at`. Counter reads are wrapped defensively (zeros if a DB
+hasn't migrated yet). No template change — `admin.html` already loops
+`stats.items()`.
+
+## Testing
+- `CountingSession` increments on request.
+- `run_cycle` attributes polls + HTTP requests to `city_state`.
+- Migration is idempotent and adds columns to a pre-existing `city_state`.
+- `stats()` returns the new keys with correct values incl. today-gating.
+- `/admin` renders the new keys.
+
+## Deploy
+Touches the **poller** (counting + migration) and **web** (reading), so the
+rebuild must include both: `docker compose up -d --build web poller`.
+
+## Out of scope (YAGNI)
+Per-cycle history table; rolling-24h window; admin-page localisation.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,6 +1,8 @@
 import pytest
+from datetime import datetime
 from app.web import create_app
 from app.db import connect, init_schema
+from app.admin import stats
 import os
 
 @pytest.fixture
@@ -49,3 +51,41 @@ def test_go_route_redirects_on_cache_hit(client):
 def test_go_route_returns_410_on_miss(client):
     r = client.get("/go/nonexistent-token", follow_redirects=False)
     assert r.status_code == 410
+
+def test_admin_renders_new_metrics(client):
+    r = client.get("/admin?token=admin-tok")
+    assert r.status_code == 200
+    for key in (b"upstream_by_city", b"slots_cached",
+                b"emails_sent_total", b"last_failure_alert_at"):
+        assert key in r.data, f"missing admin metric: {key!r}"
+
+def test_stats_includes_upstream_and_extra_metrics(tmp_path):
+    conn = connect(str(tmp_path / "s.db")); init_schema(conn)
+    today = datetime.utcnow().date().isoformat()
+    conn.execute(
+        "INSERT INTO city_state (city, polls_today, polls_total, requests_today, "
+        "requests_total, counts_date, last_polled_at) "
+        "VALUES ('leipzig', 5, 50, 12, 120, ?, ?)",
+        (today, "2026-06-03T10:00:00"))
+    conn.execute("INSERT INTO slots_cache (slot_token, city, upstream_url) "
+                 "VALUES ('t', 'leipzig', 'u')")
+    conn.execute("INSERT INTO sent_idempotency (idem_key, provider) VALUES ('k', 'mailjet')")
+    conn.execute("INSERT INTO sent_idempotency (idem_key, provider) VALUES ('p', 'pending')")
+    conn.execute("INSERT INTO meta (key, value) VALUES ('last_failure_alert_at', '2026-06-01T00:00:00')")
+    s = stats(conn)
+    up = s["upstream_by_city"]["leipzig"]
+    assert up == {"polls_today": 5, "polls_total": 50,
+                  "requests_today": 12, "requests_total": 120}
+    assert s["last_polled_at_by_city"]["leipzig"] == "2026-06-03T10:00:00"
+    assert s["slots_cached"] == 1
+    assert s["emails_sent_total"] == 1   # 'pending' excluded
+    assert s["last_failure_alert_at"] == "2026-06-01T00:00:00"
+
+def test_stats_today_counts_gated_by_stale_date(tmp_path):
+    conn = connect(str(tmp_path / "s.db")); init_schema(conn)
+    conn.execute(
+        "INSERT INTO city_state (city, polls_today, polls_total, requests_today, "
+        "requests_total, counts_date) VALUES ('leipzig', 99, 50, 99, 120, '2000-01-01')")
+    up = stats(conn)["upstream_by_city"]["leipzig"]
+    assert up["polls_today"] == 0 and up["requests_today"] == 0   # stale day -> 0
+    assert up["polls_total"] == 50 and up["requests_total"] == 120  # totals intact

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -68,6 +68,35 @@ def test_init_schema_is_idempotent(tmp_path):
     cur = conn.execute("SELECT value FROM meta WHERE key='schema_version'")
     assert cur.fetchone()[0] == str(SCHEMA_VERSION)
 
+def test_city_state_has_counter_columns(tmp_path):
+    conn = connect(str(tmp_path / "t.db"))
+    init_schema(conn)
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(city_state)")}
+    for c in ("polls_today", "polls_total", "requests_today",
+              "requests_total", "counts_date"):
+        assert c in cols, f"missing city_state column: {c}"
+
+def test_migration_adds_counters_to_preexisting_city_state(tmp_path):
+    """An older DB whose city_state predates the counter columns must be
+    upgraded in place without losing rows."""
+    db = str(tmp_path / "old.db")
+    raw = sqlite3.connect(db)
+    raw.executescript(
+        "CREATE TABLE city_state ("
+        "  city TEXT PRIMARY KEY, zero_match_since TIMESTAMP,"
+        "  last_canary_alert_at TIMESTAMP,"
+        "  requests_today INTEGER NOT NULL DEFAULT 0,"
+        "  last_polled_at TIMESTAMP);"
+    )
+    raw.execute("INSERT INTO city_state (city) VALUES ('leipzig')")
+    raw.commit(); raw.close()
+    conn = connect(db)
+    init_schema(conn)  # must ALTER in the missing columns
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(city_state)")}
+    for c in ("polls_today", "polls_total", "requests_total", "counts_date"):
+        assert c in cols, f"migration missed column: {c}"
+    assert conn.execute("SELECT city FROM city_state").fetchone()["city"] == "leipzig"
+
 def test_wal_mode_enabled(tmp_path):
     db_path = tmp_path / "test.db"
     conn = connect(str(db_path))

--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+from app.http_session import CountingSession
+
+
+def test_counting_session_starts_at_zero():
+    assert CountingSession().request_count == 0
+
+
+def test_counting_session_counts_get_post_and_request():
+    s = CountingSession()
+    # Patch the parent so no real network call happens; CountingSession.request
+    # (the subclass override) still runs and increments.
+    with patch("requests.sessions.Session.request", return_value="resp") as parent:
+        s.get("http://example.test")
+        s.post("http://example.test")
+        s.request("GET", "http://example.test")
+    assert s.request_count == 3
+    assert parent.call_count == 3

--- a/tests/test_polling_cycle.py
+++ b/tests/test_polling_cycle.py
@@ -65,6 +65,50 @@ def test_cycle_skips_already_seen_slot(db):
                   cycle_id="c1")
     send_d.assert_not_called()
 
+def test_cycle_records_poll_and_request_counts(db):
+    """run_cycle must attribute one poll and the HTTP-request delta per poll to
+    the polled city's counters."""
+    sid = insert_pending(db, email="a@x.com", city="leipzig",
+                        language="de", filter_=_f(["svc-A"]), ttl_days=90)
+    confirm(db, sid)
+    fake_slots = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "tok")]
+    def fake_poll(plan, http):
+        http.request_count += 3   # simulate 3 upstream HTTP calls
+        return fake_slots
+    with patch("app.cycle.get_scraper") as gs, patch("app.cycle.send_digest"):
+        scraper = MagicMock()
+        scraper.poll.side_effect = fake_poll
+        gs.return_value = scraper
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+    row = db.execute(
+        "SELECT polls_today, polls_total, requests_today, requests_total "
+        "FROM city_state WHERE city='leipzig'").fetchone()
+    assert row["polls_today"] == 1 and row["polls_total"] == 1
+    assert row["requests_today"] == 3 and row["requests_total"] == 3
+
+def test_cycle_resets_today_counters_on_date_rollover(db):
+    """A stale `counts_date` resets the *_today counters on the next cycle, but
+    the all-time totals keep accumulating."""
+    db.execute(
+        "INSERT INTO city_state (city, polls_today, polls_total, "
+        "requests_today, requests_total, counts_date) "
+        "VALUES ('leipzig', 99, 99, 99, 99, '2000-01-01')")
+    sid = insert_pending(db, email="a@x.com", city="leipzig",
+                        language="de", filter_=_f(["svc-A"]), ttl_days=90)
+    confirm(db, sid)
+    def fake_poll(plan, http):
+        http.request_count += 2
+        return [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "tok")]
+    with patch("app.cycle.get_scraper") as gs, patch("app.cycle.send_digest"):
+        scraper = MagicMock(); scraper.poll.side_effect = fake_poll
+        gs.return_value = scraper
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+    row = db.execute("SELECT * FROM city_state WHERE city='leipzig'").fetchone()
+    assert row["polls_today"] == 1      # reset from 99, then +1
+    assert row["requests_today"] == 2   # reset from 99, then +2
+    assert row["polls_total"] == 100    # 99 + 1, not reset
+    assert row["requests_total"] == 101  # 99 + 2, not reset
+
 def test_cycle_respects_rate_limit(db):
     sid = insert_pending(db, email="a@x.com", city="leipzig",
                         language="de", filter_=_f(["svc-A"]), ttl_days=90)


### PR DESCRIPTION
## What
Adds operational visibility to `/admin`, primarily **how many requests we send upstream to Leipzig** (relevant to the IP-block runbook / ≤10 req/min posture), plus a few cheap already-available metrics.

- **`CountingSession`** (`app/http_session.py`) — a `requests.Session` that counts every request. The poller uses it; Mailjet/Resend sends go through a separate path and are **not** counted.
- **`run_cycle`** attributes, per poll, `+1 poll` and the HTTP-request delta to that plan's city. Persisted via a set-based `UPDATE` whose `CASE` resets the `*_today` counters lazily on UTC day rollover while totals keep growing. The canary write + counter write share a row, so they're wrapped in **one transaction** (review finding — prevents a concurrent admin read seeing a half-updated row).
- **Schema** — `city_state` gains `polls_today`, `polls_total`, `requests_total`, `counts_date` (reusing the previously-dead `requests_today`). Idempotent, concurrency-safe `ADD COLUMN` migration; `SCHEMA_VERSION` → 2.
- **`admin.stats()`** — adds `upstream_by_city` (today gated by `counts_date`), `last_polled_at_by_city`, `slots_cached`, `emails_sent_total`, `last_failure_alert_at`. Counter reads are defensive (zeros on a not-yet-migrated DB).

## Review
Adversarially reviewed (3 dimensions, 13 raised / 3 confirmed). Acted on the one medium finding (transactional coherence of the two city_state UPDATEs); the other two confirmed that the defensive `stats()` path is correct.

## Tests
+9 tests (CountingSession; cycle attribution + today-reset; migration idempotency on a pre-existing table; stats shape + today-gating; admin route). Full suite: **114 passed, 3 skipped**.

## Deploy ⚠️
Unlike the last PRs, this touches the **poller** (counting + migration) *and* web (reading), so the rebuild must include **both**:
`git pull && docker compose up -d --build web poller`

Spec: `docs/specs/2026-06-03-admin-ops-metrics-design.md`
