### PR TITLE
fix(scraper): select single service and treat reserve arg as resource

### DIFF
--- a/app/cycle.py
+++ b/app/cycle.py
@@ -98,8 +98,12 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
     for sub in subs:
         if sub.last_notified_at and sub.last_notified_at > rate_cutoff:
             continue
-        # Gather candidate slots from any plan that covers this subscription's filter
+        # Gather candidate slots from any plan that covers this subscription's filter.
+        # Dedupe by hash within the cycle: the same logical slot (day/time/office/
+        # service) can surface from two resources (counters) or two overlapping
+        # plans — Slot.hash() excludes the resource, so collapse them to one line.
         candidates: list[Slot] = []
+        seen_in_cycle: set[str] = set()
         for plan in plans:
             if plan.city != sub.city:
                 continue
@@ -108,8 +112,12 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
             for slot in slots_by_plan.get(plan.key(), []):
                 if not matches(sub.sub_filter, slot):
                     continue
-                if has_seen_slot(conn, sub.id, slot.hash()):
+                slot_hash = slot.hash()
+                if slot_hash in seen_in_cycle:
                     continue
+                if has_seen_slot(conn, sub.id, slot_hash):
+                    continue
+                seen_in_cycle.add(slot_hash)
                 candidates.append(slot)
         if not candidates:
             continue

--- a/app/models.py
+++ b/app/models.py
@@ -48,10 +48,15 @@ class Slot:
     date: str          # YYYY-MM-DD
     time_str: str      # HH:MM
     location_uuid: str
-    service_uuid: str
+    service_uuid: str  # appointment type this slot was searched for (from the plan)
     booking_token: str # opaque, session-bound — excluded from hash
+    resource_uuid: str = ""  # the counter/staff resource the upstream button carries
 
     def hash(self) -> str:
+        # Identity is (day, time, office, service). The resource is deliberately
+        # excluded: two counters offering the same service slot at the same office
+        # and minute are one notification for the subscriber. booking_token is
+        # session-bound and also excluded.
         payload = f"{self.date}|{self.time_str}|{self.location_uuid}|{self.service_uuid}"
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 

--- a/app/scrapers/smartcjm.py
+++ b/app/scrapers/smartcjm.py
@@ -22,13 +22,20 @@ APPOINTMENT_RESERVE_RE = re.compile(
     r"'([^']+)'\s*,\s*"   # encoded datetime
     r"'(\d+)'\s*,\s*"     # duration minutes
     r"'([^']+)'\s*,\s*"   # location uuid
-    r"'([^']+)'\s*\)"     # service uuid
+    r"'([^']+)'\s*\)"     # resource uuid (counter/staff — NOT the service; see parse_slots)
 )
 SLOT_LI_TESTID_RE = re.compile(r"^slot_button_li-\d+$")
 
 
-def parse_slots(html: str) -> list[Slot]:
-    """Parse Smart-CJM search-result HTML into Slot records."""
+def parse_slots(html: str, *, service_uuid: str) -> list[Slot]:
+    """Parse Smart-CJM search-result HTML into Slot records.
+
+    The upstream button is `appointment_reserve(datetime, duration, location,
+    resource)` — the 4th argument is a *resource* (counter/staff), NOT the
+    service. The search is server-side filtered to a single service, so the
+    service every returned slot belongs to is `service_uuid` (the one we
+    searched for, supplied by the caller from the plan).
+    """
     if "Session abgelaufen" in html:
         return []
     soup = BeautifulSoup(html, "html.parser")
@@ -41,7 +48,7 @@ def parse_slots(html: str) -> list[Slot]:
         m = APPOINTMENT_RESERVE_RE.search(onclick)
         if not m:
             continue
-        encoded_dt, _duration, location_uuid, service_uuid = m.groups()
+        encoded_dt, _duration, location_uuid, resource_uuid = m.groups()
         dt = urllib.parse.unquote(encoded_dt)
         if "T" not in dt:
             continue
@@ -53,6 +60,7 @@ def parse_slots(html: str) -> list[Slot]:
             location_uuid=location_uuid,
             service_uuid=service_uuid,
             booking_token=encoded_dt,
+            resource_uuid=resource_uuid,
         ))
     return slots
 
@@ -116,17 +124,18 @@ def _invalidate_wsid(scfg: dict) -> None:
 
 
 def _post_services(http: requests.Session, wsid: str, csrf: str, rev: str,
-                   plan: PollPlan, catalog, scfg: dict) -> None:
-    parts = []
-    for code in catalog.appointment_types.values():
-        amount = "1" if code == plan.appointment_type else ""
-        parts.append(f"services={code}")
-        parts.append(f"service_{code}_amount={amount}")
+                   plan: PollPlan, scfg: dict) -> None:
+    # Submit ONLY the selected service, amount 1 — mirroring the browser's
+    # `autoSelectServiceAndSubmit` (one `services=<uid>` + `service_<uid>_amount`).
+    # Blasting every catalog service at once makes the server fall back to the
+    # global "earliest" slot regardless of the chosen service (amount_min is 1
+    # for every Leipzig service).
+    sel = plan.appointment_type
     body = (
         f"__RequestVerificationToken={csrf}&"
         f"action_type=&steps={scfg['steps']}&"
         "step_current=services&step_current_index=0&step_goto=%2B1&services=&"
-        + "&".join(parts)
+        f"services={sel}&service_{sel}_amount=1"
     )
     r = http.post(
         f"{scfg['base_url']}/?uid={scfg['uid']}&wsid={wsid}&lang=de&rev={rev}",
@@ -176,11 +185,11 @@ def poll(plan: PollPlan, http: requests.Session) -> list[Slot]:
             f"(vendor={scfg.get('vendor')})"
         )
     wsid, csrf, rev = _get_session_state(http, scfg)
-    _post_services(http, wsid, csrf, rev, plan, catalog, scfg)
+    _post_services(http, wsid, csrf, rev, plan, scfg)
     html = _post_locations(http, wsid, csrf, rev, plan, catalog, scfg)
     if "Session abgelaufen" in html:
         _invalidate_wsid(scfg)
         wsid, csrf, rev = _get_session_state(http, scfg)
-        _post_services(http, wsid, csrf, rev, plan, catalog, scfg)
+        _post_services(http, wsid, csrf, rev, plan, scfg)
         html = _post_locations(http, wsid, csrf, rev, plan, catalog, scfg)
-    return parse_slots(html)
+    return parse_slots(html, service_uuid=plan.appointment_type)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,3 +42,20 @@ def test_slot_hash_is_deterministic():
               location_uuid="loc-1", service_uuid="svc-1",
               booking_token="abc")
     assert s1.hash() != s3.hash()
+
+def test_slot_resource_uuid_is_captured_and_excluded_from_hash():
+    # The booking button's 4th arg is a RESOURCE (a counter/staff resource),
+    # NOT the appointment service. `service_uuid` is the appointment type the
+    # slot was searched for; `resource_uuid` is what the button carries.
+    a = Slot(date="2026-06-10", time_str="10:30", location_uuid="loc-1",
+             service_uuid="svc-A", booking_token="t1", resource_uuid="res-1")
+    b = Slot(date="2026-06-10", time_str="10:30", location_uuid="loc-1",
+             service_uuid="svc-A", booking_token="t2", resource_uuid="res-2")
+    assert a.resource_uuid == "res-1"
+    # Same logical slot (date/time/location/service) at two different resources
+    # is one notification for the subscriber — resource must not affect the hash.
+    assert a.hash() == b.hash()
+    # A different service IS a different slot.
+    c = Slot(date="2026-06-10", time_str="10:30", location_uuid="loc-1",
+             service_uuid="svc-B", booking_token="t1", resource_uuid="res-1")
+    assert a.hash() != c.hash()

--- a/tests/test_polling_cycle.py
+++ b/tests/test_polling_cycle.py
@@ -51,6 +51,46 @@ def test_cycle_sends_one_digest_per_subscriber_on_match(db):
         assert args.kwargs["subscription"].id == sid
         assert args.kwargs["matched_slots"] == fake_slots
 
+def test_cycle_dedups_same_slot_offered_by_multiple_resources(db):
+    """Two counters (resources) offering the same service slot at the same office
+    and minute are ONE notification — they share a hash (resource excluded), so the
+    digest must contain a single line, not a duplicate."""
+    sid = insert_pending(db, email="a@x.com", city="leipzig",
+                        language="de", filter_=_f(["svc-A"]), ttl_days=90)
+    confirm(db, sid)
+    dup_slots = [
+        Slot("2026-06-10", "10:30", "loc-1", "svc-A", "tok", "resource-1"),
+        Slot("2026-06-10", "10:30", "loc-1", "svc-A", "tok", "resource-2"),
+    ]
+    with patch("app.cycle.get_scraper") as gs, \
+         patch("app.cycle.send_digest") as send_d:
+        scraper = MagicMock()
+        scraper.poll.return_value = dup_slots
+        gs.return_value = scraper
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+        send_d.assert_called_once()
+        assert len(send_d.call_args.kwargs["matched_slots"]) == 1
+
+def test_cycle_aggregates_slots_for_multi_type_subscriber(db):
+    """A subscriber with two appointment types fans into two plans; a digest
+    aggregates the matching slots from both."""
+    sid = insert_pending(db, email="a@x.com", city="leipzig",
+                        language="de", filter_=_f(["svc-A", "svc-B"]), ttl_days=90)
+    confirm(db, sid)
+    def poll_by_type(plan, http):
+        if plan.appointment_type == "svc-A":
+            return [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "tA", "r1")]
+        return [Slot("2026-06-11", "09:00", "loc-2", "svc-B", "tB", "r2")]
+    with patch("app.cycle.get_scraper") as gs, \
+         patch("app.cycle.send_digest") as send_d:
+        scraper = MagicMock()
+        scraper.poll.side_effect = poll_by_type
+        gs.return_value = scraper
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+        send_d.assert_called_once()
+        services = {s.service_uuid for s in send_d.call_args.kwargs["matched_slots"]}
+        assert services == {"svc-A", "svc-B"}
+
 def test_cycle_skips_already_seen_slot(db):
     sid = insert_pending(db, email="a@x.com", city="leipzig",
                         language="de", filter_=_f(["svc-A"]), ttl_days=90)

--- a/tests/test_smartcjm_client.py
+++ b/tests/test_smartcjm_client.py
@@ -40,16 +40,18 @@ def _make_session(*, wsid_redirect_url: str, services_html: str, locations_html:
     return sess
 
 
+SVC_ANUM = "29cd0a26-fe7a-4d65-88cd-1e05fd749c71"  # An- oder Ummeldung Wohnsitz
+
+
 def test_poll_returns_slots_from_locations_response():
-    plan = PollPlan(city="leipzig",
-                    appointment_type="29cd0a26-fe7a-4d65-88cd-1e05fd749c71",
-                    locations="all")
+    plan = PollPlan(city="leipzig", appointment_type=SVC_ANUM, locations="all")
     redirect = f"{LEIPZIG_BASE}/?wsid=fake-wsid&uid=b76cab25"
+    # 4th arg is a RESOURCE uuid, NOT a service (per the upstream JS signature).
     locations_html = (
         '<ol data-testid="month_ol-1">'
         '<li data-testid="slot_button_li-1">'
         '<button onclick="return appointment_reserve(\'2026-06-10T10%3a30%3a00%2b02%3a00\','
-        ' \'10\', \'loc-1\', \'svc-1\');"></button>'
+        ' \'10\', \'loc-1\', \'res-9\');"></button>'
         '</li></ol>'
     )
     sess = _make_session(wsid_redirect_url=redirect,
@@ -60,8 +62,85 @@ def test_poll_returns_slots_from_locations_response():
     assert slots[0].date == "2026-06-10"
     assert slots[0].time_str == "10:30"
     assert slots[0].location_uuid == "loc-1"
-    assert slots[0].service_uuid == "svc-1"
+    # service_uuid is stamped from the plan (the server-side filtered search),
+    # while the button's 4th arg is captured as the resource.
+    assert slots[0].service_uuid == SVC_ANUM
+    assert slots[0].resource_uuid == "res-9"
     assert slots[0].booking_token == "2026-06-10T10%3a30%3a00%2b02%3a00"
+
+
+def test_post_services_posts_only_the_selected_service():
+    """Posting all catalog services at once breaks server-side filtering and makes
+    the search return the global 'earliest' slot regardless of the chosen service.
+    The services step must submit exactly the one selected service, amount 1."""
+    import re
+    plan = PollPlan(city="leipzig", appointment_type=SVC_ANUM, locations="all")
+    sess = _make_session(wsid_redirect_url=f"{LEIPZIG_BASE}/?wsid=w&uid=b",
+                         services_html="", locations_html="<ol></ol>")
+    poll(plan, http=sess)
+    body = sess.post.call_args_list[0].kwargs["data"]
+    submitted = re.findall(r"services=([0-9a-fA-F-]{36})", body)
+    assert submitted == [SVC_ANUM]
+    assert f"service_{SVC_ANUM}_amount=1" in body
+    # exactly one service is given a quantity — never the old "blast every service" body
+    assert body.count("_amount=1") == 1
+
+
+def test_poll_stamps_each_plans_service_when_sharing_a_cached_session():
+    """Two plans for different services in the same session must each stamp their
+    own service onto their slots — not leak the first plan's service via the cache."""
+    plan_a = PollPlan(city="leipzig", appointment_type=SVC_ANUM, locations="all")
+    plan_b = PollPlan(city="leipzig",
+                      appointment_type="b04658d5-8d85-469a-a635-93337e055b73",
+                      locations="all")
+    one_slot = (
+        '<ol data-testid="month_ol-1"><li data-testid="slot_button_li-1">'
+        '<button onclick="return appointment_reserve('
+        "'2026-06-17T10%3a10%3a00%2b02%3a00', '10', 'loc-x', 'res-shared');\">"
+        '</button></li></ol>'
+    )
+    sess = MagicMock()
+
+    def _get(url, *a, **kw):
+        if "search_result" in url:
+            return MagicMock(url=f"{LEIPZIG_BASE}/?wsid=w&uid=b", text="",
+                             status_code=200, headers={})
+        return MagicMock(url=url, text=SERVICES_PAGE_HTML, status_code=200, headers={})
+
+    sess.get.side_effect = _get
+    sess.post.side_effect = [MagicMock(text=h, status_code=200, url="", headers={})
+                             for h in ["", one_slot, "", one_slot]]
+    slots_a = poll(plan_a, http=sess)
+    slots_b = poll(plan_b, http=sess)
+    assert [s.service_uuid for s in slots_a] == [SVC_ANUM]
+    assert [s.service_uuid for s in slots_b] == ["b04658d5-8d85-469a-a635-93337e055b73"]
+
+
+def test_returned_slot_matches_subscriber_despite_resource_in_button():
+    """Regression: a slot whose button carries a *resource* uuid (not the service)
+    must still match a subscriber who wants that service. Before the fix, the
+    resource was stored as service_uuid and matches() rejected every slot."""
+    from datetime import time
+    from app.models import Filter
+    from app.filters import matches
+    plan = PollPlan(city="leipzig", appointment_type=SVC_ANUM, locations="all")
+    locations_html = (
+        '<ol data-testid="month_ol-1">'
+        '<li data-testid="slot_button_li-1">'
+        '<button onclick="return appointment_reserve('
+        "'2026-06-17T10%3a10%3a00%2b02%3a00', '10', "
+        "'868036ae-d404-4804-a6b3-3ccccac44071', "          # location
+        "'6ce5bc5f-20ee-4df3-a139-d4d017468dec');\">"        # RESOURCE, not service
+        '</button></li></ol>'
+    )
+    sess = _make_session(wsid_redirect_url=f"{LEIPZIG_BASE}/?wsid=w&uid=b",
+                         services_html="", locations_html=locations_html)
+    slots = poll(plan, http=sess)
+    assert len(slots) == 1
+    f = Filter(appointment_types=[SVC_ANUM], locations="all",
+               weekdays=[1, 2, 3, 4, 5, 6, 7],
+               time_window_start=time(0, 0), time_window_end=time(23, 59))
+    assert matches(f, slots[0]) is True
 
 
 def test_poll_sends_csrf_token_in_post_body():

--- a/tests/test_smartcjm_live.py
+++ b/tests/test_smartcjm_live.py
@@ -67,6 +67,12 @@ def test_live_poll_completes_without_raising(http, scfg, appointment_types):
     plan = PollPlan(city="leipzig", appointment_type=target_uid, locations="all")
     slots = smartcjm.poll(plan, http=http)
     assert isinstance(slots, list)
+    # Canary for the resource-as-service regression: any returned slot must carry
+    # the service we searched for, not the button's resource uuid. This single
+    # assertion would have caught the original production outage on any live run
+    # that returned at least one slot.
+    if slots:
+        assert all(s.service_uuid == target_uid for s in slots)
 
 
 def test_live_get_service_list_endpoint_returns_known_services(http, scfg, appointment_types):

--- a/tests/test_smartcjm_parser.py
+++ b/tests/test_smartcjm_parser.py
@@ -3,19 +3,33 @@ from app.scrapers.smartcjm import parse_slots
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
-def test_parse_with_slots():
+# The slot search is server-side filtered to one service, so the service the
+# slots belong to is the one we searched for — passed in by the caller. The
+# button's own 4th arg is a *resource*, not the service (see the upstream JS
+# signature: appointment_reserve(datetime, duration, location, resource)).
+SVC = "29cd0a26-fe7a-4d65-88cd-1e05fd749c71"
+
+
+def test_parse_with_slots_sets_service_from_arg_and_resource_from_button():
     html = (FIXTURES / "leipzig_with_slots.html").read_text(encoding="utf-8")
-    slots = parse_slots(html)
+    slots = parse_slots(html, service_uuid=SVC)
     assert len(slots) > 0
     s = slots[0]
-    assert s.date  # ISO date YYYY-MM-DD
+    assert s.date            # ISO date YYYY-MM-DD
     assert ":" in s.time_str
-    assert s.booking_token  # opaque
+    assert s.booking_token   # opaque
+    # service_uuid comes from the search context, not the button
+    assert all(x.service_uuid == SVC for x in slots)
+    # the button's 4th arg is captured as the resource, distinct from the service
+    assert s.resource_uuid
+    assert all(x.resource_uuid != SVC for x in slots)
+
 
 def test_parse_no_slots():
     html = (FIXTURES / "leipzig_no_slots.html").read_text(encoding="utf-8")
-    assert parse_slots(html) == []
+    assert parse_slots(html, service_uuid=SVC) == []
+
 
 def test_session_expired_returns_empty():
     html = (FIXTURES / "leipzig_session_expired.html").read_text(encoding="utf-8")
-    assert parse_slots(html) == []
+    assert parse_slots(html, service_uuid=SVC) == []

--- a/tests/test_smartcjm_wsid_cache.py
+++ b/tests/test_smartcjm_wsid_cache.py
@@ -17,8 +17,9 @@ SERVICES_PAGE_HTML = (
 ONE_SLOT_HTML = (
     '<ol data-testid="month_ol-1">'
     '<li data-testid="slot_button_li-1">'
+    # appointment_reserve(datetime, duration, location, RESOURCE) — 4th arg is a resource.
     '<button onclick="return appointment_reserve(\'2026-06-10T10%3a30%3a00%2b02%3a00\','
-    ' \'10\', \'loc-1\', \'svc-1\');"></button>'
+    ' \'10\', \'loc-1\', \'res-cache-1\');"></button>'
     '</li></ol>'
 )
 


### PR DESCRIPTION
## Why

The Leipzig poller has **never delivered an appointment notification** since launch. Diagnosed on the Pi (read-only) and verified live against `terminvereinbarung.leipzig.de`.

## Two bugs (both verified live)

1. **`_post_services` over-posted all 15 services.** The server then ignored the selection and returned the global "earliest" slot regardless of which service was chosen. Fix: submit only the selected service (`services=<uid>&service_<uid>_amount=1`), mirroring the site's own `autoSelectServiceAndSubmit` JS.
2. **The slot button's 4th arg is a RESOURCE, not the service.** The upstream signature is `appointment_reserve(datetime, duration, location, resource)` (e.g. `6ce5bc5f` = "Termine Otto-Schill 01"). `parse_slots` stored it as `Slot.service_uuid`, so `matches()` compared a resource uuid against subscribers' `appointment_types` → never matched. Fix: `parse_slots` stamps the service from the **plan** and stores the button's 4th arg as the new `Slot.resource_uuid`.

`Slot.hash()` keeps `(date|time|location|service)` (resource excluded); `run_cycle` dedupes candidates in-cycle so two counters at the same minute = one email line.

## Verification
- Unit suite: **120 passed, 3 skipped** (opt-in live). Each fix went RED→GREEN.
- Live (read-only): the fixed logic matches a real Personalausweis slot for an existing subscriber; an An-/Ummeldung-at-one-office subscriber correctly gets nothing.
- Adversarial multi-lens review (5 lenses + synthesis); must-fix (in-cycle dedup) addressed; added a **live canary** asserting `slot.service_uuid == requested service` that would have caught the original outage.

## Deliberately not changed
`catalog_sync._probe_one_service` shares the over-posting pattern, but verified live it's harmless — single- vs all-service posting returns the identical 11-location set. Left untouched (live-active path).

## Deploy notes
`seen_slots` is empty (0 rows) → no re-notification burst on deploy.
