### PR TITLE
fix(mail): fail over to Resend on any Mailjet error (incl. 401/403)

### DIFF
--- a/app/mail.py
+++ b/app/mail.py
@@ -72,7 +72,10 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
     try:
         resp = _call_mailjet(to, subject, body)
         provider = "mailjet"
-        if (resp.status_code >= 500 or resp.status_code == 429) and os.environ.get("RESEND_API_KEY"):
+        # Fail over to Resend on ANY Mailjet error (4xx incl. 401/403 account
+        # blocks, and 5xx/429), not just transient ones — a blocked Mailjet
+        # account returns 401, and that's exactly when the fallback must engage.
+        if resp.status_code >= 400 and os.environ.get("RESEND_API_KEY"):
             resp = _call_resend(to, subject, body)
             provider = "resend"
         if resp.status_code >= 400:

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -41,6 +41,32 @@ def test_failover_to_resend_on_mailjet_5xx(db, resend_configured):
     row = db.execute("SELECT provider FROM sent_idempotency WHERE idem_key='k2'").fetchone()
     assert row["provider"] == "resend"
 
+def test_failover_to_resend_on_mailjet_401_account_block(db, resend_configured):
+    """A Mailjet 401 (e.g. account temporarily blocked) must fail over to Resend,
+    not hard-fail. Auth/account errors are exactly when failover matters most."""
+    with patch("app.mail._call_mailjet", return_value=_resp(401)), \
+         patch("app.mail._call_resend", return_value=_ok()) as re_:
+        send(db, "alice@example.com", "subj", "body", idem_key="k401")
+    re_.assert_called_once()
+    row = db.execute("SELECT provider FROM sent_idempotency WHERE idem_key='k401'").fetchone()
+    assert row["provider"] == "resend"
+
+def test_failover_to_resend_on_mailjet_403(db, resend_configured):
+    with patch("app.mail._call_mailjet", return_value=_resp(403)), \
+         patch("app.mail._call_resend", return_value=_ok()) as re_:
+        send(db, "alice@example.com", "subj", "body", idem_key="k403")
+    re_.assert_called_once()
+    row = db.execute("SELECT provider FROM sent_idempotency WHERE idem_key='k403'").fetchone()
+    assert row["provider"] == "resend"
+
+def test_no_fallback_on_401_without_resend(db, monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with patch("app.mail._call_mailjet", return_value=_resp(401)), \
+         patch("app.mail._call_resend") as re_:
+        with pytest.raises(MailFailed):
+            send(db, "alice@example.com", "subj", "body", idem_key="k401nofb")
+    re_.assert_not_called()
+
 def test_idempotency_skips_second_send(db):
     with patch("app.mail._call_mailjet", return_value=_ok()) as mj:
         send(db, "alice@example.com", "subj", "body", idem_key="k3")


### PR DESCRIPTION
## Why
The Mailjet account is temporarily blocked, so `POST /v3.1/send` returns **401** (`mj-0001`). The old failover only triggered on `5xx`/`429`, so a configured Resend key never engaged and every notification hard-failed — even though the scraper fix is now correctly finding matching slots.

## Change
Widen the failover condition in `app/mail.py` from `(status >= 500 or status == 429)` to **any error status `>= 400`** (when `RESEND_API_KEY` is set). Auth/account errors (401/403) are exactly when the fallback must engage.

## Tests
- New: 401 account-block → fails over to Resend; 403 → fails over; 401 without Resend configured → still hard-fails (no silent drop).
- Full suite: **123 passed, 3 skipped**.

## Context
Verified live (read-only): Resend key is valid (sending-scoped), transport works (`requests` reaches Resend, no Cloudflare block), and the sender domain is verified. Once deployed, a blocked Mailjet → automatic Resend delivery.
