### PR TITLE
fix(web): key slots_cache by decoded token so /go links resolve

### DIFF
--- a/app/cycle.py
+++ b/app/cycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sqlite3
+import urllib.parse
 from datetime import datetime, timedelta
 import requests
 from app.filters import matches
@@ -132,10 +133,16 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
         scfg = load_catalog(sub.city).scraper_config
         for slot in candidates:
             upstream = _build_upstream_url(scfg, slot)
+            # The booking_token is a URL-encoded datetime (e.g. ...T17%3a20%3a00%2b02%3a00).
+            # The email links to /go/<booking_token>, and Flask URL-DECODES the path
+            # param on click — so the slots_cache key must be the DECODED form, or the
+            # /go lookup misses and every link 410s. (upstream_url keeps the encoded
+            # token: it sits in a query string the city site decodes itself.)
+            slot_token = urllib.parse.unquote(slot.booking_token)
             conn.execute(
                 "INSERT INTO slots_cache (slot_token, city, upstream_url) "
                 "VALUES (?, ?, ?) ON CONFLICT (slot_token) DO NOTHING",
-                (slot.booking_token, sub.city, upstream),
+                (slot_token, sub.city, upstream),
             )
         send_digest(conn=conn, subscription=sub, matched_slots=candidates,
                     cycle_id=cycle_id, cfg=cfg)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -52,6 +52,36 @@ def test_go_route_returns_410_on_miss(client):
     r = client.get("/go/nonexistent-token", follow_redirects=False)
     assert r.status_code == 410
 
+def test_go_link_from_email_resolves_for_datetime_token(client):
+    """End-to-end: the booking link the digest email contains must resolve via /go,
+    not 410. Smart-CJM slot tokens are URL-encoded datetimes (T%3a..%2b..); Flask
+    decodes the /go path param on click, so slots_cache must be keyed so the decoded
+    token matches what run_cycle stored."""
+    from unittest.mock import patch, MagicMock
+    from datetime import time
+    from app.db import connect
+    from app.models import Slot, Filter
+    from app.repo import insert_pending, confirm
+    from app.cycle import run_cycle
+    conn = connect(os.environ["DB_PATH"])
+    f = Filter(appointment_types=["29cd0a26-fe7a-4d65-88cd-1e05fd749c71"], locations="all",
+               weekdays=[1, 2, 3, 4, 5, 6, 7], time_window_start=time(0, 0),
+               time_window_end=time(23, 59))
+    sid = insert_pending(conn, email="a@x.com", city="leipzig", language="de",
+                         filter_=f, ttl_days=90)
+    confirm(conn, sid)
+    # booking_token as it appears in the upstream button / email link: URL-encoded datetime
+    booking_token = "2026-06-18T17%3a20%3a00%2b02%3a00"
+    slot = Slot("2026-06-18", "17:20", "loc-1",
+                "29cd0a26-fe7a-4d65-88cd-1e05fd749c71", booking_token, "res-1")
+    with patch("app.cycle.get_scraper") as gs, patch("app.cycle.send_digest"):
+        sc = MagicMock(); sc.poll.return_value = [slot]; gs.return_value = sc
+        run_cycle(conn, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+    # The email link is /go/<booking_token>; the browser/Flask decodes the path on click.
+    r = client.get(f"/go/{booking_token}", follow_redirects=False)
+    assert r.status_code == 302
+    assert "appointment_reserve" in r.headers["Location"]
+
 def test_admin_renders_new_metrics(client):
     r = client.get("/admin?token=admin-tok")
     assert r.status_code == 200


### PR DESCRIPTION
## Why
Every booking link in the digest emails returns **410 "This appointment link has expired."** — not churn, a bug.

`booking_token` is a URL-encoded datetime (`...T17%3a20%3a00%2b02%3a00`). The email links to `/go/<booking_token>`; Flask **URL-decodes** the path param on click (`→ ...T17:20:00+02:00`), but `run_cycle` stored the **encoded** form as the `slots_cache` key — so the lookup always missed → 410. Verified live: the upstream booking URL itself is fine (HTTP 200, live `wsid` session), so only the `/go` key was wrong.

## Fix
Store the **decoded** token as the `slots_cache` key, matching what Flask delivers to the route. The `upstream_url` keeps the encoded token (it's a query-string value the city site decodes itself — a literal `+` there would be read as a space).

## Tests
- New end-to-end test drives `run_cycle` (real storage) + the `/go` route with a realistic datetime token; the prior test used a trivial `tok1` and never exercised the encode/decode round-trip.
- Full suite: **124 passed, 3 skipped**.

## Note
Latent bug — only surfaced once notifications actually started sending (after the scraper + mail-failover fixes).
