### PR TITLE
docs(privacy): list Resend as an EU (Ireland) processor

### DIFF
--- a/app/templates/datenschutz.html
+++ b/app/templates/datenschutz.html
@@ -10,7 +10,7 @@
     <h2>Retention period</h2>
     <p>Subscriptions expire automatically 90 days after sign-up unless extended via the renewal link. Deleted records are permanently removed 30 days after deletion.</p>
     <h2>Processors</h2>
-    <p>Mailjet (EU servers) for email delivery. Data processing agreement in place.</p>
+    <p>Mailjet (EU servers) and Resend (EU servers, Ireland region) for email delivery. A data processing agreement (DPA) is in place with both providers.</p>
     <h2>Your rights</h2>
     <p>Access (Art. 15), rectification (Art. 16), erasure (Art. 17), restriction (Art. 18), portability (Art. 20), withdrawal of consent (Art. 7(3)). Contact: jakub@jakubwaller.eu.</p>
   {% else %}
@@ -23,7 +23,7 @@
     <h2>Speicherdauer</h2>
     <p>Abonnements laufen 90 Tage nach der Erstanmeldung automatisch ab, sofern sie nicht über den Erneuerungslink verlängert werden. Gelöschte Datensätze werden 30 Tage nach der Löschung endgültig entfernt.</p>
     <h2>Auftragsverarbeiter</h2>
-    <p>Mailjet (EU-Server) zum Versand der E-Mails. AVV-Vertrag liegt vor.</p>
+    <p>Mailjet (EU-Server) und Resend (EU-Server, Region Irland) zum Versand der E-Mails. Mit beiden Anbietern besteht ein AVV-Vertrag.</p>
     <h2>Deine Rechte</h2>
     <p>Auskunft (Art. 15), Berichtigung (Art. 16), Löschung (Art. 17), Einschränkung (Art. 18), Datenübertragbarkeit (Art. 20), Widerruf der Einwilligung (Art. 7(3)). Kontakt: jakub@jakubwaller.eu.</p>
   {% endif %}


### PR DESCRIPTION
## Why
Resend now processes subscriber email addresses + content (currently sending all mail while Mailjet is blocked), so it must be disclosed in the privacy policy's processors section.

## Change
Adds Resend to the Auftragsverarbeiter / Processors section (DE + EN). The Resend account uses the **Ireland (EU)** region and its DPA is executed on signup, so both providers are EU-hosted with an AVV in place — no third-country transfer to disclose.
