### PR TITLE
feat(web): show English service & location labels on the English site

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
@@ -9,12 +9,32 @@ CATALOG_ROOT = Path(__file__).parent.parent / "catalog"
 class CatalogError(Exception):
     pass
 
+
+def _localized(de_map: dict[str, str], en_map: dict[str, str],
+               lang: str) -> dict[str, str]:
+    """Return a name→uuid map for display in `lang`.
+
+    The uuid is the stable identity; only the label is language-specific. For
+    English we re-key the German map by uuid so the full German set is always
+    shown — any uuid the English table is missing falls back to its German
+    label rather than dropping the option. Result is sorted by display name.
+    """
+    if lang != "en" or not en_map:
+        return dict(de_map)
+    en_by_uuid = {uuid: name for name, uuid in en_map.items()}
+    merged = {en_by_uuid.get(uuid, de_name): uuid
+              for de_name, uuid in de_map.items()}
+    return dict(sorted(merged.items()))
+
+
 @dataclass(frozen=True)
 class Catalog:
     city: str
-    appointment_types: dict[str, str]  # name → uuid
-    locations: dict[str, str]          # name → uuid
+    appointment_types: dict[str, str]  # name → uuid (German — canonical)
+    locations: dict[str, str]          # name → uuid (German — canonical)
     scraper_config: dict               # vendor-specific, opaque to web layer
+    appointment_types_en: dict[str, str] = field(default_factory=dict)
+    locations_en: dict[str, str] = field(default_factory=dict)
 
     def appointment_type_name_for(self, uuid: str) -> str | None:
         return next((n for n, u in self.appointment_types.items() if u == uuid), None)
@@ -28,6 +48,14 @@ class Catalog:
     def location_uuid_for(self, name: str) -> str | None:
         return self.locations.get(name)
 
+    def appointment_types_for(self, lang: str) -> dict[str, str]:
+        """name→uuid map for the appointment-type dropdown, localized for `lang`."""
+        return _localized(self.appointment_types, self.appointment_types_en, lang)
+
+    def locations_for(self, lang: str) -> dict[str, str]:
+        """name→uuid map for the locations list, localized for `lang`."""
+        return _localized(self.locations, self.locations_en, lang)
+
 @lru_cache(maxsize=8)
 def load_catalog(city: str) -> Catalog:
     city_dir = CATALOG_ROOT / city
@@ -39,5 +67,17 @@ def load_catalog(city: str) -> Catalog:
         scfg = json.loads((city_dir / "scraper_config.json").read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
         raise CatalogError(f"Missing catalog file for {city}: {exc.filename}") from exc
+    # English labels are optional: a city without an *.en.json simply falls
+    # back to the German names everywhere (see Catalog.appointment_types_for).
+    ats_en = _read_optional_json(city_dir / "appointment_type.en.json")
+    locs_en = _read_optional_json(city_dir / "locations.en.json")
     return Catalog(city=city, appointment_types=ats, locations=locs,
-                   scraper_config=scfg)
+                   scraper_config=scfg,
+                   appointment_types_en=ats_en, locations_en=locs_en)
+
+
+def _read_optional_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}

--- a/app/catalog_sync.py
+++ b/app/catalog_sync.py
@@ -13,26 +13,39 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # ---------- public API ----------
 
 def fetch_services(http: requests.Session,
-                   base_url: str, uid: str) -> dict[str, str]:
+                   base_url: str, uid: str) -> tuple[dict[str, str], dict[str, str]]:
+    """Return (german, english) name→uuid maps.
+
+    The lang query param is ignored by get_service_list — German is always in
+    `display_name`, and the English label (when present) is in
+    `data.display_name_en`. A service without an English label falls back to
+    its German name so the English map always covers the full set.
+    """
     r = http.get(f"{base_url}/get_service_list?uid={uid}", timeout=30)
     data = r.json()
     if not data.get("success"):
         raise RuntimeError("get_service_list returned success=false")
-    out: dict[str, str] = {}
+    de: dict[str, str] = {}
+    en: dict[str, str] = {}
     for s in data["results"]:
         name = (s.get("display_name") or "").strip()
-        if name:
-            out[name] = s["uid"]
-    return dict(sorted(out.items()))
+        if not name:
+            continue
+        de[name] = s["uid"]
+        name_en = ((s.get("data") or {}).get("display_name_en") or "").strip() or name
+        en[name_en] = s["uid"]
+    return dict(sorted(de.items())), dict(sorted(en.items()))
 
 
 def fetch_locations(http: requests.Session,
                     base_url: str, uid: str,
-                    service_uids: list[str], steps: str) -> dict[str, str]:
+                    service_uids: list[str], steps: str,
+                    lang: str = "de") -> dict[str, str]:
     union_by_uid: dict[str, str] = {}
     for svc in service_uids:
         try:
-            locs = _probe_one_service(http, base_url, uid, svc, service_uids, steps)
+            locs = _probe_one_service(http, base_url, uid, svc, service_uids,
+                                      steps, lang=lang)
         except Exception:
             continue
         for loc_uid, loc_name in locs.items():
@@ -49,11 +62,13 @@ def sync_city(city: str,
     scfg = json.loads((city_dir / "scraper_config.json").read_text())
     svc_path = city_dir / "appointment_type.json"
     loc_path = city_dir / "locations.json"
+    svc_en_path = city_dir / "appointment_type.en.json"
+    loc_en_path = city_dir / "locations.en.json"
     current_services = json.loads(svc_path.read_text())
     current_locations = json.loads(loc_path.read_text())
 
     try:
-        live_services = fetch_services(http, scfg["base_url"], scfg["uid"])
+        live_services, live_services_en = fetch_services(http, scfg["base_url"], scfg["uid"])
         live_locations = fetch_locations(http, scfg["base_url"], scfg["uid"],
                                           list(live_services.values()),
                                           scfg["steps"])
@@ -64,10 +79,23 @@ def sync_city(city: str,
     service_drift = _diff(current_services, live_services)
     location_drift = _diff(current_locations, live_locations)
 
+    # Drift detection and alerting stay anchored on the German (canonical)
+    # catalog. The English label files are rewritten alongside their German
+    # counterparts so the two can never diverge in uuid set. English fetches
+    # are best-effort: a failure must never leave the German files unwritten.
     if service_drift:
         _atomic_write_json(svc_path, live_services)
+        _atomic_write_json(svc_en_path, live_services_en)
     if location_drift:
         _atomic_write_json(loc_path, live_locations)
+        try:
+            live_locations_en = fetch_locations(http, scfg["base_url"], scfg["uid"],
+                                                 list(live_services.values()),
+                                                 scfg["steps"], lang="en")
+            if live_locations_en:
+                _atomic_write_json(loc_en_path, live_locations_en)
+        except requests.RequestException:
+            pass  # German file already written; English stays at its last good value
     if service_drift or location_drift:
         alert_fn(city=city,
                  service_drift=service_drift,
@@ -83,14 +111,15 @@ def _probe_one_service(http: requests.Session,
                        base_url: str, uid: str,
                        target_uid: str,
                        all_service_uids: list[str],
-                       steps: str) -> dict[str, str]:
+                       steps: str,
+                       lang: str = "de") -> dict[str, str]:
     # 1. wsid acquire
     r0 = http.get(f"{base_url}/search_result?search_mode=earliest&uid={uid}",
                   timeout=30, allow_redirects=True)
     wsid = r0.url.split("wsid=", 1)[1].split("&", 1)[0]
 
     # 2. fetch services page for CSRF + dynamic rev
-    r1 = http.get(f"{base_url}/?uid={uid}&wsid={wsid}&lang=de",
+    r1 = http.get(f"{base_url}/?uid={uid}&wsid={wsid}&lang={lang}",
                   timeout=30, allow_redirects=False)
     if getattr(r1, "status_code", 200) == 302:
         r1 = http.get(_rewrite_8443(r1.headers["Location"]),
@@ -112,7 +141,7 @@ def _probe_one_service(http: requests.Session,
             + f"&action_type=&steps={steps}"
             + "&step_current=services&step_current_index=0&step_goto=%2B1&services=&"
             + "&".join(parts))
-    r2 = http.post(f"{base_url}/?uid={uid}&wsid={wsid}&lang=de&rev={rev}",
+    r2 = http.post(f"{base_url}/?uid={uid}&wsid={wsid}&lang={lang}&rev={rev}",
                    headers={"Content-Type": "application/x-www-form-urlencoded"},
                    data=body, timeout=30, allow_redirects=False)
     if getattr(r2, "status_code", 200) == 302:
@@ -136,7 +165,9 @@ def _parse_location_checkboxes(html: str) -> dict[str, str]:
         if not lbl:
             continue
         for line in lbl.text.split("\n"):
-            line = line.strip()
+            # Collapse runs of whitespace — the English wizard emits labels like
+            # "Resident Services Office  Leutzsch" with a stray double space.
+            line = " ".join(line.split())
             if line:
                 out[loc_uid] = line
                 break

--- a/app/web.py
+++ b/app/web.py
@@ -103,8 +103,8 @@ def create_app() -> Flask:
                                city=city,
                                confirmed=confirmed,
                                error=error,
-                               appointment_types=catalog.appointment_types,
-                               locations=catalog.locations,
+                               appointment_types=catalog.appointment_types_for(lang),
+                               locations=catalog.locations_for(lang),
                                kofi_url=app.config["TERMINE_CONFIG"].kofi_url)
 
     @app.route("/subscribe", methods=["POST"])
@@ -246,10 +246,11 @@ def create_app() -> Flask:
         if not row or row["deleted_at"] is not None:
             return ("Subscription not found", 404)
         catalog = load_catalog(row["city"])
+        lang = row["language"]
         return render_template("manage.html",
-                               lang=row["language"], city=row["city"],
-                               appointment_types=catalog.appointment_types,
-                               locations=catalog.locations, token=token,
+                               lang=lang, city=row["city"],
+                               appointment_types=catalog.appointment_types_for(lang),
+                               locations=catalog.locations_for(lang), token=token,
                                current=Filter.from_json(row["filters_json"]))
 
     @app.route("/renew/<token>")

--- a/catalog/leipzig/appointment_type.en.json
+++ b/catalog/leipzig/appointment_type.en.json
@@ -1,0 +1,17 @@
+{
+  "Applying for a certificate of good conduct": "8de69270-b174-4096-bfe9-200db8ee2bfd",
+  "Applying for a passport": "65974655-4a92-475a-8b2f-579450e285a4",
+  "Applying for an eID card (for non-German citizens of the European Union and members of the European Economic Area)": "b9e7fb09-ade9-426f-ae1d-1124336607b3",
+  "Applying for an identity card": "b04658d5-8d85-469a-a635-93337e055b73",
+  "Applying for passports and identity cards": "ab01087e-d3a2-4162-a0e7-60de9119d474",
+  "Applying for registration certificate": "2d50130b-5450-4917-bf4e-c64a5a82b62e",
+  "Applying for the Leipzig Pass": "1e654575-716d-408b-8a16-7ef8b37d7cd0",
+  "Applying for the Saxony Family Pass": "59a88143-39f5-4b58-8568-ce1b1548cd20",
+  "Collection of identity documents": "7ea65748-8333-4269-bf65-8453f9f27cf4",
+  "Declaration of civil status (civil status case within Germany and/or the EU)": "55a26ca3-eeb7-4b92-9ddd-848942f9605f",
+  "Deregistration when moving abroad": "9bd4aa45-24d8-4733-bbf2-def52e05f684",
+  "Official certification": "d9b85ae0-5d32-49dc-b8c9-12f0515c5d0e",
+  "Registering or re-registering your place of residence within Leipzig": "29cd0a26-fe7a-4d65-88cd-1e05fd749c71",
+  "Registering or re-registering your place of residence within Leipzig for citizens with foreign identification cards": "81c1868f-30d3-4aef-b1df-5ce29d6a6158",
+  "manage eID function": "c9513802-a744-4ea6-8fff-e8c4e0b0a146"
+}

--- a/catalog/leipzig/locations.en.json
+++ b/catalog/leipzig/locations.en.json
@@ -1,0 +1,13 @@
+{
+  "Resident Services Office Gohlis-Center": "bd548597-b447-4e35-ad0f-5aea9d950958",
+  "Resident Services Office Leutzsch": "dafd1124-6d47-4c5e-97d1-9311527c3241",
+  "Resident Services Office Liebertwolkwitz": "9905fdaf-23e6-4f90-9ca4-dbc7b97a2929",
+  "Resident Services Office Otto-Schill-Straße": "acf4e0bb-a78c-4670-95fc-50cf15348e0b",
+  "Resident Services Office Paunsdorf-Center": "cc242587-a45e-4f3e-98c0-bc19a5db420e",
+  "Resident Services Office Ratzelbogen": "868036ae-d404-4804-a6b3-3ccccac44071",
+  "Resident Services Office Schönefeld": "81875be0-4566-4c9a-8528-8490179b72f0",
+  "Resident Services Office Wiedebach-Passage": "cbd90fc9-c2c4-46c7-976c-0863784bf16f",
+  "Resident Services Office Wiederitzsch": "83339d2d-376a-4893-9c2d-4b47f141efce",
+  "mobiler Bürgerservice - Bibliothek Plagwitz Georg Maurer": "a8cf4f57-20af-4d9a-88f3-4be9dcc92321",
+  "mobiler Bürgerservice - Bibliothek Reudnitz": "2b29f10b-f5c0-4765-b588-c722fea02260"
+}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -21,3 +21,59 @@ def test_catalog_lookup_helpers():
     uuid = cat.appointment_types[name]
     assert cat.appointment_type_name_for(uuid) == name
     assert cat.appointment_type_uuid_for(name) == uuid
+
+
+# ---------- English localization ----------
+
+def test_leipzig_catalog_loads_english_names():
+    cat = load_catalog("leipzig")
+    assert cat.appointment_types_en, "expected English service names to load"
+    assert cat.locations_en, "expected English location names to load"
+    # Same uuid set as German — English files only differ in the display labels.
+    assert set(cat.appointment_types_en.values()) == set(cat.appointment_types.values())
+    assert set(cat.locations_en.values()) == set(cat.locations.values())
+
+
+def test_appointment_types_for_en_returns_english_labels():
+    cat = load_catalog("leipzig")
+    de = cat.appointment_types_for("de")
+    en = cat.appointment_types_for("en")
+    assert de == cat.appointment_types  # de view is the German map verbatim
+    # Known mapping: Personalausweis → "Applying for an identity card".
+    uid = "b04658d5-8d85-469a-a635-93337e055b73"
+    assert en["Applying for an identity card"] == uid
+    assert "Personalausweis beantragen" not in en  # German label replaced
+
+
+def test_locations_for_en_returns_english_labels():
+    cat = load_catalog("leipzig")
+    en = cat.locations_for("en")
+    assert "Resident Services Office Otto-Schill-Straße" in en
+    # English view keeps the full German uuid set (labels swapped, set unchanged).
+    assert set(en.values()) == set(cat.locations.values())
+
+
+def test_for_lang_falls_back_to_german_per_missing_uuid():
+    """A uuid present in German but missing from the English table must still
+    appear (labeled in German) rather than disappear from the dropdown."""
+    cat = Catalog(
+        city="x",
+        appointment_types={"DE A": "u1", "DE B": "u2"},
+        locations={},
+        scraper_config={},
+        appointment_types_en={"EN A": "u1"},  # u2 has no English label
+        locations_en={},
+    )
+    en = cat.appointment_types_for("en")
+    assert en == {"DE B": "u2", "EN A": "u1"}  # u2 falls back to its German label
+
+
+def test_for_lang_with_no_english_table_returns_german():
+    cat = Catalog(
+        city="x",
+        appointment_types={"DE A": "u1"},
+        locations={"DE L": "l1"},
+        scraper_config={},
+    )
+    assert cat.appointment_types_for("en") == {"DE A": "u1"}
+    assert cat.locations_for("en") == {"DE L": "l1"}

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -27,11 +27,28 @@ def test_fetch_services_parses_response_into_name_uid_dict():
             ],
         },
     )
-    out = catalog_sync.fetch_services(http, LEIPZIG_BASE, LEIPZIG_UID)
-    assert out == {
+    de, en = catalog_sync.fetch_services(http, LEIPZIG_BASE, LEIPZIG_UID)
+    assert de == {
         "Personalausweis beantragen": "u1",
         "Reisepass beantragen": "u2",
     }
+    # No data.display_name_en in the response → English falls back to German.
+    assert en == de
+
+
+def test_fetch_services_extracts_english_from_data_display_name_en():
+    """English service labels live in result.data.display_name_en (the lang
+    query param is ignored by get_service_list); missing → fall back to German."""
+    http = MagicMock()
+    http.get.return_value = MagicMock(status_code=200, json=lambda: {
+        "success": True, "results": [
+            {"uid": "u1", "display_name": "Personalausweis beantragen",
+             "data": {"display_name_en": "Applying for an identity card"}},
+            {"uid": "u2", "display_name": "Reisepass beantragen", "data": {}},
+        ]})
+    de, en = catalog_sync.fetch_services(http, LEIPZIG_BASE, LEIPZIG_UID)
+    assert de == {"Personalausweis beantragen": "u1", "Reisepass beantragen": "u2"}
+    assert en == {"Applying for an identity card": "u1", "Reisepass beantragen": "u2"}
 
 
 def test_fetch_services_strips_trailing_whitespace_from_names():
@@ -43,8 +60,8 @@ def test_fetch_services_strips_trailing_whitespace_from_names():
             {"uid": "u1", "display_name": "An- oder Ummeldung Wohnsitz "},
         ]},
     )
-    out = catalog_sync.fetch_services(http, LEIPZIG_BASE, LEIPZIG_UID)
-    assert "An- oder Ummeldung Wohnsitz" in out  # no trailing space
+    de, _en = catalog_sync.fetch_services(http, LEIPZIG_BASE, LEIPZIG_UID)
+    assert "An- oder Ummeldung Wohnsitz" in de  # no trailing space
 
 
 def test_fetch_services_raises_on_success_false():
@@ -129,6 +146,57 @@ def test_fetch_locations_returns_union_across_services():
         "Bürgerbüro Eins": "loc-1",
         "Bürgerbüro Zwei": "loc-2",
     }
+
+
+def test_fetch_locations_passes_lang_to_the_wizard():
+    """English location labels come from the wizard rendered with lang=en, so
+    fetch_locations must thread the requested language into its GET/POST URLs."""
+    http = _build_probe_http(
+        services_page=_services_page_html(),
+        locations_pages_by_target_uid={"svc": {"loc-1": "Resident Services Office X"}},
+    )
+    catalog_sync.fetch_locations(http, LEIPZIG_BASE, LEIPZIG_UID,
+                                 service_uids=["svc"], steps=STEPS, lang="en")
+    urls = ([c.args[0] for c in http.get.call_args_list]
+            + [c.args[0] for c in http.post.call_args_list])
+    assert any("lang=en" in u for u in urls), "wizard requests must carry lang=en"
+    assert not any("lang=de" in u for u in urls)
+
+
+def test_parse_location_checkboxes_collapses_internal_whitespace():
+    """The English wizard emits labels like 'Resident Services Office  Leutzsch'
+    with a double space; collapse runs of whitespace to a single space."""
+    html = ('<form>'
+            '<input type="checkbox" name="locations" value="loc-1" id="l1"/>'
+            '<label for="l1">\n\t\tResident Services Office  Leutzsch\n\t\tStreet 1</label>'
+            '</form>')
+    out = catalog_sync._parse_location_checkboxes(html)
+    assert out == {"loc-1": "Resident Services Office Leutzsch"}
+
+
+def test_sync_city_writes_english_service_file_on_drift(tmp_catalog_root):
+    """When the service catalog drifts, the English label file is rewritten
+    alongside the German one so the two never diverge."""
+    http = _build_probe_http(
+        services_page=_services_page_html(),
+        locations_pages_by_target_uid={
+            "u1": {"loc-1": "Bürgerbüro Eins"},
+            "u2": {"loc-1": "Bürgerbüro Eins"},
+        },
+    )
+    http.get.side_effect = _stack_get([
+        MagicMock(status_code=200, json=lambda: {"success": True, "results": [
+            {"uid": "u1", "display_name": "Personalausweis beantragen",
+             "data": {"display_name_en": "Applying for an identity card"}},
+            {"uid": "u2", "display_name": "Reisepass beantragen",
+             "data": {"display_name_en": "Applying for a passport"}},
+        ]}),
+    ], probe_get_side_effect=http.get.side_effect)
+    catalog_sync.sync_city("leipzig", http, alert_fn=lambda *a, **k: None,
+                           catalog_root=tmp_catalog_root)
+    en = json.loads((tmp_catalog_root / "leipzig" / "appointment_type.en.json").read_text())
+    assert en == {"Applying for a passport": "u2",
+                  "Applying for an identity card": "u1"}
 
 
 def test_fetch_locations_handles_8443_redirect():

--- a/tests/test_smartcjm_live.py
+++ b/tests/test_smartcjm_live.py
@@ -77,7 +77,10 @@ def test_live_poll_completes_without_raising(http, scfg, appointment_types):
 
 def test_live_get_service_list_endpoint_returns_known_services(http, scfg, appointment_types):
     """Canary: the JSON endpoint still exists and returns the catalog's UUIDs."""
-    live = catalog_sync.fetch_services(http, scfg["base_url"], scfg["uid"])
+    live, live_en = catalog_sync.fetch_services(http, scfg["base_url"], scfg["uid"])
+    # Canary: the English map must cover the exact same uuid set (it only differs
+    # in display labels) — catches a regression in the data.display_name_en path.
+    assert set(live_en.values()) == set(live.values())
     catalog_uids = set(appointment_types.values())
     live_uids = set(live.values())
     intersection = catalog_uids & live_uids

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -89,6 +89,45 @@ def test_no_pending_banner_on_bare_form(client):
     body_en = client.get("/?lang=en").data.decode().lower()
     assert "almost done" not in body_en
 
+def test_form_en_shows_english_service_and_location_labels(client):
+    """The English form must render Leipzig's English service/location labels,
+    not the German ones (regression: EN page showed a German dropdown)."""
+    body = client.get("/?lang=en").data.decode()
+    assert "Applying for an identity card" in body          # EN service label
+    assert "Resident Services Office Otto-Schill-Straße" in body  # EN location label
+    assert "Personalausweis beantragen" not in body         # German label gone
+    assert "Bürgerbüro Otto-Schill-Straße (Zentrum)" not in body
+
+
+def test_form_de_still_shows_german_labels(client):
+    body = client.get("/?lang=de").data.decode()
+    assert "Personalausweis beantragen" in body
+    assert "Bürgerbüro Otto-Schill-Straße (Zentrum)" in body
+    assert "Applying for an identity card" not in body
+
+
+def test_manage_page_localizes_labels_to_subscriber_language(client):
+    """The /manage page must use the subscriber's stored language for the
+    dropdown and locations, just like the public form."""
+    import os
+    from datetime import time
+    from app.db import connect
+    from app.models import Filter
+    from app.repo import insert_pending, confirm
+    from app.tokens import sign
+    conn = connect(os.environ["DB_PATH"])
+    f = Filter(appointment_types=["b04658d5-8d85-469a-a635-93337e055b73"],
+               locations="all", weekdays=[1, 2, 3, 4, 5],
+               time_window_start=time(0, 0), time_window_end=time(23, 59))
+    sid = insert_pending(conn, email="en@x.com", city="leipzig", language="en",
+                         filter_=f, ttl_days=90)
+    confirm(conn, sid)
+    tok = sign(sid, "manage", primary="x" * 32, previous="")
+    body = client.get(f"/manage/{tok}").data.decode()
+    assert "Applying for an identity card" in body
+    assert "Personalausweis beantragen" not in body
+
+
 def test_subscribe_error_banner_shown(client):
     """When a confirmation email could not be sent, /?subscribe_error=mail
     shows a localized, retryable error banner."""


### PR DESCRIPTION
## Problem
The English site (`?lang=en`) rendered the **German** appointment-type dropdown and location checkboxes — the catalog only stored German names.

Leipzig exposes English, but in two different places:
- **Services:** `get_service_list` ignores `&lang=en`; the English label is in `result.data.display_name_en` (fall back to German when absent).
- **Locations:** only in the wizard HTML rendered with `lang=en`, and only by unioning across services — a single probe misses the two mobile offices.

## Change
- New `catalog/leipzig/appointment_type.en.json` + `locations.en.json`, validated to map to the **exact same uuid set** as German.
- `Catalog` gains optional `*_en` maps + `appointment_types_for(lang)` / `locations_for(lang)`, with a **per-uuid fallback to German** so a missing/stale English entry degrades gracefully rather than dropping options.
- `/` form and `/manage` feed the language-appropriate maps. **Templates unchanged.**
- `catalog_sync` keeps the English files in lockstep with German on drift — English service names come free from the same JSON; English locations fetched best-effort so a failure can't break the German critical path. Location-label whitespace collapsed.

## Faithful edge cases
- The two *"mobiler Bürgerservice – Bibliothek …"* offices have no upstream English translation → they stay German (as on Leipzig's own English page).
- German behavior is untouched.

## Tests
TDD throughout. Full suite: **137 passed, 3 skipped** (opt-in live). Added coverage for the English extraction, `lang` threading, whitespace normalization, the sync write, and end-to-end English form/manage rendering.
