### PR TITLE
Richer appointment digest + dashboard-style admin summary emails

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -3,6 +3,89 @@ import sqlite3
 from datetime import datetime
 
 
+def _humanize_age(iso: str | None, now: datetime) -> str:
+    """Return a ' (3h ago)' suffix for an ISO timestamp; '' if missing/unparsable.
+
+    Naive timestamps are treated as UTC, mirroring the dashboard's JS.
+    """
+    if not iso:
+        return ""
+    try:
+        dt = datetime.fromisoformat(iso.rstrip("Z"))
+    except (TypeError, ValueError):
+        return ""
+    sec = max(0, int((now - dt).total_seconds()))
+    if sec < 60:
+        rel = "just now"
+    elif sec < 3600:
+        rel = f"{sec // 60}m ago"
+    elif sec < 86400:
+        rel = f"{sec // 3600}h ago"
+    else:
+        rel = f"{sec // 86400}d ago"
+    return f" ({rel})"
+
+
+def _ts(iso: str | None, now: datetime, *, missing: str) -> str:
+    """Absolute UTC timestamp + relative hint, e.g. '2026-06-09 14:32Z (3h ago)'.
+
+    Email is static, so (unlike the live dashboard) we show the exact UTC time
+    and append the relative age as a glance hint. Missing -> `missing`.
+    """
+    if not iso:
+        return missing
+    try:
+        abs_ = datetime.fromisoformat(iso.rstrip("Z")).strftime("%Y-%m-%d %H:%M") + "Z"
+    except (TypeError, ValueError):
+        abs_ = iso
+    return f"{abs_}{_humanize_age(iso, now)}"
+
+
+def render_summary_text(s: dict, *, now: datetime) -> str:
+    """Plain-text ops summary mirroring the /admin dashboard sections.
+
+    Pure: takes a `stats()` dict and the current time (injected for testable
+    relative-age rendering) and returns the email body.
+    """
+    out = ["OVERVIEW",
+           f"  Active subscriptions   {s['active_subscriptions']}",
+           f"  Pending confirmation   {s['pending_confirmation']}",
+           f"  Signups                24h {s['signups_last_24h']} · 7d {s['signups_last_7d']}",
+           f"  Digests sent (7d)      {s['digests_sent_last_7d']}",
+           f"  Emails sent (total)    {s['emails_sent_total']}",
+           f"  Slots cached           {s['slots_cached']}",
+           "",
+           "CITIES"]
+    # City-key union, same sources as the dashboard template.
+    city_keys = (list(s.get("upstream_by_city", {}))
+                 + list(s.get("active_subscriptions_by_city", {}))
+                 + list(s.get("last_polled_at_by_city", {})))
+    cities = sorted(dict.fromkeys(city_keys))
+    if not cities:
+        out.append("  No polling activity yet.")
+    else:
+        for city in cities:
+            up = s.get("upstream_by_city", {}).get(city, {})
+            zms = s.get("parser_zero_match_since_by_city", {}).get(city)
+            lp = s.get("last_polled_at_by_city", {}).get(city)
+            status = f"NO MATCHES since {zms}" if zms else "matching slots"
+            subs = s.get("active_subscriptions_by_city", {}).get(city, 0)
+            plans = s.get("current_plan_count_by_city", {}).get(city, 0)
+            out.append(f"  {city} — {status}")
+            out.append(f"    Last polled   {_ts(lp, now, missing='never')}")
+            out.append(f"    Active subs   {subs} · Plans {plans}")
+            out.append(f"    Polls         {up.get('polls_today', 0)} today "
+                       f"· {up.get('polls_total', 0)} total")
+            out.append(f"    Requests      {up.get('requests_today', 0)} today "
+                       f"· {up.get('requests_total', 0)} total")
+    out += ["",
+            "SYSTEM",
+            f"  Last housekeeping  {_ts(s.get('last_housekeeping_at'), now, missing='never')}",
+            f"  Last backup        {_ts(s.get('last_backup_at'), now, missing='never')}",
+            f"  Failure alert      {_ts(s.get('last_failure_alert_at'), now, missing='none')}"]
+    return "\n".join(out)
+
+
 def stats(conn: sqlite3.Connection) -> dict:
     def scalar(q, *args):
         row = conn.execute(q, args).fetchone()

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -27,6 +27,14 @@ def _localized(de_map: dict[str, str], en_map: dict[str, str],
     return dict(sorted(merged.items()))
 
 
+def _label_for(name_to_uuid: dict[str, str], uuid: str) -> str:
+    """Reverse a name→uuid map to find the display name for `uuid`.
+
+    Falls back to the uuid itself when absent, so callers never get None.
+    """
+    return next((n for n, u in name_to_uuid.items() if u == uuid), uuid)
+
+
 @dataclass(frozen=True)
 class Catalog:
     city: str
@@ -55,6 +63,18 @@ class Catalog:
     def locations_for(self, lang: str) -> dict[str, str]:
         """name→uuid map for the locations list, localized for `lang`."""
         return _localized(self.locations, self.locations_en, lang)
+
+    def appointment_type_label(self, uuid: str, lang: str) -> str:
+        """Localized display name for a service uuid; the raw uuid if unknown.
+
+        Never raises and never returns empty: slots can carry an out-of-catalog
+        uuid, and a notification must still render (worst case showing the uuid).
+        """
+        return _label_for(self.appointment_types_for(lang), uuid)
+
+    def location_label(self, uuid: str, lang: str) -> str:
+        """Localized display name for a location uuid; the raw uuid if unknown."""
+        return _label_for(self.locations_for(lang), uuid)
 
 @lru_cache(maxsize=8)
 def load_catalog(city: str) -> Catalog:

--- a/app/digest.py
+++ b/app/digest.py
@@ -1,24 +1,85 @@
 from __future__ import annotations
 import sqlite3
+from datetime import datetime
 from app.i18n import t
 from app.models import Subscription, Slot
 from app.mail import send, _idem_key
 
+# Weekday abbreviations for the date line (i18n.t is string-only, so the
+# per-language lists live here rather than in the JSON bundles). Index 0 = Mon.
+_WEEKDAY_ABBR = {
+    "de": ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"],
+    "en": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+}
+
+
+def _format_date(date_str: str, lang: str) -> str:
+    """'2026-06-12' -> 'Fr 12.06.'. Falls back to the raw string if unparsable."""
+    try:
+        d = datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:
+        return date_str
+    abbr = _WEEKDAY_ABBR.get(lang, _WEEKDAY_ABBR["de"])[d.weekday()]
+    return f"{abbr} {d.day:02d}.{d.month:02d}."
+
+
 def render_digest_text(sub: Subscription, slots: list[Slot], *,
                        unsubscribe_url: str, public_base_url: str,
-                       kofi_url: str) -> str:
+                       kofi_url: str, catalog=None) -> str:
     lang = sub.language
+    # Resolve the catalog for uuid->name lookups. This must never block a
+    # notification: an unknown city or missing catalog files degrades to
+    # showing raw uuids rather than dropping the email.
+    if catalog is None:
+        try:
+            from app.catalog import load_catalog
+            catalog = load_catalog(sub.city)
+        except Exception:
+            catalog = None
+
+    def svc_label(uuid: str) -> str:
+        return catalog.appointment_type_label(uuid, lang) if catalog else uuid
+
+    def loc_label(uuid: str) -> str:
+        return catalog.location_label(uuid, lang) if catalog else uuid
+
     lines = [t(lang, "digest.greeting"), "", t(lang, "digest.intro"), ""]
-    # Group by day
-    by_day: dict[str, list[Slot]] = {}
+
+    # "Deine Auswahl" — echo the subscriber's filter (what they selected).
+    f = sub.sub_filter
+    services = ", ".join(svc_label(u) for u in f.appointment_types)
+    if f.locations == "all":
+        locations = t(lang, "digest.all_locations")
+    else:
+        locations = ", ".join(loc_label(u) for u in f.locations)
+    svc_lbl = t(lang, "digest.selection_service_label")
+    loc_lbl = t(lang, "digest.selection_locations_label")
+    pad = max(len(svc_lbl), len(loc_lbl)) + 1  # width of the longest "label:"
+    lines.append(t(lang, "digest.selection_heading"))
+    lines.append(f"  {(svc_lbl + ':').ljust(pad)} {services}")
+    lines.append(f"  {(loc_lbl + ':').ljust(pad)} {locations}")
+    lines.append("")
+
+    # Slots grouped by office (offices sorted by display name); within an
+    # office, sorted by day then time. The per-slot service label is shown
+    # only when the filter spans more than one type — otherwise the header
+    # already names the single service and the line stays uncluttered.
+    multi_service = len(f.appointment_types) > 1
+    by_office: dict[str, list[Slot]] = {}
     for s in slots:
-        by_day.setdefault(s.date, []).append(s)
-    for day in sorted(by_day):
-        lines.append(day)
-        for s in by_day[day]:
+        by_office.setdefault(s.location_uuid, []).append(s)
+    for office_uuid in sorted(by_office, key=loc_label):
+        lines.append(loc_label(office_uuid))
+        for s in sorted(by_office[office_uuid], key=lambda s: (s.date, s.time_str)):
             go_url = f"{public_base_url}/go/{s.booking_token}"
-            lines.append(f"  {s.time_str}  →  {go_url}")
-        lines.append("")
+            date_str = _format_date(s.date, lang)
+            if multi_service:
+                lines.append(f"  {date_str}  {s.time_str}  ·  "
+                             f"{svc_label(s.service_uuid)}  →  {go_url}")
+            else:
+                lines.append(f"  {date_str}  {s.time_str}  →  {go_url}")
+    lines.append("")
+
     lines.append(t(lang, "digest.burst_warning"))
     lines.append("")
     lines.append(t(lang, "digest.unsubscribe", unsubscribe_url=unsubscribe_url))
@@ -29,7 +90,8 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
 def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
                 matched_slots: list[Slot], cycle_id: str, cfg) -> None:
     """Send a digest. `cfg` is the loaded Config (passed in by callers
-    that already have it loaded — never re-read from os.environ here)."""
+    that already have it loaded — never re-read from os.environ here).
+    render_digest_text loads the per-city catalog itself for label lookups."""
     from app.tokens import sign
     unsub_token = sign(subscription.id, "unsubscribe",
                        primary=cfg.token_secret_primary,

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -234,9 +234,9 @@ def _sync_catalogs(conn, cfg):
 
 
 def _send_summary_email(conn, cfg):
-    from app.admin import stats
+    from app.admin import stats, render_summary_text
     s = stats(conn)
-    body = "\n".join(f"{k}: {v}" for k, v in s.items())
+    body = render_summary_text(s, now=datetime.utcnow())
     try:
         mail_send(conn, cfg.developer_email, "[termine-notifier] ops summary", body,
                   idem_key=_idem_key(0, [], f"summary-{datetime.utcnow().date()}"))

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -2,6 +2,10 @@
   "digest.subject": "Neue Termine verfügbar",
   "digest.greeting": "Hallo,",
   "digest.intro": "Es wurden neue passende Termine gefunden:",
+  "digest.selection_heading": "Deine Auswahl",
+  "digest.selection_service_label": "Leistung",
+  "digest.selection_locations_label": "Standorte",
+  "digest.all_locations": "Alle Standorte",
   "digest.burst_warning": "Viele Termine öffnen sich gleichzeitig — schneller Klick gewinnt.",
   "digest.unsubscribe": "Abmelden: {unsubscribe_url}",
   "digest.kofi": "Hat dir diese Benachrichtigung geholfen? Du kannst mir einen Kaffee spendieren: {kofi_url} (aber nur, wenn du magst — der Dienst bleibt kostenlos.)"

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2,6 +2,10 @@
   "digest.subject": "New appointments available",
   "digest.greeting": "Hello,",
   "digest.intro": "We found new matching appointments:",
+  "digest.selection_heading": "Your selection",
+  "digest.selection_service_label": "Service",
+  "digest.selection_locations_label": "Locations",
+  "digest.all_locations": "All locations",
   "digest.burst_warning": "Many appointments open at once — the fastest click wins.",
   "digest.unsubscribe": "Unsubscribe: {unsubscribe_url}",
   "digest.kofi": "Did this notification help? You can buy me a coffee: {kofi_url} (only if you want — the service stays free.)"

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,7 +2,7 @@ import pytest
 from datetime import datetime
 from app.web import create_app
 from app.db import connect, init_schema
-from app.admin import stats
+from app.admin import stats, render_summary_text
 import os
 
 @pytest.fixture
@@ -125,6 +125,95 @@ def test_stats_includes_upstream_and_extra_metrics(tmp_path):
     assert s["slots_cached"] == 1
     assert s["emails_sent_total"] == 1   # 'pending' excluded
     assert s["last_failure_alert_at"] == "2026-06-01T00:00:00"
+
+# ---------- ops-summary email renderer (mirrors the dashboard) ----------
+
+NOW = datetime(2026, 6, 9, 14, 34, 0)
+
+
+def _summary_stats(**over):
+    base = {
+        "active_subscriptions": 42,
+        "active_subscriptions_by_city": {"leipzig": 42},
+        "current_plan_count_by_city": {"leipzig": 6},
+        "parser_zero_match_since_by_city": {},
+        "pending_confirmation": 3,
+        "signups_last_24h": 5,
+        "signups_last_7d": 19,
+        "digests_sent_last_7d": 88,
+        "upstream_by_city": {"leipzig": {"polls_today": 120, "polls_total": 9821,
+                                         "requests_today": 240, "requests_total": 20140}},
+        "last_polled_at_by_city": {"leipzig": "2026-06-09T14:32:00"},
+        "slots_cached": 17,
+        "emails_sent_total": 1203,
+        "last_failure_alert_at": None,
+        "last_housekeeping_at": "2026-06-09T11:30:00",
+        "last_backup_at": "2026-06-09T09:30:00",
+    }
+    base.update(over)
+    return base
+
+
+def _line(text, needle):
+    return next(l for l in text.splitlines() if needle in l)
+
+
+def test_summary_has_three_sections():
+    text = render_summary_text(_summary_stats(), now=NOW)
+    assert "OVERVIEW" in text
+    assert "CITIES" in text
+    assert "SYSTEM" in text
+
+
+def test_summary_overview_numbers():
+    text = render_summary_text(_summary_stats(), now=NOW)
+    assert "42" in _line(text, "Active subscriptions")
+    assert "1203" in _line(text, "Emails sent")
+    assert "17" in _line(text, "Slots cached")
+    signups = _line(text, "Signups")
+    assert "24h 5" in signups and "7d 19" in signups
+
+
+def test_summary_city_block():
+    text = render_summary_text(_summary_stats(), now=NOW)
+    assert "leipzig" in _line(text, "leipzig")
+    assert "matching slots" in _line(text, "leipzig")
+    polls = _line(text, "Polls")
+    assert "120 today" in polls and "9821 total" in polls
+    assert "240 today" in _line(text, "Requests")
+    subs = _line(text, "Plans")   # only the city block has a "Plans" count
+    assert "42" in subs and "Plans 6" in subs
+
+
+def test_summary_last_polled_shows_absolute_and_relative():
+    text = render_summary_text(_summary_stats(), now=NOW)
+    lp = _line(text, "Last polled")
+    assert "2026-06-09 14:32Z" in lp   # absolute UTC
+    assert "2m ago" in lp              # relative hint (now - 2 min)
+
+
+def test_summary_city_status_no_matches():
+    text = render_summary_text(
+        _summary_stats(parser_zero_match_since_by_city={"leipzig": "2026-06-08T06:00:00"}),
+        now=NOW)
+    assert "NO MATCHES since 2026-06-08T06:00:00" in _line(text, "leipzig")
+
+
+def test_summary_system_fallbacks():
+    text = render_summary_text(
+        _summary_stats(last_backup_at=None, last_failure_alert_at=None), now=NOW)
+    assert "never" in _line(text, "Last backup")
+    assert "none" in _line(text, "Failure alert")
+    hk = _line(text, "Last housekeeping")
+    assert "2026-06-09 11:30Z" in hk and "3h ago" in hk
+
+
+def test_summary_empty_cities():
+    text = render_summary_text(
+        _summary_stats(upstream_by_city={}, active_subscriptions_by_city={},
+                       last_polled_at_by_city={}), now=NOW)
+    assert "No polling activity yet." in text
+
 
 def test_stats_today_counts_gated_by_stale_date(tmp_path):
     conn = connect(str(tmp_path / "s.db")); init_schema(conn)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -77,3 +77,38 @@ def test_for_lang_with_no_english_table_returns_german():
     )
     assert cat.appointment_types_for("en") == {"DE A": "u1"}
     assert cat.locations_for("en") == {"DE L": "l1"}
+
+
+# ---------- uuid → label lookups (for email rendering) ----------
+
+def _label_catalog():
+    return Catalog(
+        city="x",
+        appointment_types={"Personalausweis": "u1"},
+        locations={"Bürgerbüro Mitte": "l1", "Bürgerbüro Nord": "l2"},
+        scraper_config={},
+        appointment_types_en={"Identity card": "u1"},
+        locations_en={"Citizen office centre": "l1"},
+    )
+
+
+def test_appointment_type_label_localizes():
+    cat = _label_catalog()
+    assert cat.appointment_type_label("u1", "de") == "Personalausweis"
+    assert cat.appointment_type_label("u1", "en") == "Identity card"
+
+
+def test_location_label_localizes_with_german_fallback_per_uuid():
+    cat = _label_catalog()
+    assert cat.location_label("l1", "de") == "Bürgerbüro Mitte"
+    assert cat.location_label("l1", "en") == "Citizen office centre"
+    # l2 has no English label — fall back to its German name, not the uuid.
+    assert cat.location_label("l2", "en") == "Bürgerbüro Nord"
+
+
+def test_labels_fall_back_to_uuid_when_unknown():
+    """A uuid absent from the catalog must render as the raw uuid, never crash
+    or blank — slots can carry an out-of-catalog uuid (real prod failure mode)."""
+    cat = _label_catalog()
+    assert cat.appointment_type_label("ghost-uuid", "de") == "ghost-uuid"
+    assert cat.location_label("ghost-uuid", "en") == "ghost-uuid"

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -2,37 +2,144 @@ from datetime import datetime, time
 from unittest.mock import patch
 import pytest
 from app.db import connect, init_schema
+from app.catalog import Catalog
 from app.models import Filter, Slot, Subscription
 from app.digest import render_digest_text
 
-def _sub(language="de"):
+
+def _sub(language="de", appointment_types=("svc-A",), locations="all"):
+    locs = "all" if locations == "all" else list(locations)
     return Subscription(
         id=1, email="a@x.com", city="leipzig", language=language,
         sub_filter=Filter(
-            appointment_types=["svc-A"], locations="all",
-            weekdays=[1,2,3,4,5,6,7],
-            time_window_start=time(0,0), time_window_end=time(23,59),
+            appointment_types=list(appointment_types), locations=locs,
+            weekdays=[1, 2, 3, 4, 5, 6, 7],
+            time_window_start=time(0, 0), time_window_end=time(23, 59),
         ),
-        created_at=datetime(2026,5,1), confirmed_at=datetime(2026,5,1),
+        created_at=datetime(2026, 5, 1), confirmed_at=datetime(2026, 5, 1),
         last_notified_at=None,
-        expires_at=datetime(2026,8,1),
+        expires_at=datetime(2026, 8, 1),
         reminder_sent_at=None, heartbeat_30d_at=None, heartbeat_60d_at=None,
         deleted_at=None,
     )
 
+
+def _cat():
+    return Catalog(
+        city="leipzig",
+        appointment_types={"Personalausweis": "svc-A", "Reisepass": "svc-B"},
+        locations={"Bürgerbüro Mitte": "loc-1", "Bürgerbüro Nord": "loc-2"},
+        scraper_config={},
+        appointment_types_en={"Identity card": "svc-A", "Passport": "svc-B"},
+        locations_en={"Citizen office centre": "loc-1"},  # loc-2 EN missing on purpose
+    )
+
+
+def _render(sub, slots, *, catalog=None):
+    return render_digest_text(
+        sub, slots, unsubscribe_url="https://x/unsubscribe/tok",
+        public_base_url="https://x", kofi_url="https://ko-fi.com/me",
+        catalog=catalog)
+
+
+# ---------- existing baseline (no catalog → uuid fallback path) ----------
+
 def test_render_digest_de():
     slots = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")]
-    text = render_digest_text(_sub("de"), slots,
-                              unsubscribe_url="https://x/unsubscribe/tok",
-                              public_base_url="https://x", kofi_url="https://ko-fi.com/me")
-    assert "2026-06-10" in text
+    text = _render(_sub("de"), slots)
+    assert "10.06." in text          # weekday + dd.mm. (2026-06-10 is a Wednesday)
     assert "10:30" in text
     assert "schneller Klick" in text  # burst-congestion line
     assert "https://x/unsubscribe/tok" in text
 
+
 def test_render_digest_en():
     slots = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")]
-    text = render_digest_text(_sub("en"), slots,
-                              unsubscribe_url="https://x/unsubscribe/tok",
-                              public_base_url="https://x", kofi_url="https://ko-fi.com/me")
+    text = _render(_sub("en"), slots)
     assert "click wins" in text.lower()
+
+
+# ---------- "Deine Auswahl" selection header ----------
+
+def test_selection_header_shows_service_and_locations_de():
+    sub = _sub("de", appointment_types=["svc-A"], locations=["loc-1", "loc-2"])
+    slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA"),
+             Slot("2026-06-13", "08:00", "loc-2", "svc-A", "tB")]
+    text = _render(sub, slots, catalog=_cat())
+    assert "Deine Auswahl" in text
+    assert "Personalausweis" in text
+    assert "Bürgerbüro Mitte" in text
+    assert "Bürgerbüro Nord" in text
+
+
+def test_selection_header_all_locations_label():
+    sub = _sub("de", appointment_types=["svc-A"], locations="all")
+    slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA")]
+    text = _render(sub, slots, catalog=_cat())
+    assert "Alle Standorte" in text
+
+
+def test_selection_header_english_labels():
+    sub = _sub("en", appointment_types=["svc-A"], locations=["loc-1"])
+    slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA")]
+    text = _render(sub, slots, catalog=_cat())
+    assert "Your selection" in text
+    assert "Identity card" in text
+    assert "Citizen office centre" in text
+
+
+# ---------- per-office grouping ----------
+
+def test_slots_grouped_by_office():
+    sub = _sub("de", appointment_types=["svc-A"], locations="all")
+    slots = [
+        Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA"),
+        Slot("2026-06-12", "10:40", "loc-1", "svc-A", "tB"),
+        Slot("2026-06-13", "08:00", "loc-2", "svc-A", "tC"),
+    ]
+    text = _render(sub, slots, catalog=_cat())
+    mitte = text.index("Bürgerbüro Mitte")
+    nord = text.index("Bürgerbüro Nord")
+    assert mitte < nord                       # offices sorted by name
+    assert mitte < text.index("09:20") < nord  # Mitte's slots under its header
+    assert mitte < text.index("10:40") < nord
+    assert text.index("08:00") > nord          # Nord's slot under its header
+
+
+def test_slot_line_has_weekday_date_time_and_link():
+    sub = _sub("de", appointment_types=["svc-A"], locations="all")
+    slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tok-A")]
+    text = _render(sub, slots, catalog=_cat())
+    line = next(ln for ln in text.splitlines() if "09:20" in ln)
+    assert "Fr 12.06." in line                       # 2026-06-12 is a Friday
+    assert "https://x/go/tok-A" in line
+
+
+# ---------- per-slot service only when the filter spans >1 type ----------
+
+def test_multi_service_filter_labels_each_line():
+    sub = _sub("de", appointment_types=["svc-A", "svc-B"], locations="all")
+    slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA"),
+             Slot("2026-06-12", "10:40", "loc-1", "svc-B", "tB")]
+    text = _render(sub, slots, catalog=_cat())
+    line_a = next(ln for ln in text.splitlines() if "09:20" in ln)
+    line_b = next(ln for ln in text.splitlines() if "10:40" in ln)
+    assert "Personalausweis" in line_a
+    assert "Reisepass" in line_b
+
+
+def test_single_service_filter_omits_per_line_service():
+    sub = _sub("de", appointment_types=["svc-A"], locations="all")
+    slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA")]
+    text = _render(sub, slots, catalog=_cat())
+    line = next(ln for ln in text.splitlines() if "09:20" in ln)
+    assert "Personalausweis" not in line   # header already names the one service
+
+
+# ---------- robustness ----------
+
+def test_out_of_catalog_location_uuid_renders_uuid_not_crash():
+    sub = _sub("de", appointment_types=["svc-A"], locations="all")
+    slots = [Slot("2026-06-12", "09:20", "ghost-loc", "svc-A", "tA")]
+    text = _render(sub, slots, catalog=_cat())
+    assert "ghost-loc" in text  # raw uuid as the office header, no exception

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -31,6 +31,17 @@ def _f():
     return Filter(appointment_types=["A"], locations="all", weekdays=[1,2,3,4,5,6,7],
                   time_window_start=time(0,0), time_window_end=time(23,59))
 
+
+def test_ops_summary_email_uses_dashboard_layout(db):
+    from app.config import load_config
+    from app.housekeeping import _send_summary_email
+    with patch("app.mail.send") as send:
+        _send_summary_email(db, load_config())
+    assert send.call_count == 1
+    body = send.call_args.args[3]   # send(conn, to, subject, body, *, idem_key=...)
+    assert "OVERVIEW" in body and "CITIES" in body and "SYSTEM" in body
+    assert "active_subscriptions:" not in body   # not the old raw key:value dump
+
 def test_expired_subscriptions_soft_deleted(db):
     sid = insert_pending(db, email="a@x.com", city="leipzig", language="de",
                          filter_=_f(), ttl_days=90)


### PR DESCRIPTION
Both notification emails stay **plain text** (no HTML, no remote images — the "kein Tracking" promise is untouched), but read much better.

## Appointment ("new appointments") digest
- New **"Deine Auswahl" / "Your selection"** header echoing the subscriber's selected appointment type(s) and locations (`Alle Standorte` / `All locations` when the filter is open).
- Slots **grouped by office** (sorted by name); each line shows weekday + `dd.mm.`, the time, and the `/go` link.
- Per-slot service label appears **only** when the filter spans more than one appointment type (otherwise the header already names it).
- New `Catalog.appointment_type_label` / `location_label` helpers with a **uuid fallback**, so a slot carrying an out-of-catalog uuid renders the uuid instead of crashing or blanking the line.

## Admin ops-summary email
- Replaces the raw `key: value` stats dump with `render_summary_text()`, mirroring the `/admin` dashboard's **OVERVIEW / CITIES / SYSTEM** sections (per-city status, last-polled, subs·plans, polls, requests).
- Timestamps render as **absolute UTC + a relative hint** (`2026-06-09 14:32Z (2m ago)`) — exact times suit a static email better than the dashboard's JS-only "ago".
- The 4 short alert emails (failure burst, canary, backup-stale, catalog drift) are unchanged.

## Notes
- TDD throughout (red → green). New/extended tests in `test_catalog.py`, `test_digest.py`, `test_admin.py`, `test_housekeeping.py`.
- Unchanged: `mail.py`, transport, idempotency, the admin webpage, DB schema.
- Full suite: **174 passed, 3 skipped**.