### PR TITLE
Render styled pages for unsubscribe/manage/renew/error results

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -201,6 +201,25 @@
     }
     button[type="submit"]:hover { background: var(--accent-hover); }
     button[type="submit"]:active { transform: translateY(1px); }
+    .result-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.85rem 1.25rem;
+      align-items: center;
+      margin: 1.75rem 0 0;
+    }
+    .btn-link {
+      display: inline-block;
+      padding: 0.7rem 1.5rem;
+      background: var(--accent);
+      color: var(--accent-text);
+      border-radius: var(--radius-input);
+      text-decoration: none;
+      font-weight: 500;
+      transition: background 0.15s, transform 0.05s;
+    }
+    .btn-link:hover { background: var(--accent-hover); }
+    .btn-link:active { transform: translateY(1px); }
     footer {
       margin-top: 2.5rem;
       font-size: 0.875rem;

--- a/app/templates/result.html
+++ b/app/templates/result.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}{{ heading }} · Termine-Notifier{% endblock %}
+{% block content %}
+  <div class="notice notice-{{ kind or 'success' }}" role="status">
+    <strong>{{ badge }}</strong>
+  </div>
+
+  <h1>{{ heading }}</h1>
+
+  {% if message %}<p>{{ message }}</p>{% endif %}
+
+  <p class="result-actions">
+    {% if action_url %}
+      <a href="{{ action_url }}" class="btn-link">{{ action_label }}</a>
+    {% endif %}
+    <a href="/{% if lang == 'en' %}?lang=en{% endif %}">
+      {% if lang == 'en' %}Back to the start page{% else %}Zur Startseite{% endif %}
+    </a>
+  </p>
+{% endblock %}

--- a/app/web.py
+++ b/app/web.py
@@ -81,6 +81,42 @@ _RESULT_MESSAGES: dict[str, dict] = {
                "This subscription no longer exists. You may have already "
                "unsubscribed."),
     },
+    "invalid_email": {
+        "kind": "error",
+        "de": ("E-Mail ungültig", "Bitte überprüfe deine E-Mail-Adresse",
+               "Die eingegebene E-Mail-Adresse scheint nicht gültig zu sein. "
+               "Bitte gehe zurück und versuche es erneut."),
+        "en": ("Invalid email", "Please check your email address",
+               "The email address you entered doesn't look valid. Please go "
+               "back and try again."),
+    },
+    "rate_limited": {
+        "kind": "error",
+        "de": ("Zu viele Anfragen", "Bitte versuche es später erneut",
+               "Es wurden in kurzer Zeit zu viele Anmeldungen vorgenommen. "
+               "Bitte warte einen Moment und versuche es dann noch einmal."),
+        "en": ("Too many requests", "Please try again later",
+               "Too many sign-ups were made in a short time. Please wait a "
+               "moment and try again."),
+    },
+    "waitlist_full": {
+        "kind": "error",
+        "de": ("Warteliste voll", "Die Warteliste ist gerade voll",
+               "Aktuell können keine neuen Anmeldungen aufgenommen werden. "
+               "Bitte versuche es in ein paar Tagen noch einmal."),
+        "en": ("Wait-list full", "The wait-list is currently full",
+               "We can't take new sign-ups right now. Please try again in a "
+               "few days."),
+    },
+    "missing_type": {
+        "kind": "error",
+        "de": ("Anliegen fehlt", "Bitte wähle ein Anliegen",
+               "Es wurde kein Anliegen ausgewählt. Bitte gehe zurück und wähle "
+               "die gewünschte Terminart."),
+        "en": ("Appointment type missing", "Please choose an appointment type",
+               "No appointment type was selected. Please go back and choose "
+               "the type you need."),
+    },
 }
 
 
@@ -200,26 +236,29 @@ def create_app() -> Flask:
         if request.form.get("website", ""):
             return ("", 200)
         cfg = app.config["TERMINE_CONFIG"]
+        # Read the form language up front so every error below can render a
+        # localized result page (the success paths redirect, so they don't
+        # need it).
+        lang = request.form.get("lang", "de")
         ip = request.headers.get("X-Forwarded-For", request.remote_addr or "")
         email = request.form.get("email", "").strip().lower()
         if not email or "@" not in email:
-            return ("Invalid email", 400)
+            return _result_page("invalid_email", lang, status=400)
         # 2. per-IP rate limit (in-memory, soft)
         if not GLOBAL_IP_LIMITER.hit(f"ip:{ip}",
                                      cfg.subscribe_ratelimit_per_ip_per_hour,
                                      3600):
-            return ("Rate limit exceeded", 429)
+            return _result_page("rate_limited", lang, status=429)
         # 3. per-email rate limit (DB-backed, hard - shared across workers)
         conn_for_check = connect(cfg.db_path)
         if not email_rate_limit_ok(conn_for_check, email,
                                    cfg.subscribe_ratelimit_per_email_per_day):
-            return ("Rate limit exceeded", 429)
+            return _result_page("rate_limited", lang, status=429)
         # 4. parse filter from form
-        lang = request.form.get("lang", "de")
         city = request.form.get("city", "leipzig")
         atype = request.form.get("appointment_type", "").strip()
         if not atype:
-            return ("Missing appointment_type", 400)
+            return _result_page("missing_type", lang, status=400)
         all_locs = request.form.get("all_locations") == "1"
         loc_list = request.form.getlist("locations")
         locations = "all" if all_locs or not loc_list else loc_list
@@ -241,11 +280,7 @@ def create_app() -> Flask:
             existing = [(s.city, s.sub_filter) for s in active_subscriptions(conn)]
             if would_exceed_cap(existing, city, f,
                                 max_plans_per_city=cfg.max_plans_per_city):
-                msg = (("Aktuell ist die Warteliste voll. "
-                        "Bitte in ein paar Tagen erneut versuchen.")
-                       if lang == "de"
-                       else "The wait-list is currently full. Please try again in a few days.")
-                return (msg, 503)
+                return _result_page("waitlist_full", lang, status=503)
             sub_id = insert_pending(conn, email=email, city=city,
                                     language=lang, filter_=f,
                                     ttl_days=cfg.subscription_ttl_days)
@@ -321,7 +356,10 @@ def create_app() -> Flask:
         if request.method == "POST":
             atype = request.form.get("appointment_type", "").strip()
             if not atype:
-                return ("Missing appointment_type", 400)
+                row = conn.execute("SELECT language FROM subscriptions WHERE id=?",
+                                   (sub_id,)).fetchone()
+                return _result_page("missing_type",
+                                    row["language"] if row else "de", status=400)
             all_locs = request.form.get("all_locations") == "1"
             loc_list = request.form.getlist("locations")
             locations = "all" if all_locs or not loc_list else loc_list

--- a/app/web.py
+++ b/app/web.py
@@ -17,6 +17,73 @@ from app.mail import send as mail_send, _idem_key
 log = logging.getLogger(__name__)
 
 
+# Localized copy for the standalone result/status pages (unsubscribe, manage
+# update, renew, expired links, errors). Each entry: kind (notice style) plus
+# a (badge, heading, message) triple per language. Routes render these through
+# templates/result.html so they share the styled card layout instead of
+# returning a bare string the browser shows top-left.
+_RESULT_MESSAGES: dict[str, dict] = {
+    "unsubscribed": {
+        "kind": "success",
+        "de": ("Abgemeldet", "Schade, dass du gehst",
+               "Du bist erfolgreich abgemeldet und erhältst keine weiteren "
+               "Termin-Benachrichtigungen mehr. Falls du es dir anders "
+               "überlegst, kannst du dich jederzeit wieder anmelden."),
+        "en": ("Unsubscribed", "Sorry to see you go",
+               "You've been unsubscribed and won't receive any more "
+               "appointment notifications. If you change your mind, you can "
+               "sign up again any time."),
+    },
+    "updated": {
+        "kind": "success",
+        "de": ("Gespeichert", "Einstellungen aktualisiert",
+               "Deine Filter wurden gespeichert. Wir benachrichtigen dich ab "
+               "sofort nach den neuen Kriterien."),
+        "en": ("Saved", "Settings updated",
+               "Your filters have been saved. We'll notify you based on your "
+               "new criteria from now on."),
+    },
+    "renewed": {
+        "kind": "success",
+        "de": ("Verlängert", "Abo verlängert",
+               "Dein Abonnement wurde verlängert. Du erhältst weiterhin "
+               "Benachrichtigungen über freie Termine."),
+        "en": ("Renewed", "Subscription renewed",
+               "Your subscription has been renewed. You'll keep receiving "
+               "notifications about available appointments."),
+    },
+    "link_expired": {
+        "kind": "error",
+        "de": ("Link abgelaufen", "Dieser Termin-Link ist abgelaufen",
+               "Freie Termine sind oft innerhalb von Sekunden vergeben. Schau "
+               "am besten direkt auf der offiziellen Seite der Stadt nach, ob "
+               "noch etwas frei ist."),
+        "en": ("Link expired", "This appointment link has expired",
+               "Free appointments are often taken within seconds. Please "
+               "check directly on the city's official booking site to see "
+               "what's still available."),
+    },
+    "invalid_token": {
+        "kind": "error",
+        "de": ("Ungültiger Link", "Dieser Link ist ungültig",
+               "Der Link ist fehlerhaft oder nicht mehr gültig. Bitte "
+               "verwende den aktuellen Link aus deiner E-Mail."),
+        "en": ("Invalid link", "This link is invalid",
+               "The link is malformed or no longer valid. Please use the most "
+               "recent link from your email."),
+    },
+    "not_found": {
+        "kind": "error",
+        "de": ("Nicht gefunden", "Abonnement nicht gefunden",
+               "Dieses Abonnement existiert nicht mehr. Möglicherweise hast du "
+               "dich bereits abgemeldet."),
+        "en": ("Not found", "Subscription not found",
+               "This subscription no longer exists. You may have already "
+               "unsubscribed."),
+    },
+}
+
+
 def _parse_hhmm(s: str) -> time_cls:
     h, m = s.split(":")
     return time_cls(int(h), int(m))
@@ -78,6 +145,26 @@ def create_app() -> Flask:
             args["lang"] = target_lang
             return f"{request.path}?{urlencode(args)}"
         return {"switch_lang_url": switch_lang_url}
+
+    def _result_page(key: str, lang: str, *, status: int = 200,
+                     action_url: str | None = None,
+                     action_label: str | None = None):
+        """Render a styled standalone result page (templates/result.html)."""
+        if lang not in ("de", "en"):
+            lang = "de"
+        spec = _RESULT_MESSAGES[key]
+        badge, heading, message = spec[lang]
+        return render_template(
+            "result.html",
+            lang=lang,
+            kind=spec["kind"],
+            badge=badge,
+            heading=heading,
+            message=message,
+            action_url=action_url,
+            action_label=action_label,
+            kofi_url=app.config["TERMINE_CONFIG"].kofi_url,
+        ), status
 
     @app.route("/healthz")
     def healthz():
@@ -182,7 +269,8 @@ def create_app() -> Flask:
                             primary=cfg.token_secret_primary,
                             previous=cfg.token_secret_previous)
         except InvalidToken:
-            return ("Invalid token", 400)
+            return _result_page("invalid_token",
+                                request.args.get("lang", "de"), status=400)
         conn = connect(cfg.db_path)
         confirm(conn, sub_id)
         row = conn.execute("SELECT language FROM subscriptions WHERE id=?",
@@ -210,10 +298,14 @@ def create_app() -> Flask:
                             primary=cfg.token_secret_primary,
                             previous=cfg.token_secret_previous)
         except InvalidToken:
-            return ("Invalid token", 400)
+            return _result_page("invalid_token",
+                                request.args.get("lang", "de"), status=400)
         conn = connect(cfg.db_path)
+        row = conn.execute("SELECT language FROM subscriptions WHERE id=?",
+                           (sub_id,)).fetchone()
+        lang = request.args.get("lang") or (row["language"] if row else "de")
         soft_delete(conn, sub_id)
-        return ("Unsubscribed.", 200)
+        return _result_page("unsubscribed", lang)
 
     @app.route("/manage/<token>", methods=["GET", "POST"])
     def manage_route(token):
@@ -223,7 +315,8 @@ def create_app() -> Flask:
                             primary=cfg.token_secret_primary,
                             previous=cfg.token_secret_previous)
         except InvalidToken:
-            return ("Invalid token", 400)
+            return _result_page("invalid_token",
+                                request.args.get("lang", "de"), status=400)
         conn = connect(cfg.db_path)
         if request.method == "POST":
             atype = request.form.get("appointment_type", "").strip()
@@ -241,10 +334,18 @@ def create_app() -> Flask:
                        time_window_end=_parse_hhmm(te))
             conn.execute("UPDATE subscriptions SET filters_json=? WHERE id=?",
                          (f.to_json(), sub_id))
-            return ("Updated.", 200)
+            row = conn.execute("SELECT language FROM subscriptions WHERE id=?",
+                               (sub_id,)).fetchone()
+            lang = row["language"] if row else "de"
+            back_label = ("Zurück zu den Einstellungen" if lang == "de"
+                          else "Back to your settings")
+            return _result_page("updated", lang,
+                                 action_url=f"/manage/{token}",
+                                 action_label=back_label)
         row = conn.execute("SELECT * FROM subscriptions WHERE id=?", (sub_id,)).fetchone()
         if not row or row["deleted_at"] is not None:
-            return ("Subscription not found", 404)
+            return _result_page("not_found", request.args.get("lang", "de"),
+                                status=404)
         catalog = load_catalog(row["city"])
         lang = row["language"]
         return render_template("manage.html",
@@ -261,14 +362,18 @@ def create_app() -> Flask:
                          primary=cfg.token_secret_primary,
                          previous=cfg.token_secret_previous)
         except InvalidToken:
-            return ("Invalid token", 400)
+            return _result_page("invalid_token",
+                                request.args.get("lang", "de"), status=400)
         conn = connect(cfg.db_path)
         conn.execute(
             "UPDATE subscriptions SET expires_at=datetime('now', ?) "
             "WHERE id=? AND deleted_at IS NULL",
             (f"+{cfg.subscription_ttl_days} days", sid),
         )
-        return ("Subscription renewed.", 200)
+        row = conn.execute("SELECT language FROM subscriptions WHERE id=?",
+                           (sid,)).fetchone()
+        lang = request.args.get("lang") or (row["language"] if row else "de")
+        return _result_page("renewed", lang)
 
     @app.route("/go/<slot_token>")
     def go_route(slot_token):
@@ -279,7 +384,8 @@ def create_app() -> Flask:
             (slot_token,),
         ).fetchone()
         if not row:
-            return ("This appointment link has expired.", 410)
+            return _result_page("link_expired",
+                                request.args.get("lang", "de"), status=410)
         return redirect(row["upstream_url"], code=302)
 
     @app.route("/admin")


### PR DESCRIPTION
The token routes (unsubscribe, manage update, renew, expired /go links,
invalid-token and not-found errors) returned bare strings, so browsers
showed unstyled text in the top-left corner. Route them through a new
reusable templates/result.html that extends base.html, giving each a
card layout, success/error notice, heading, body copy, and action links.

Results are localized (DE/EN) using the subscriber's stored language,
with a ?lang query override so the language switcher works on these
landing pages. HTTP status codes (400/404/410) are preserved.