### PR TITLE
Raise plan cap and per-IP signup limit for traffic spikes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ RESEND_API_KEY=
 # tiers (Resend 100/day, Mailjet 10/hour). Raise both after upgrading to paid.
 RESEND_DAILY_QUOTA=100
 MAILJET_HOURLY_QUOTA=10
+# Order digests try providers. Mailjet-first routes notification volume through
+# Mailjet so its account sees traffic (needed to get the new-sender throttle
+# lifted); Resend takes the overflow. Flip to "resend,mailjet" once Mailjet's
+# limit is raised, with no redeploy.
+EMAIL_PROVIDER_ORDER=mailjet,resend
 # Email DEVELOPER_EMAIL once/day when daily Resend usage crosses this percent
 # of RESEND_DAILY_QUOTA, or whenever notifications get deferred for lack of
 # quota — the cue to switch to a paid plan.

--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,16 @@ DEDUP_WINDOW_HOURS=24
 RATE_LIMIT_MINUTES=15
 SUBSCRIPTION_TTL_DAYS=90
 RENEWAL_REMINDER_DAYS_BEFORE=10
-MAX_PLANS_PER_CITY=10
+# One poll plan is needed per distinct appointment type per city (location
+# variety collapses into a single "all" plan). Leipzig has 15 types, so 15
+# lets every type be watched without ever hitting the wait-list. Lower it only
+# to cap polling work at the cost of turning away rarer appointment types.
+MAX_PLANS_PER_CITY=15
 PARSER_CANARY_THRESHOLD_HOURS=2
-SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR=5
+# Raised from 5: many readers share one public IP behind mobile-carrier CGNAT,
+# so a low per-IP cap turns away legitimate sign-ups during a traffic spike.
+# Abuse is still bounded by SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY below.
+SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR=30
 SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY=1
 DEVELOPER_EMAIL=
 KOFI_URL=https://ko-fi.com/jakubwaller

--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,22 @@ MAILJET_FROM_NAME=Leipzig-Termine
 # Optional. Where subscriber replies go. Lets the From be a sending subdomain
 # that doesn't receive mail; replies route here instead. Leave blank to omit.
 REPLY_TO_EMAIL=termine@jakubwaller.eu
+# Deprecated / unused: kept only so existing .env files keep loading. The real
+# per-provider caps used for quota-aware delivery are the two below.
 MAILJET_DAILY_QUOTA=6000
 # Optional fallback provider. Leave blank to disable — Mailjet failures
 # will then surface as MailFailed instead of falling back silently.
 RESEND_API_KEY=
+# Quota-aware delivery caps. Notification digests are sent in batches, Resend
+# first (up to 100/call) then Mailjet, and never past these rolling-window
+# limits — the overflow is deferred to a later cycle. Defaults match the free
+# tiers (Resend 100/day, Mailjet 10/hour). Raise both after upgrading to paid.
+RESEND_DAILY_QUOTA=100
+MAILJET_HOURLY_QUOTA=10
+# Email DEVELOPER_EMAIL once/day when daily Resend usage crosses this percent
+# of RESEND_DAILY_QUOTA, or whenever notifications get deferred for lack of
+# quota — the cue to switch to a paid plan.
+QUOTA_ALERT_THRESHOLD_PCT=80
 TOKEN_SECRET_PRIMARY=
 TOKEN_SECRET_PREVIOUS=
 ADMIN_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -5,16 +5,19 @@ MAILJET_FROM_NAME=Leipzig-Termine
 # Optional. Where subscriber replies go. Lets the From be a sending subdomain
 # that doesn't receive mail; replies route here instead. Leave blank to omit.
 REPLY_TO_EMAIL=termine@jakubwaller.eu
-# Deprecated / unused: kept only so existing .env files keep loading. The real
-# per-provider caps used for quota-aware delivery are the two below.
-MAILJET_DAILY_QUOTA=6000
+# Mailjet daily cap (free tier = 200/day). Enforced together with the hourly
+# cap below — whichever is tighter wins. During the new-sender warm-up the
+# hourly throttle binds; once Mailjet lifts it, this daily cap takes over. Set
+# high after upgrading to a paid Mailjet plan.
+MAILJET_DAILY_QUOTA=200
 # Optional fallback provider. Leave blank to disable — Mailjet failures
 # will then surface as MailFailed instead of falling back silently.
 RESEND_API_KEY=
-# Quota-aware delivery caps. Notification digests are sent in batches, Resend
-# first (up to 100/call) then Mailjet, and never past these rolling-window
+# Quota-aware delivery caps. Notification digests are sent in batches (Resend
+# up to 100/call, Mailjet up to 50/call) and never past these rolling-window
 # limits — the overflow is deferred to a later cycle. Defaults match the free
-# tiers (Resend 100/day, Mailjet 10/hour). Raise both after upgrading to paid.
+# tiers (Resend 100/day; Mailjet 10/hour warm-up throttle + 200/day above).
+# Raise these to match your plan after upgrading.
 RESEND_DAILY_QUOTA=100
 MAILJET_HOURLY_QUOTA=10
 # Order digests try providers. Mailjet-first routes notification volume through

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ class Config:
     resend_daily_quota: int
     mailjet_hourly_quota: int
     quota_alert_threshold_pct: int
+    email_provider_order: tuple
     token_secret_primary: str
     token_secret_previous: str
     admin_token: str
@@ -57,6 +58,13 @@ def load_config() -> Config:
         resend_daily_quota=int(os.environ.get("RESEND_DAILY_QUOTA", "100")),
         mailjet_hourly_quota=int(os.environ.get("MAILJET_HOURLY_QUOTA", "10")),
         quota_alert_threshold_pct=int(os.environ.get("QUOTA_ALERT_THRESHOLD_PCT", "80")),
+        # Order in which providers are tried for notification digests. Default
+        # Mailjet-first so its account sees the traffic (needed to get the
+        # new-sender throttle lifted); Resend absorbs the overflow.
+        email_provider_order=tuple(
+            p.strip() for p in
+            os.environ.get("EMAIL_PROVIDER_ORDER", "mailjet,resend").split(",")
+            if p.strip()),
         token_secret_primary=_req("TOKEN_SECRET_PRIMARY"),
         token_secret_previous=os.environ.get("TOKEN_SECRET_PREVIOUS", ""),
         admin_token=_req("ADMIN_TOKEN"),

--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,9 @@ class Config:
     mailjet_from_name: str
     mailjet_daily_quota: int
     resend_api_key: str
+    resend_daily_quota: int
+    mailjet_hourly_quota: int
+    quota_alert_threshold_pct: int
     token_secret_primary: str
     token_secret_previous: str
     admin_token: str
@@ -48,6 +51,12 @@ def load_config() -> Config:
         mailjet_from_name=_req("MAILJET_FROM_NAME"),
         mailjet_daily_quota=_req_int("MAILJET_DAILY_QUOTA"),
         resend_api_key=os.environ.get("RESEND_API_KEY", ""),
+        # Free-tier send caps used for quota-aware delivery + alerting. Defaults
+        # match Resend's free tier (100/day) and the current Mailjet allowance
+        # (10/hour). Raise these after upgrading to a paid plan.
+        resend_daily_quota=int(os.environ.get("RESEND_DAILY_QUOTA", "100")),
+        mailjet_hourly_quota=int(os.environ.get("MAILJET_HOURLY_QUOTA", "10")),
+        quota_alert_threshold_pct=int(os.environ.get("QUOTA_ALERT_THRESHOLD_PCT", "80")),
         token_secret_primary=_req("TOKEN_SECRET_PRIMARY"),
         token_secret_previous=os.environ.get("TOKEN_SECRET_PREVIOUS", ""),
         admin_token=_req("ADMIN_TOKEN"),

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -5,14 +5,13 @@ from datetime import datetime, timedelta
 import requests
 from app.filters import matches
 from app.planning import build_plans
-from app.repo import (active_subscriptions, has_seen_slot, record_seen_slot,
-                       set_last_notified)
+from app.repo import active_subscriptions, has_seen_slot
 from app.scrapers import get_scraper
 from app.http_session import CountingSession
 from app.models import Subscription, Slot, PollPlan
 
 # Imported here so tests can monkey-patch it.
-from app.digest import send_digest  # noqa: E402
+from app.digest import send_digest, flush_digests  # noqa: E402
 
 def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
               rate_limit_minutes: int, cycle_id: str,
@@ -96,7 +95,12 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
             )
     now = datetime.utcnow()
     rate_cutoff = now - timedelta(minutes=rate_limit_minutes)
-    for sub in subs:
+    # Fairness: serve longest-waiting subscribers first (never-notified, then
+    # oldest last_notified_at). When a burst exceeds the daily send quota, the
+    # deferred tail is whoever was most recently served — so nobody is
+    # permanently starved across cycles. datetime.min sorts NULLs to the front.
+    outbox: list = []
+    for sub in sorted(subs, key=lambda s: s.last_notified_at or datetime.min):
         if sub.last_notified_at and sub.last_notified_at > rate_cutoff:
             continue
         # Gather candidate slots from any plan that covers this subscription's filter.
@@ -122,10 +126,6 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
                 candidates.append(slot)
         if not candidates:
             continue
-        # Send and record atomically. Mailjet idempotency prevents double
-        # sends across retries; this transaction ensures that IF the email
-        # was sent, the seen_slots + last_notified_at writes are visible
-        # together — preventing a crash from re-presenting the same slots.
         # Cache each slot's city + upstream URL so /go/<token> works for
         # any city without hardcoding Leipzig. The scrapers know their
         # own upstream URL format; ask them via the catalog.
@@ -144,12 +144,12 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
                 "VALUES (?, ?, ?) ON CONFLICT (slot_token) DO NOTHING",
                 (slot_token, sub.city, upstream),
             )
+        # Stage for batched delivery. seen_slots + last_notified are recorded
+        # inside flush_digests, but only for digests that were actually sent —
+        # quota-deferred ones stay unrecorded so a later cycle re-sends them.
         send_digest(conn=conn, subscription=sub, matched_slots=candidates,
-                    cycle_id=cycle_id, cfg=cfg)
-        with transaction(conn):
-            for slot in candidates:
-                record_seen_slot(conn, sub.id, slot.hash())
-            set_last_notified(conn, sub.id)
+                    cycle_id=cycle_id, cfg=cfg, sink=outbox)
+    flush_digests(conn, outbox, cfg)
 
 def _build_upstream_url(scfg: dict, slot) -> str:
     """Vendor-specific upstream booking URL composition.

--- a/app/digest.py
+++ b/app/digest.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 import sqlite3
+from dataclasses import dataclass
 from datetime import datetime
 from app.i18n import t
 from app.models import Subscription, Slot
-from app.mail import send, _idem_key
+from app.mail import (send, send_batch, maybe_quota_alert, Outgoing,
+                      _idem_key)
 
 # Weekday abbreviations for the date line (i18n.t is string-only, so the
 # per-language lists live here rather than in the JSON bundles). Index 0 = Mon.
@@ -87,11 +89,24 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
     lines.append(t(lang, "digest.kofi", kofi_url=kofi_url))
     return "\n".join(lines)
 
+@dataclass
+class QueuedDigest:
+    """A rendered digest staged for batched delivery. Carries the subscription
+    and slots so the flush can record seen_slots only for what was delivered."""
+    item: Outgoing
+    subscription: Subscription
+    slots: list[Slot]
+
 def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
-                matched_slots: list[Slot], cycle_id: str, cfg) -> None:
-    """Send a digest. `cfg` is the loaded Config (passed in by callers
-    that already have it loaded — never re-read from os.environ here).
-    render_digest_text loads the per-city catalog itself for label lookups."""
+                matched_slots: list[Slot], cycle_id: str, cfg,
+                sink: list | None = None) -> None:
+    """Render a digest and stage it for delivery. `cfg` is the loaded Config
+    (passed in by callers that already have it loaded — never re-read from
+    os.environ here). render_digest_text loads the per-city catalog itself.
+
+    With a `sink` list (the normal cycle path), the rendered digest is appended
+    for batched delivery via `flush_digests`. Without one, it is delivered
+    immediately (used for one-off sends outside a poll cycle)."""
     from app.tokens import sign
     unsub_token = sign(subscription.id, "unsubscribe",
                        primary=cfg.token_secret_primary,
@@ -105,4 +120,30 @@ def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
     key = _idem_key(subscription.id,
                     [s.hash() for s in matched_slots],
                     cycle_id)
-    send(conn, subscription.email, subj, body, idem_key=key)
+    queued = QueuedDigest(
+        item=Outgoing(to=subscription.email, subject=subj, body=body, idem_key=key),
+        subscription=subscription,
+        slots=list(matched_slots),
+    )
+    if sink is None:
+        flush_digests(conn, [queued], cfg)
+    else:
+        sink.append(queued)
+
+def flush_digests(conn: sqlite3.Connection, sink: list, cfg) -> None:
+    """Deliver every staged digest in `sink` via quota-aware batches, then
+    record seen_slots + last_notified for the ones that were actually sent.
+    Deferred digests are left unrecorded so the next cycle re-sends them."""
+    if not sink:
+        return
+    from app.db import transaction
+    from app.repo import record_seen_slot, set_last_notified
+    result = send_batch(conn, [q.item for q in sink], cfg)
+    for q in sink:
+        if q.item.idem_key not in result.delivered:
+            continue
+        with transaction(conn):
+            for slot in q.slots:
+                record_seen_slot(conn, q.subscription.id, slot.hash())
+            set_last_notified(conn, q.subscription.id)
+    maybe_quota_alert(conn, cfg, deferred=result.deferred)

--- a/app/mail.py
+++ b/app/mail.py
@@ -165,17 +165,28 @@ def _window_used(conn: sqlite3.Connection, provider: str, window_seconds: int) -
 def _providers(cfg) -> list[tuple]:
     """Ordered (name, send_fn, batch_size, [(limit, window_seconds), ...]).
 
-    Resend first: it accepts up to 100 in one call, so it absorbs a burst best.
-    Mailjet second, throttled to its hourly allowance. Its usage already
-    includes transactional confirmation emails sent via `send()`, since those
-    are recorded under provider='mailjet'.
+    Order follows cfg.email_provider_order (default Mailjet-first, so Mailjet's
+    account sees the notification traffic — the prerequisite for getting its
+    new-sender throttle lifted; Resend absorbs whatever exceeds Mailjet's
+    hourly allowance). Resend is skipped when no API key is configured. Each
+    provider's window usage already includes transactional emails sent via
+    `send()`, since those are recorded under the same provider name.
     """
+    available = {
+        "mailjet": ("mailjet", _call_mailjet_batch, 50,
+                    [(cfg.mailjet_hourly_quota, 3600)]),
+        "resend": ("resend", _call_resend_batch, 100,
+                   [(cfg.resend_daily_quota, 86400)]),
+    }
+    order = getattr(cfg, "email_provider_order", ("mailjet", "resend"))
     specs: list[tuple] = []
-    if os.environ.get("RESEND_API_KEY"):
-        specs.append(("resend", _call_resend_batch, 100,
-                      [(cfg.resend_daily_quota, 86400)]))
-    specs.append(("mailjet", _call_mailjet_batch, 50,
-                  [(cfg.mailjet_hourly_quota, 3600)]))
+    for name in order:
+        spec = available.get(name)
+        if spec is None:
+            continue
+        if name == "resend" and not os.environ.get("RESEND_API_KEY"):
+            continue
+        specs.append(spec)
     return specs
 
 def _headroom(conn: sqlite3.Connection, limits: list[tuple], provider: str) -> int:

--- a/app/mail.py
+++ b/app/mail.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 import hashlib
 import os
 import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 from typing import Any
 import requests
 
@@ -12,7 +14,8 @@ def _idem_key(subscription_id: int, slot_hashes: list[str], cycle_id: str) -> st
     payload = f"{subscription_id}|{','.join(sorted(slot_hashes))}|{cycle_id}"
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-def _call_mailjet(to: str, subject: str, body: str) -> Any:
+def _mailjet_message(to: str, subject: str, body: str) -> dict:
+    """One entry of Mailjet's v3.1 `Messages` array (shared by single + batch)."""
     message = {
         "From": {"Email": os.environ["MAILJET_FROM_EMAIL"],
                  "Name":  os.environ["MAILJET_FROM_NAME"]},
@@ -30,14 +33,10 @@ def _call_mailjet(to: str, subject: str, body: str) -> Any:
     reply_to = os.environ.get("REPLY_TO_EMAIL")
     if reply_to:
         message["ReplyTo"] = {"Email": reply_to}
-    return requests.post(
-        "https://api.mailjet.com/v3.1/send",
-        auth=(os.environ["MAILJET_API_KEY"], os.environ["MAILJET_API_SECRET"]),
-        json={"Messages": [message]},
-        timeout=30,
-    )
+    return message
 
-def _call_resend(to: str, subject: str, body: str) -> Any:
+def _resend_email(to: str, subject: str, body: str) -> dict:
+    """One Resend email object (shared by single `/emails` + `/emails/batch`)."""
     payload = {
         "from": f"{os.environ['MAILJET_FROM_NAME']} <{os.environ['MAILJET_FROM_EMAIL']}>",
         "to": [to],
@@ -51,10 +50,21 @@ def _call_resend(to: str, subject: str, body: str) -> Any:
     reply_to = os.environ.get("REPLY_TO_EMAIL")
     if reply_to:
         payload["reply_to"] = reply_to
+    return payload
+
+def _call_mailjet(to: str, subject: str, body: str) -> Any:
+    return requests.post(
+        "https://api.mailjet.com/v3.1/send",
+        auth=(os.environ["MAILJET_API_KEY"], os.environ["MAILJET_API_SECRET"]),
+        json={"Messages": [_mailjet_message(to, subject, body)]},
+        timeout=30,
+    )
+
+def _call_resend(to: str, subject: str, body: str) -> Any:
     return requests.post(
         "https://api.resend.com/emails",
         headers={"Authorization": f"Bearer {os.environ['RESEND_API_KEY']}"},
-        json=payload,
+        json=_resend_email(to, subject, body),
         timeout=30,
     )
 
@@ -97,4 +107,180 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
     conn.execute(
         "UPDATE sent_idempotency SET provider=? WHERE idem_key=?",
         (provider, idem_key),
+    )
+
+
+# --------------------------------------------------------------------------
+# Batched, quota-aware delivery (notification digests).
+#
+# Free-tier providers cap total sends (Resend ~100/day, Mailjet ~10/hour), so
+# a notification burst must (a) be sent in as few HTTP calls as possible and
+# (b) stop before a provider's cap to avoid account blocks. `send_batch` packs
+# recipients into provider batch calls, sends only within each provider's
+# remaining rolling-window quota, and DEFERS the rest (releasing their
+# idempotency claims so a later cycle retries them).
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Outgoing:
+    to: str
+    subject: str
+    body: str
+    idem_key: str
+
+@dataclass
+class BatchResult:
+    delivered: set[str] = field(default_factory=set)  # idem_keys actually sent
+    deferred: int = 0                                  # left for a later cycle
+    sent_by_provider: dict[str, int] = field(default_factory=dict)
+
+def _call_mailjet_batch(items: list[Outgoing]) -> bool:
+    resp = requests.post(
+        "https://api.mailjet.com/v3.1/send",
+        auth=(os.environ["MAILJET_API_KEY"], os.environ["MAILJET_API_SECRET"]),
+        json={"Messages": [_mailjet_message(i.to, i.subject, i.body) for i in items]},
+        timeout=60,
+    )
+    return resp.status_code < 400
+
+def _call_resend_batch(items: list[Outgoing]) -> bool:
+    resp = requests.post(
+        "https://api.resend.com/emails/batch",
+        headers={"Authorization": f"Bearer {os.environ['RESEND_API_KEY']}"},
+        json=[_resend_email(i.to, i.subject, i.body) for i in items],
+        timeout=60,
+    )
+    return resp.status_code < 400
+
+def _window_used(conn: sqlite3.Connection, provider: str, window_seconds: int) -> int:
+    """Count emails a provider actually sent within the last `window_seconds`.
+    Reads sent_idempotency (14-day retention covers our day/hour windows)."""
+    row = conn.execute(
+        "SELECT COUNT(*) AS n FROM sent_idempotency "
+        "WHERE provider = ? AND sent_at > datetime('now', ?)",
+        (provider, f"-{window_seconds} seconds"),
+    ).fetchone()
+    return row["n"] if row else 0
+
+def _providers(cfg) -> list[tuple]:
+    """Ordered (name, send_fn, batch_size, [(limit, window_seconds), ...]).
+
+    Resend first: it accepts up to 100 in one call, so it absorbs a burst best.
+    Mailjet second, throttled to its hourly allowance. Its usage already
+    includes transactional confirmation emails sent via `send()`, since those
+    are recorded under provider='mailjet'.
+    """
+    specs: list[tuple] = []
+    if os.environ.get("RESEND_API_KEY"):
+        specs.append(("resend", _call_resend_batch, 100,
+                      [(cfg.resend_daily_quota, 86400)]))
+    specs.append(("mailjet", _call_mailjet_batch, 50,
+                  [(cfg.mailjet_hourly_quota, 3600)]))
+    return specs
+
+def _headroom(conn: sqlite3.Connection, limits: list[tuple], provider: str) -> int:
+    room = None
+    for limit, window in limits:
+        avail = limit - _window_used(conn, provider, window)
+        room = avail if room is None else min(room, avail)
+    return max(0, room if room is not None else 0)
+
+def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchResult:
+    """Send `items` within provider quotas, batched. Returns what was delivered.
+
+    Claims each idempotency row first (INSERT OR IGNORE); already-claimed keys
+    are skipped as already-sent. Newly-claimed items are packed into provider
+    batch calls up to each provider's remaining rolling-window quota. A chunk
+    that fails at the HTTP level has its claims released and falls through to
+    the next provider. Anything past the combined quota is deferred: its claim
+    is released so a later cycle re-sends it (fresh cycle_id ⇒ fresh idem_key).
+    """
+    result = BatchResult()
+    pending: list[Outgoing] = []
+    for it in items:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO sent_idempotency (idem_key, provider) "
+            "VALUES (?, 'pending')",
+            (it.idem_key,),
+        )
+        if cur.rowcount == 1:
+            pending.append(it)
+        # rowcount 0 → already sent/claimed by an earlier cycle: skip silently.
+
+    remaining = list(pending)
+    for name, send_fn, batch_size, limits in _providers(cfg):
+        if not remaining:
+            break
+        room = _headroom(conn, limits, name)
+        while remaining and room > 0:
+            take = min(batch_size, room, len(remaining))
+            chunk = remaining[:take]
+            try:
+                ok = send_fn(chunk)
+            except Exception:
+                ok = False
+            if not ok:
+                # Provider errored: stop using it and leave these items claimed
+                # (still 'pending') so the next provider can send them. If every
+                # provider fails, the trailing deferral block releases them.
+                break
+            conn.executemany(
+                "UPDATE sent_idempotency SET provider=?, sent_at=CURRENT_TIMESTAMP "
+                "WHERE idem_key=?",
+                [(name, c.idem_key) for c in chunk],
+            )
+            for c in chunk:
+                result.delivered.add(c.idem_key)
+            result.sent_by_provider[name] = result.sent_by_provider.get(name, 0) + take
+            remaining = remaining[take:]
+            room -= take
+
+    if remaining:
+        # Over quota (or every provider failed): defer. Release the claims so
+        # the next cycle can retry — do NOT mark seen; the caller must skip
+        # recording seen_slots for these so they resurface.
+        conn.executemany("DELETE FROM sent_idempotency WHERE idem_key=?",
+                         [(c.idem_key,) for c in remaining])
+        result.deferred = len(remaining)
+    return result
+
+def maybe_quota_alert(conn: sqlite3.Connection, cfg, *, deferred: int) -> None:
+    """Email the developer when daily send volume nears the free-tier cap, or
+    when notifications had to be deferred for lack of quota. Rate-limited to
+    once per 24h via meta. This is the signal to upgrade to a paid plan."""
+    used = _window_used(conn, "resend", 86400)
+    threshold = cfg.resend_daily_quota * cfg.quota_alert_threshold_pct / 100
+    if deferred == 0 and used < threshold:
+        return
+    if not cfg.developer_email:
+        return
+    row = conn.execute(
+        "SELECT value FROM meta WHERE key='last_quota_alert_at'"
+    ).fetchone()
+    if row:
+        try:
+            if datetime.utcnow() - datetime.fromisoformat(row["value"]) < timedelta(hours=24):
+                return
+        except ValueError:
+            pass
+    pct = round(used / cfg.resend_daily_quota * 100) if cfg.resend_daily_quota else 0
+    subject = "[termine-notifier] email quota running low"
+    body = (
+        f"Resend usage in the last 24h: {used}/{cfg.resend_daily_quota} ({pct}%).\n"
+        f"Notifications deferred this cycle for lack of quota: {deferred}.\n\n"
+        "Subscribers may be going un-notified. Consider upgrading to a paid "
+        "email plan (e.g. Resend Pro) and raising RESEND_DAILY_QUOTA / "
+        "MAILJET_HOURLY_QUOTA accordingly."
+    )
+    try:
+        send(conn, cfg.developer_email, subject, body,
+             idem_key=_idem_key(0, [], f"quota-alert-{datetime.utcnow().date()}"))
+    except Exception:
+        # Alerting must never break a delivery cycle.
+        return
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES ('last_quota_alert_at', ?) "
+        "ON CONFLICT (key) DO UPDATE SET value=excluded.value, "
+        "updated_at=CURRENT_TIMESTAMP",
+        (datetime.utcnow().isoformat(),),
     )

--- a/app/mail.py
+++ b/app/mail.py
@@ -172,9 +172,13 @@ def _providers(cfg) -> list[tuple]:
     provider's window usage already includes transactional emails sent via
     `send()`, since those are recorded under the same provider name.
     """
+    # Mailjet is bounded by BOTH its hourly cap (the new-sender warm-up
+    # throttle) and its daily cap (free tier = 200/day); _headroom takes the
+    # tighter of the two. Resend's free tier is a flat daily cap.
     available = {
         "mailjet": ("mailjet", _call_mailjet_batch, 50,
-                    [(cfg.mailjet_hourly_quota, 3600)]),
+                    [(cfg.mailjet_hourly_quota, 3600),
+                     (cfg.mailjet_daily_quota, 86400)]),
         "resend": ("resend", _call_resend_batch, 100,
                    [(cfg.resend_daily_quota, 86400)]),
     }

--- a/tests/test_delivery_quota.py
+++ b/tests/test_delivery_quota.py
@@ -1,0 +1,74 @@
+from datetime import time
+from unittest.mock import patch, MagicMock
+import pytest
+from app.db import connect, init_schema
+from app.models import Filter, Slot
+from app.repo import insert_pending, confirm
+from app.cycle import run_cycle
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    for k, v in {
+        "MAILJET_API_KEY": "m", "MAILJET_API_SECRET": "m", "MAILJET_FROM_EMAIL": "x@x",
+        "MAILJET_FROM_NAME": "x", "MAILJET_DAILY_QUOTA": "6000", "RESEND_API_KEY": "r",
+        "TOKEN_SECRET_PRIMARY": "x" * 32, "TOKEN_SECRET_PREVIOUS": "",
+        "ADMIN_TOKEN": "a" * 32, "PUBLIC_BASE_URL": "https://x",
+        "DEDUP_WINDOW_HOURS": "24", "RATE_LIMIT_MINUTES": "15",
+        "SUBSCRIPTION_TTL_DAYS": "90", "RENEWAL_REMINDER_DAYS_BEFORE": "10",
+        "MAX_PLANS_PER_CITY": "10", "PARSER_CANARY_THRESHOLD_HOURS": "2",
+        "SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR": "99",
+        "SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY": "99",
+        "DEVELOPER_EMAIL": "dev@x", "KOFI_URL": "https://k",
+        # Only one email may go out per cycle; Mailjet disabled for the test.
+        "RESEND_DAILY_QUOTA": "1", "MAILJET_HOURLY_QUOTA": "0",
+    }.items():
+        monkeypatch.setenv(k, v)
+    conn = connect(str(tmp_path / "t.db"))
+    init_schema(conn)
+    return conn
+
+
+def _f():
+    return Filter(appointment_types=["svc-A"], locations="all",
+                  weekdays=[1, 2, 3, 4, 5, 6, 7],
+                  time_window_start=time(0, 0), time_window_end=time(23, 59))
+
+
+def _last_notified(conn, sid):
+    return conn.execute("SELECT last_notified_at FROM subscriptions WHERE id=?",
+                        (sid,)).fetchone()["last_notified_at"]
+
+
+def _has_seen(conn, sid):
+    return conn.execute("SELECT COUNT(*) AS n FROM seen_slots WHERE subscription_id=?",
+                        (sid,)).fetchone()["n"] > 0
+
+
+def test_quota_limited_cycle_serves_longest_waiting_first_and_defers_rest(db):
+    """With room for one send this cycle, the longest-waiting subscriber (never
+    notified) is served ahead of a recently-notified one, and the deferred
+    subscriber keeps no seen_slots row so it resurfaces next cycle — no
+    permanent starvation, no lost state."""
+    # s_recent was notified 20 min ago (outside the 15-min rate limit, so
+    # eligible again); s_new has never been notified.
+    s_recent = insert_pending(db, email="a@x.com", city="leipzig", language="de",
+                              filter_=_f(), ttl_days=90); confirm(db, s_recent)
+    s_new = insert_pending(db, email="b@x.com", city="leipzig", language="de",
+                           filter_=_f(), ttl_days=90); confirm(db, s_new)
+    db.execute("UPDATE subscriptions SET last_notified_at=datetime('now','-20 minutes') "
+               "WHERE id=?", (s_recent,))
+    slot = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "tok")]
+
+    scraper = MagicMock(); scraper.poll.return_value = slot
+    with patch("app.cycle.get_scraper", return_value=scraper), \
+         patch("app.mail._call_resend_batch", return_value=True) as rb:
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+
+    # Exactly one email this cycle (quota = 1)...
+    assert rb.call_count == 1
+    assert len(rb.call_args_list[0].args[0]) == 1
+    # ...and it went to the never-notified subscriber, not the recently-served one.
+    assert _has_seen(db, s_new) and not _has_seen(db, s_recent)
+    # The deferred subscriber was left untouched → it will resurface next cycle.
+    assert _last_notified(db, s_recent) is not None  # unchanged (its old value)

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -34,6 +34,15 @@ def test_full_flow(env):
     def fake_send(conn, to, subject, body, *, idem_key):
         sent_mails.append((to, subject))
 
+    # Digests are delivered via the batched path (app.digest.send_batch), so
+    # capture that too and report everything delivered.
+    from app.mail import BatchResult
+
+    def fake_send_batch(conn, items, cfg):
+        for it in items:
+            sent_mails.append((it.to, it.subject))
+        return BatchResult(delivered={it.idem_key for it in items})
+
     # 1. subscribe (mock mail)
     # Patch every binding site of app.mail.send since the symbol is imported by name
     # into app.web (as mail_send) and app.digest (as send), bypassing patching of
@@ -45,6 +54,7 @@ def test_full_flow(env):
         stack = ExitStack()
         for tgt in mail_patch_targets:
             stack.enter_context(patch(tgt, side_effect=fake_send))
+        stack.enter_context(patch("app.digest.send_batch", side_effect=fake_send_batch))
         return stack
 
     with _patch_mail():

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -21,9 +21,10 @@ def resend_on(monkeypatch):
         monkeypatch.setenv(k, v)
 
 
-def _cfg(**over):
+def _cfg(order=("mailjet", "resend"), **over):
     base = dict(resend_daily_quota=100, mailjet_hourly_quota=10,
-                quota_alert_threshold_pct=80, developer_email="dev@x")
+                quota_alert_threshold_pct=80, developer_email="dev@x",
+                email_provider_order=order)
     base.update(over)
     return SimpleNamespace(**base)
 
@@ -39,20 +40,58 @@ def _sent(conn, provider):
         (provider,)).fetchone()["n"]
 
 
+_RESEND_FIRST = ("resend", "mailjet")
+
+
 def test_delivers_all_within_quota_via_resend(db, resend_on):
     with patch("app.mail._call_resend_batch", return_value=True) as rb, \
          patch("app.mail._call_mailjet_batch") as mb:
-        res = send_batch(db, _items(3), _cfg())
+        res = send_batch(db, _items(3), _cfg(order=_RESEND_FIRST))
     assert len(res.delivered) == 3 and res.deferred == 0
     rb.assert_called_once()          # one batch call, not three
     mb.assert_not_called()
     assert _sent(db, "resend") == 3
 
 
+def test_default_order_sends_via_mailjet_first(db, resend_on):
+    # Production default is Mailjet-first: within its hourly quota, digests go
+    # through Mailjet and Resend is not touched.
+    with patch("app.mail._call_mailjet_batch", return_value=True) as mb, \
+         patch("app.mail._call_resend_batch") as rb:
+        res = send_batch(db, _items(4), _cfg())   # default order = mailjet,resend
+    assert len(res.delivered) == 4 and res.deferred == 0
+    mb.assert_called_once()
+    rb.assert_not_called()
+    assert _sent(db, "mailjet") == 4
+
+
+def test_order_is_configurable(db, resend_on):
+    # Flipping the order routes the same batch to the other provider.
+    with patch("app.mail._call_mailjet_batch") as mb, \
+         patch("app.mail._call_resend_batch", return_value=True) as rb:
+        send_batch(db, _items(2), _cfg(order=("resend", "mailjet")))
+    rb.assert_called_once()
+    mb.assert_not_called()
+
+
+def test_mailjet_overflow_spills_to_resend(db, resend_on):
+    # Mailjet-first with only 2/hour of headroom: 2 go via Mailjet, the rest
+    # spill to Resend — this is the warm-up-period behaviour.
+    with patch("app.mail._call_mailjet_batch", return_value=True) as mb, \
+         patch("app.mail._call_resend_batch", return_value=True) as rb:
+        res = send_batch(db, _items(5), _cfg(mailjet_hourly_quota=2,
+                                             resend_daily_quota=100))
+    assert len(res.delivered) == 5 and res.deferred == 0
+    assert _sent(db, "mailjet") == 2 and _sent(db, "resend") == 3
+    mb.assert_called_once()
+    rb.assert_called_once()
+
+
 def test_chunks_into_batches_of_100(db, resend_on):
     with patch("app.mail._call_resend_batch", return_value=True) as rb, \
          patch("app.mail._call_mailjet_batch"):
-        res = send_batch(db, _items(150), _cfg(resend_daily_quota=1000))
+        res = send_batch(db, _items(150),
+                         _cfg(order=_RESEND_FIRST, resend_daily_quota=1000))
     assert len(res.delivered) == 150 and res.deferred == 0
     assert rb.call_count == 2        # 100 + 50
     assert len(rb.call_args_list[0].args[0]) == 100
@@ -63,7 +102,8 @@ def test_defers_overflow_past_quota(db, resend_on):
     # Resend capped at 2, Mailjet disabled → 2 sent, 3 deferred.
     with patch("app.mail._call_resend_batch", return_value=True), \
          patch("app.mail._call_mailjet_batch") as mb:
-        res = send_batch(db, _items(5), _cfg(resend_daily_quota=2,
+        res = send_batch(db, _items(5), _cfg(order=_RESEND_FIRST,
+                                             resend_daily_quota=2,
                                              mailjet_hourly_quota=0))
     assert len(res.delivered) == 2 and res.deferred == 3
     mb.assert_not_called()
@@ -75,7 +115,7 @@ def test_defers_overflow_past_quota(db, resend_on):
 def test_falls_over_to_mailjet_when_resend_errors(db, resend_on):
     with patch("app.mail._call_resend_batch", return_value=False) as rb, \
          patch("app.mail._call_mailjet_batch", return_value=True) as mb:
-        res = send_batch(db, _items(4), _cfg())
+        res = send_batch(db, _items(4), _cfg(order=_RESEND_FIRST))
     assert len(res.delivered) == 4 and res.deferred == 0
     rb.assert_called_once()
     mb.assert_called_once()
@@ -89,17 +129,20 @@ def test_existing_usage_counts_against_quota(db, resend_on):
         [(f"old{i}",) for i in range(9)])
     with patch("app.mail._call_resend_batch", return_value=True), \
          patch("app.mail._call_mailjet_batch", return_value=True):
-        res = send_batch(db, _items(5), _cfg(resend_daily_quota=10,
+        res = send_batch(db, _items(5), _cfg(order=_RESEND_FIRST,
+                                             resend_daily_quota=10,
                                              mailjet_hourly_quota=0))
     assert len(res.delivered) == 1 and res.deferred == 4   # only 1 resend slot left
 
 
 def test_already_sent_idem_key_is_skipped(db, resend_on):
     db.execute("INSERT INTO sent_idempotency (idem_key, provider) VALUES ('k0','resend')")
-    with patch("app.mail._call_resend_batch", return_value=True) as rb:
+    with patch("app.mail._call_resend_batch", return_value=True) as rb, \
+         patch("app.mail._call_mailjet_batch", return_value=True) as mb:
         res = send_batch(db, _items(1), _cfg())   # idem_key 'k0' already sent
     assert res.delivered == set() and res.deferred == 0
     rb.assert_not_called()
+    mb.assert_not_called()
 
 
 def test_quota_alert_fires_on_deferral_and_is_rate_limited(db):

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+import pytest
+from app.db import connect, init_schema
+from app.mail import send_batch, maybe_quota_alert, Outgoing
+
+
+@pytest.fixture
+def db(tmp_path):
+    conn = connect(str(tmp_path / "t.db"))
+    init_schema(conn)
+    return conn
+
+
+@pytest.fixture
+def resend_on(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    # Mailjet creds are read by the batch call even when mocked out.
+    for k, v in {"MAILJET_API_KEY": "m", "MAILJET_API_SECRET": "s",
+                 "MAILJET_FROM_EMAIL": "x@x", "MAILJET_FROM_NAME": "x"}.items():
+        monkeypatch.setenv(k, v)
+
+
+def _cfg(**over):
+    base = dict(resend_daily_quota=100, mailjet_hourly_quota=10,
+                quota_alert_threshold_pct=80, developer_email="dev@x")
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _items(n, prefix="k"):
+    return [Outgoing(to=f"u{i}@x.com", subject="s", body="b",
+                     idem_key=f"{prefix}{i}") for i in range(n)]
+
+
+def _sent(conn, provider):
+    return conn.execute(
+        "SELECT COUNT(*) AS n FROM sent_idempotency WHERE provider=?",
+        (provider,)).fetchone()["n"]
+
+
+def test_delivers_all_within_quota_via_resend(db, resend_on):
+    with patch("app.mail._call_resend_batch", return_value=True) as rb, \
+         patch("app.mail._call_mailjet_batch") as mb:
+        res = send_batch(db, _items(3), _cfg())
+    assert len(res.delivered) == 3 and res.deferred == 0
+    rb.assert_called_once()          # one batch call, not three
+    mb.assert_not_called()
+    assert _sent(db, "resend") == 3
+
+
+def test_chunks_into_batches_of_100(db, resend_on):
+    with patch("app.mail._call_resend_batch", return_value=True) as rb, \
+         patch("app.mail._call_mailjet_batch"):
+        res = send_batch(db, _items(150), _cfg(resend_daily_quota=1000))
+    assert len(res.delivered) == 150 and res.deferred == 0
+    assert rb.call_count == 2        # 100 + 50
+    assert len(rb.call_args_list[0].args[0]) == 100
+    assert len(rb.call_args_list[1].args[0]) == 50
+
+
+def test_defers_overflow_past_quota(db, resend_on):
+    # Resend capped at 2, Mailjet disabled → 2 sent, 3 deferred.
+    with patch("app.mail._call_resend_batch", return_value=True), \
+         patch("app.mail._call_mailjet_batch") as mb:
+        res = send_batch(db, _items(5), _cfg(resend_daily_quota=2,
+                                             mailjet_hourly_quota=0))
+    assert len(res.delivered) == 2 and res.deferred == 3
+    mb.assert_not_called()
+    assert _sent(db, "resend") == 2
+    # Deferred claims must be released so a later cycle retries them.
+    assert db.execute("SELECT COUNT(*) AS n FROM sent_idempotency").fetchone()["n"] == 2
+
+
+def test_falls_over_to_mailjet_when_resend_errors(db, resend_on):
+    with patch("app.mail._call_resend_batch", return_value=False) as rb, \
+         patch("app.mail._call_mailjet_batch", return_value=True) as mb:
+        res = send_batch(db, _items(4), _cfg())
+    assert len(res.delivered) == 4 and res.deferred == 0
+    rb.assert_called_once()
+    mb.assert_called_once()
+    assert _sent(db, "mailjet") == 4 and _sent(db, "resend") == 0
+
+
+def test_existing_usage_counts_against_quota(db, resend_on):
+    # Pre-existing resend sends in the last 24h eat into the daily quota.
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'resend')",
+        [(f"old{i}",) for i in range(9)])
+    with patch("app.mail._call_resend_batch", return_value=True), \
+         patch("app.mail._call_mailjet_batch", return_value=True):
+        res = send_batch(db, _items(5), _cfg(resend_daily_quota=10,
+                                             mailjet_hourly_quota=0))
+    assert len(res.delivered) == 1 and res.deferred == 4   # only 1 resend slot left
+
+
+def test_already_sent_idem_key_is_skipped(db, resend_on):
+    db.execute("INSERT INTO sent_idempotency (idem_key, provider) VALUES ('k0','resend')")
+    with patch("app.mail._call_resend_batch", return_value=True) as rb:
+        res = send_batch(db, _items(1), _cfg())   # idem_key 'k0' already sent
+    assert res.delivered == set() and res.deferred == 0
+    rb.assert_not_called()
+
+
+def test_quota_alert_fires_on_deferral_and_is_rate_limited(db):
+    cfg = _cfg()
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, cfg, deferred=5)
+        maybe_quota_alert(db, cfg, deferred=5)   # within 24h → suppressed
+    snd.assert_called_once()
+    assert db.execute(
+        "SELECT COUNT(*) AS n FROM meta WHERE key='last_quota_alert_at'"
+    ).fetchone()["n"] == 1
+
+
+def test_quota_alert_fires_near_threshold(db):
+    # 8/10 resend sends today = 80% → at threshold, alert even with no deferral.
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'resend')",
+        [(f"r{i}",) for i in range(8)])
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(resend_daily_quota=10), deferred=0)
+    snd.assert_called_once()
+
+
+def test_quota_alert_silent_when_healthy(db):
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(resend_daily_quota=100), deferred=0)
+    snd.assert_not_called()

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -23,6 +23,7 @@ def resend_on(monkeypatch):
 
 def _cfg(order=("mailjet", "resend"), **over):
     base = dict(resend_daily_quota=100, mailjet_hourly_quota=10,
+                mailjet_daily_quota=100_000,  # effectively unbounded unless set
                 quota_alert_threshold_pct=80, developer_email="dev@x",
                 email_provider_order=order)
     base.update(over)
@@ -72,6 +73,24 @@ def test_order_is_configurable(db, resend_on):
         send_batch(db, _items(2), _cfg(order=("resend", "mailjet")))
     rb.assert_called_once()
     mb.assert_not_called()
+
+
+def test_mailjet_daily_cap_binds_when_tighter_than_hourly(db, resend_on):
+    # Hourly headroom is generous (50) but the daily cap (200/day free tier) has
+    # only 3 left → Mailjet sends 3, the rest spill to Resend. The 197 prior
+    # sends are dated 2h ago: inside the daily window, outside the hourly one.
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider, sent_at) "
+        "VALUES (?, 'mailjet', datetime('now','-2 hours'))",
+        [(f"mj{i}",) for i in range(197)])
+    with patch("app.mail._call_mailjet_batch", return_value=True) as mb, \
+         patch("app.mail._call_resend_batch", return_value=True) as rb:
+        res = send_batch(db, _items(5), _cfg(mailjet_hourly_quota=50,
+                                             mailjet_daily_quota=200,
+                                             resend_daily_quota=100))
+    assert len(res.delivered) == 5 and res.deferred == 0
+    assert res.sent_by_provider.get("mailjet") == 3    # 200 - 197
+    assert res.sent_by_provider.get("resend") == 2
 
 
 def test_mailjet_overflow_spills_to_resend(db, resend_on):


### PR DESCRIPTION
Set MAX_PLANS_PER_CITY to 15 so every Leipzig appointment type (15 total)
can be watched without ever hitting the wait-list cap, which is keyed on
distinct appointment types rather than subscriber count.

Raise SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR from 5 to 30: many readers
share one public IP behind mobile-carrier CGNAT, so a low per-IP cap
turns away legitimate sign-ups during a spike. Abuse is still bounded by
the per-email daily limit.