### PR TITLE
Keep sign-ups on email-quota exhaustion and retry confirmations

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -7,4 +7,4 @@ COPY catalog/ catalog/
 ENV PYTHONUNBUFFERED=1
 # Application-factory form: gunicorn calls create_app() at startup, so
 # load_config() runs only when the container actually boots — not on import.
-CMD ["gunicorn", "-w", "2", "-b", "0.0.0.0:8000", "app.web:create_app()"]
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "app.web:create_app()"]

--- a/app/confirmations.py
+++ b/app/confirmations.py
@@ -1,0 +1,57 @@
+"""Confirmation-email delivery for pending sign-ups.
+
+Confirmation emails go through the same quota-aware batch path as digests, so
+when the daily email quota is exhausted a sign-up is NOT lost: its pending row
+stays valid and `send_pending_confirmations` re-sends the confirmation on a
+later poll cycle (i.e. the next day once quota resets). `confirmation_sent_at`
+marks a sign-up as done so it isn't re-sent.
+"""
+from __future__ import annotations
+import sqlite3
+from app.mail import send_batch, Outgoing, _idem_key
+from app.repo import set_confirmation_sent, pending_confirmations
+from app.tokens import sign
+
+
+def build_confirmation(sub_id: int, email: str, lang: str, cfg) -> Outgoing:
+    tok = sign(sub_id, "confirm",
+               primary=cfg.token_secret_primary,
+               previous=cfg.token_secret_previous)
+    url = f"{cfg.public_base_url}/confirm/{tok}"
+    if lang == "en":
+        subject, body = "Confirmation needed", f"Please confirm your subscription: {url}"
+    else:
+        subject, body = "Bestätigung benötigt", f"Bitte bestätige dein Abonnement: {url}"
+    # Stable per-subscription key: a deferred send and its later retry share it,
+    # so the idempotency layer never double-sends a confirmation.
+    return Outgoing(to=email, subject=subject, body=body,
+                    idem_key=_idem_key(sub_id, [], f"confirm-{sub_id}"))
+
+
+def send_confirmation_now(conn: sqlite3.Connection, sub_id: int, email: str,
+                          lang: str, cfg) -> bool:
+    """Try to send this sign-up's confirmation immediately. Returns True if it
+    went out, False if it was deferred (quota exhausted) — in which case the
+    pending row stays put and `send_pending_confirmations` retries it later."""
+    item = build_confirmation(sub_id, email, lang, cfg)
+    result = send_batch(conn, [item], cfg)
+    if item.idem_key in result.delivered:
+        set_confirmation_sent(conn, sub_id)
+        return True
+    return False
+
+
+def send_pending_confirmations(conn: sqlite3.Connection, cfg, *,
+                               max_age_days: int = 7) -> None:
+    """Retry confirmation emails for sign-ups that never got one (quota was
+    exhausted when they registered). Called once per poll cycle."""
+    pending = pending_confirmations(conn, max_age_days=max_age_days)
+    if not pending:
+        return
+    items = [build_confirmation(sub_id, email, lang, cfg)
+             for (sub_id, email, lang) in pending]
+    key_to_sub = {item.idem_key: sub_id
+                  for item, (sub_id, _e, _l) in zip(items, pending)}
+    result = send_batch(conn, items, cfg)
+    for idem_key in result.delivered:
+        set_confirmation_sent(conn, key_to_sub[idem_key])

--- a/app/db.py
+++ b/app/db.py
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   reminder_sent_at  TIMESTAMP,
   heartbeat_30d_at  TIMESTAMP,
   heartbeat_60d_at  TIMESTAMP,
-  deleted_at        TIMESTAMP
+  deleted_at        TIMESTAMP,
+  confirmation_sent_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_active_subs
   ON subscriptions(deleted_at, confirmed_at, expires_at, city);
@@ -77,6 +78,11 @@ def connect(db_path: str) -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
+    # Wait up to 5s for a competing writer instead of raising "database is
+    # locked" immediately. The web workers and the poller share this file, so
+    # concurrent writes (a sign-up landing mid-poll-cycle) are expected — WAL
+    # serialises them, and this lets a blocked write queue rather than error.
+    conn.execute("PRAGMA busy_timeout=5000")
     return conn
 
 @contextmanager
@@ -122,6 +128,11 @@ def init_schema(conn: sqlite3.Connection) -> None:
         "polls_total":    "INTEGER NOT NULL DEFAULT 0",
         "requests_total": "INTEGER NOT NULL DEFAULT 0",
         "counts_date":    "TEXT",
+    })
+    # Tracks when a pending sign-up's confirmation email was successfully sent,
+    # so the retry pass can re-send confirmations that were quota-deferred.
+    _add_missing_columns(conn, "subscriptions", {
+        "confirmation_sent_at": "TIMESTAMP",
     })
     conn.execute(
         "INSERT INTO meta (key, value) VALUES ('schema_version', ?) "

--- a/app/mail.py
+++ b/app/mail.py
@@ -210,17 +210,22 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
     the next provider. Anything past the combined quota is deferred: its claim
     is released so a later cycle re-sends it (fresh cycle_id ⇒ fresh idem_key).
     """
+    from app.db import transaction
     result = BatchResult()
     pending: list[Outgoing] = []
-    for it in items:
-        cur = conn.execute(
-            "INSERT OR IGNORE INTO sent_idempotency (idem_key, provider) "
-            "VALUES (?, 'pending')",
-            (it.idem_key,),
-        )
-        if cur.rowcount == 1:
-            pending.append(it)
-        # rowcount 0 → already sent/claimed by an earlier cycle: skip silently.
+    # Claim all idempotency rows in ONE transaction. In autocommit each INSERT
+    # would fsync separately — fatal when a popular slot matches tens of
+    # thousands of subscribers (that many fsyncs would overrun the cycle).
+    with transaction(conn):
+        for it in items:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO sent_idempotency (idem_key, provider) "
+                "VALUES (?, 'pending')",
+                (it.idem_key,),
+            )
+            if cur.rowcount == 1:
+                pending.append(it)
+            # rowcount 0 → already sent/claimed by an earlier cycle: skip.
 
     remaining = list(pending)
     for name, send_fn, batch_size, limits in _providers(cfg):
@@ -239,11 +244,12 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
                 # (still 'pending') so the next provider can send them. If every
                 # provider fails, the trailing deferral block releases them.
                 break
-            conn.executemany(
-                "UPDATE sent_idempotency SET provider=?, sent_at=CURRENT_TIMESTAMP "
-                "WHERE idem_key=?",
-                [(name, c.idem_key) for c in chunk],
-            )
+            with transaction(conn):
+                conn.executemany(
+                    "UPDATE sent_idempotency SET provider=?, sent_at=CURRENT_TIMESTAMP "
+                    "WHERE idem_key=?",
+                    [(name, c.idem_key) for c in chunk],
+                )
             for c in chunk:
                 result.delivered.add(c.idem_key)
             result.sent_by_provider[name] = result.sent_by_provider.get(name, 0) + take
@@ -253,9 +259,11 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
     if remaining:
         # Over quota (or every provider failed): defer. Release the claims so
         # the next cycle can retry — do NOT mark seen; the caller must skip
-        # recording seen_slots for these so they resurface.
-        conn.executemany("DELETE FROM sent_idempotency WHERE idem_key=?",
-                         [(c.idem_key,) for c in remaining])
+        # recording seen_slots for these so they resurface. One transaction so
+        # the release is a single fsync, not one per deferred item.
+        with transaction(conn):
+            conn.executemany("DELETE FROM sent_idempotency WHERE idem_key=?",
+                             [(c.idem_key,) for c in remaining])
         result.deferred = len(remaining)
     return result
 

--- a/app/poller.py
+++ b/app/poller.py
@@ -28,6 +28,10 @@ def main() -> None:
                       cycle_id=cycle_id,
                       cfg=cfg,
                       http=http)
+            # Retry confirmation emails deferred by quota exhaustion. After
+            # run_cycle so time-sensitive slot notifications get quota first.
+            from app.confirmations import send_pending_confirmations
+            send_pending_confirmations(conn, cfg)
             consecutive_failures = 0
         except Exception as exc:
             consecutive_failures += 1

--- a/app/repo.py
+++ b/app/repo.py
@@ -26,6 +26,27 @@ def soft_delete(conn: sqlite3.Connection, sub_id: int) -> None:
         (sub_id,),
     )
 
+def set_confirmation_sent(conn: sqlite3.Connection, sub_id: int) -> None:
+    conn.execute(
+        "UPDATE subscriptions SET confirmation_sent_at=CURRENT_TIMESTAMP WHERE id=?",
+        (sub_id,),
+    )
+
+def pending_confirmations(conn: sqlite3.Connection, *,
+                          max_age_days: int = 7) -> list[tuple[int, str, str]]:
+    """Sign-ups still awaiting a confirmation email: unconfirmed, not deleted,
+    no confirmation delivered yet, created within `max_age_days` (older ones are
+    abandoned rather than retried forever). Oldest first for fair delivery."""
+    rows = conn.execute(
+        "SELECT id, email, language FROM subscriptions "
+        "WHERE confirmed_at IS NULL AND deleted_at IS NULL "
+        "AND confirmation_sent_at IS NULL "
+        "AND created_at > datetime('now', ?) "
+        "ORDER BY created_at",
+        (f"-{max_age_days} days",),
+    ).fetchall()
+    return [(r["id"], r["email"], r["language"]) for r in rows]
+
 def _row_to_subscription(row: sqlite3.Row) -> Subscription:
     from datetime import datetime
     def _p(s): return datetime.fromisoformat(s) if s else None

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -16,6 +16,24 @@
     </div>
   {% endif %}
 
+  {% if confirmed == 'queued' %}
+    <div class="notice notice-success" role="status">
+      {% if lang == 'en' %}
+        <strong>You're registered!</strong> Due to high demand we've hit
+        today's email limit, so your confirmation email will arrive a little
+        later — possibly not until tomorrow. Your sign-up is saved and the
+        email will be sent automatically; there's no need to register again.
+        (Please check your spam folder too.)
+      {% else %}
+        <strong>Du bist registriert!</strong> Wegen hoher Nachfrage ist das
+        heutige E-Mail-Limit erreicht. Deine Bestätigungs-E-Mail kommt daher
+        etwas später — möglicherweise erst morgen. Deine Anmeldung ist
+        gespeichert und die E-Mail wird automatisch verschickt; du musst dich
+        nicht erneut anmelden. (Schau bitte auch im Spam-Ordner nach.)
+      {% endif %}
+    </div>
+  {% endif %}
+
   {% if error == 'mail' %}
     <div class="notice notice-error" role="alert">
       {% if lang == 'en' %}

--- a/app/web.py
+++ b/app/web.py
@@ -125,17 +125,12 @@ def _parse_hhmm(s: str) -> time_cls:
     return time_cls(int(h), int(m))
 
 
-def _send_confirmation_email(conn, sub_id: int, email: str, lang: str, cfg) -> None:
-    tok = sign(sub_id, "confirm",
-               primary=cfg.token_secret_primary,
-               previous=cfg.token_secret_previous)
-    url = f"{cfg.public_base_url}/confirm/{tok}"
-    body_de = f"Bitte bestätige dein Abonnement: {url}"
-    body_en = f"Please confirm your subscription: {url}"
-    body = body_en if lang == "en" else body_de
-    subj = "Bestätigung benötigt" if lang == "de" else "Confirmation needed"
-    key = _idem_key(sub_id, [], f"confirm-{sub_id}")
-    mail_send(conn, email, subj, body, idem_key=key)
+def _send_confirmation_email(conn, sub_id: int, email: str, lang: str, cfg) -> bool:
+    """Try to send the confirmation now. Returns True if delivered, False if
+    deferred (quota exhausted) — the sign-up stays pending and the poller's
+    retry pass sends it later (e.g. next day once quota resets)."""
+    from app.confirmations import send_confirmation_now
+    return send_confirmation_now(conn, sub_id, email, lang, cfg)
 
 
 def _send_manage_link_email(conn, sub_id: int, cfg) -> None:
@@ -284,17 +279,18 @@ def create_app() -> Flask:
             sub_id = insert_pending(conn, email=email, city=city,
                                     language=lang, filter_=f,
                                     ttl_days=cfg.subscription_ttl_days)
-        # The confirmation email is the ONLY way the user can complete signup,
-        # so — unlike the manage-link email in /confirm — we must NOT claim
-        # success if it fails. Surface a retryable error instead of a 500 and
-        # drop the orphaned pending row so it can't linger unconfirmable.
+        # Try to send the confirmation now. If the daily email quota is
+        # exhausted (or the send errors), we KEEP the pending sign-up and the
+        # poller's retry pass sends the confirmation on a later cycle — so the
+        # registration is never lost. Only the message differs: "check your
+        # inbox" vs "it may arrive tomorrow". No soft-delete, no lockout.
         try:
-            _send_confirmation_email(conn, sub_id, email, lang, cfg)
+            delivered = _send_confirmation_email(conn, sub_id, email, lang, cfg)
         except Exception:
-            log.exception("confirmation email failed for sub %s", sub_id)
-            soft_delete(conn, sub_id)
-            return redirect("/?subscribe_error=mail")
-        return redirect("/?confirmed=pending")
+            log.exception("confirmation email errored for sub %s; will retry", sub_id)
+            delivered = False
+        return redirect("/?confirmed=pending" if delivered
+                        else "/?confirmed=queued")
 
     @app.route("/confirm/<token>")
     def confirm_route(token):

--- a/scripts/loadtest.py
+++ b/scripts/loadtest.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Local load test for termine-notifier. Providers are mocked — no network,
+no real emails — so this is safe to run anywhere and must NOT be pointed at
+production. It measures the two things a traffic spike actually stresses:
+
+  A. Concurrent sign-up writes  -> SQLite write contention / lock errors.
+  B. run_cycle() at N subscribers -> matching-loop + delivery time per cycle.
+
+Usage:
+    python scripts/loadtest.py                # default sizes
+    python scripts/loadtest.py --subs 50000   # cycle test at 50k subscribers
+    python scripts/loadtest.py --threads 32 --per-thread 200
+"""
+from __future__ import annotations
+import argparse
+import os
+import tempfile
+import threading
+import time as _time
+from datetime import time as _t
+from unittest.mock import patch, MagicMock
+
+
+def _setenv(db_path: str) -> None:
+    os.environ.update({
+        "DB_PATH": db_path,
+        "TOKEN_SECRET_PRIMARY": "x" * 32, "TOKEN_SECRET_PREVIOUS": "",
+        "ADMIN_TOKEN": "a" * 32, "PUBLIC_BASE_URL": "https://x",
+        "MAILJET_API_KEY": "m", "MAILJET_API_SECRET": "m",
+        "MAILJET_FROM_EMAIL": "x@x", "MAILJET_FROM_NAME": "x",
+        "MAILJET_DAILY_QUOTA": "200", "RESEND_API_KEY": "re",
+        "DEDUP_WINDOW_HOURS": "24", "RATE_LIMIT_MINUTES": "15",
+        "SUBSCRIPTION_TTL_DAYS": "90", "RENEWAL_REMINDER_DAYS_BEFORE": "10",
+        "MAX_PLANS_PER_CITY": "15", "PARSER_CANARY_THRESHOLD_HOURS": "2",
+        "SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR": "99999",
+        "SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY": "99999",
+        "DEVELOPER_EMAIL": "dev@x", "KOFI_URL": "https://k",
+        # Free-tier quotas so the cycle test reflects production: delivery is
+        # quota-bounded and the rest is deferred, exactly as it would be live.
+        "RESEND_DAILY_QUOTA": "100", "MAILJET_HOURLY_QUOTA": "10",
+    })
+
+
+def test_concurrent_signups(db_path, threads, per_thread):
+    from app.db import connect
+    from app.models import Filter
+    from app.repo import insert_pending
+    f = Filter(["svc-A"], "all", [1, 2, 3, 4, 5], _t(0, 0), _t(23, 59))
+    errors, done = [], []
+
+    def worker(wid):
+        conn = connect(db_path)
+        for i in range(per_thread):
+            try:
+                insert_pending(conn, email=f"u{wid}_{i}@x.com", city="leipzig",
+                               language="de", filter_=f, ttl_days=90)
+                done.append(1)
+            except Exception as exc:               # e.g. "database is locked"
+                errors.append(str(exc))
+
+    ts = [threading.Thread(target=worker, args=(w,)) for w in range(threads)]
+    t0 = _time.perf_counter()
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
+    dt = _time.perf_counter() - t0
+    total = threads * per_thread
+    print(f"\n[A] Concurrent sign-ups: {threads} threads x {per_thread} = {total}")
+    print(f"    time       : {dt:.2f}s  ({total/dt:,.0f} inserts/sec)")
+    print(f"    lock errors: {len(errors)}"
+          + (f"  e.g. {errors[0]}" if errors else "  (none)"))
+
+
+def test_cycle_scaling(db_path, n_subs):
+    from app.db import connect, transaction
+    from app.config import load_config
+    from app.models import Filter, Slot
+    from app.repo import insert_pending, confirm
+    from app.cycle import run_cycle
+    conn = connect(db_path)
+    f = Filter(["svc-A"], "all", [1, 2, 3, 4, 5, 6, 7], _t(0, 0), _t(23, 59))
+    # Seed inside one transaction: autocommit per-row would fsync N times and
+    # dominate the run. This is harness setup, not the measured path.
+    with transaction(conn):
+        for i in range(n_subs):
+            sid = insert_pending(conn, email=f"c{i}@x.com", city="leipzig",
+                                 language="de", filter_=f, ttl_days=90)
+            confirm(conn, sid)
+    cfg = load_config()
+    slots = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "tok")]
+    scraper = MagicMock(); scraper.poll.return_value = slots
+    with patch("app.cycle.get_scraper", return_value=scraper), \
+         patch("app.mail._call_mailjet_batch", return_value=True), \
+         patch("app.mail._call_resend_batch", return_value=True):
+        t0 = _time.perf_counter()
+        run_cycle(conn, max_plans_per_city=15, rate_limit_minutes=15,
+                  cycle_id="load", cfg=cfg)
+        dt = _time.perf_counter() - t0
+    sent = conn.execute(
+        "SELECT COUNT(*) AS n FROM sent_idempotency WHERE provider!='pending'"
+    ).fetchone()["n"]
+    print(f"\n[B] run_cycle at {n_subs:,} confirmed subscribers (free-tier quotas)")
+    print(f"    cycle time  : {dt:.2f}s  ({'OK, under 60s' if dt < 60 else 'OVER 60s!'})")
+    print(f"    digests sent: {sent:,} (quota-capped); deferred: {n_subs - sent:,}")
+    print(f"    matching cost: {dt/max(n_subs,1)*1000:.3f} ms/sub")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--threads", type=int, default=16)
+    ap.add_argument("--per-thread", type=int, default=100)
+    ap.add_argument("--subs", type=int, nargs="+", default=[1000, 10000, 50000])
+    args = ap.parse_args()
+
+    for n in args.subs:
+        with tempfile.TemporaryDirectory() as d:
+            db_path = os.path.join(d, "load.db")
+            _setenv(db_path)
+            from app.db import connect, init_schema
+            init_schema(connect(db_path))
+            if n == args.subs[0]:
+                test_concurrent_signups(db_path, args.threads, args.per_thread)
+            test_cycle_scaling(db_path, n)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_confirmations.py
+++ b/tests/test_confirmations.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+from datetime import time
+from unittest.mock import patch
+import pytest
+from app.db import connect, init_schema
+from app.models import Filter
+from app.repo import insert_pending, confirm, pending_confirmations
+from app.confirmations import send_confirmation_now, send_pending_confirmations
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re")
+    for k, v in {"MAILJET_API_KEY": "m", "MAILJET_API_SECRET": "s",
+                 "MAILJET_FROM_EMAIL": "x@x", "MAILJET_FROM_NAME": "x"}.items():
+        monkeypatch.setenv(k, v)
+    conn = connect(str(tmp_path / "t.db"))
+    init_schema(conn)
+    return conn
+
+
+def _cfg(**over):
+    base = dict(resend_daily_quota=100, mailjet_hourly_quota=10,
+                mailjet_daily_quota=200, quota_alert_threshold_pct=80,
+                developer_email="dev@x", email_provider_order=("mailjet", "resend"),
+                token_secret_primary="x" * 32, token_secret_previous="",
+                public_base_url="https://x")
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _sub(conn, email="a@x.com"):
+    return insert_pending(conn, email=email, city="leipzig", language="de",
+                          filter_=Filter(["svc-A"], "all", [1],
+                                         time(0, 0), time(23, 59)), ttl_days=90)
+
+
+def _sent_at(conn, sid):
+    return conn.execute("SELECT confirmation_sent_at FROM subscriptions WHERE id=?",
+                        (sid,)).fetchone()[0]
+
+
+def _pending_ids(conn):
+    return [p[0] for p in pending_confirmations(conn)]
+
+
+def test_deferred_confirmation_is_kept_then_delivered_by_retry(db):
+    sid = _sub(db)
+    # All quota exhausted → the immediate send defers.
+    with patch("app.mail._call_mailjet_batch", return_value=True), \
+         patch("app.mail._call_resend_batch", return_value=True):
+        delivered = send_confirmation_now(db, sid, "a@x.com", "de",
+                                          _cfg(mailjet_hourly_quota=0,
+                                               mailjet_daily_quota=0,
+                                               resend_daily_quota=0))
+    assert delivered is False
+    assert _sent_at(db, sid) is None          # not marked sent
+    assert sid in _pending_ids(db)            # still awaiting confirmation
+
+    # Later cycle, quota available → retry pass delivers it.
+    with patch("app.mail._call_mailjet_batch", return_value=True) as mb:
+        send_pending_confirmations(db, _cfg())
+    mb.assert_called_once()
+    assert _sent_at(db, sid) is not None
+    assert sid not in _pending_ids(db)
+
+
+def test_retry_is_idempotent_once_delivered(db):
+    sid = _sub(db)
+    with patch("app.mail._call_mailjet_batch", return_value=True):
+        assert send_confirmation_now(db, sid, "a@x.com", "de", _cfg()) is True
+    # A second retry pass must not re-send an already-confirmed-sent sign-up.
+    with patch("app.mail._call_mailjet_batch", return_value=True) as mb:
+        send_pending_confirmations(db, _cfg())
+    mb.assert_not_called()
+
+
+def test_retry_skips_already_confirmed_users(db):
+    sid = _sub(db, "b@x.com")
+    confirm(db, sid)                          # user clicked the link already
+    with patch("app.mail._call_mailjet_batch", return_value=True) as mb:
+        send_pending_confirmations(db, _cfg())
+    mb.assert_not_called()
+
+
+def test_retry_abandons_stale_signups(db):
+    sid = _sub(db, "old@x.com")
+    db.execute("UPDATE subscriptions SET created_at=datetime('now','-10 days') "
+               "WHERE id=?", (sid,))
+    assert _pending_ids(db) == []             # outside the 7-day retry window
+    with patch("app.mail._call_mailjet_batch", return_value=True) as mb:
+        send_pending_confirmations(db, _cfg())
+    mb.assert_not_called()

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -55,6 +55,7 @@ def test_full_flow(env):
         for tgt in mail_patch_targets:
             stack.enter_context(patch(tgt, side_effect=fake_send))
         stack.enter_context(patch("app.digest.send_batch", side_effect=fake_send_batch))
+        stack.enter_context(patch("app.confirmations.send_batch", side_effect=fake_send_batch))
         return stack
 
     with _patch_mail():

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -38,33 +38,49 @@ def _form(email="alice@example.com"):
 
 def test_subscribe_success_with_mocked_mail(client):
     from unittest.mock import patch
-    with patch("app.web._send_confirmation_email") as send:
+    with patch("app.web._send_confirmation_email", return_value=True) as send:
         r = client.post("/subscribe", data=_form())
-    assert r.status_code in (200, 302)
+    assert r.status_code == 302
+    assert "confirmed=pending" in r.headers.get("Location", "")
     send.assert_called_once()
 
-def test_subscribe_mail_failure_does_not_500(client):
-    """If the confirmation email fails to send, /subscribe must NOT 500 and
-    must NOT pretend success. It surfaces a retryable error and drops the
-    orphaned (unconfirmable) pending row. Regression test for the same
-    unguarded-mail-send class of bug as /confirm."""
+def test_subscribe_quota_deferral_keeps_registration_and_shows_queued(client):
+    """When the confirmation email is deferred (daily quota exhausted), the
+    sign-up must stay a valid pending row — NOT be discarded — and the user is
+    told it may arrive tomorrow. The poller retry pass sends it later."""
     import os
     from unittest.mock import patch
     from app.db import connect
-    # Distinct IP + email so the session-global IP limiter and the DB row
-    # query don't collide with other subscribe tests.
-    email = "mailfail@example.com"
-    with patch("app.web._send_confirmation_email",
-               side_effect=RuntimeError("mail provider exploded")):
+    email = "queued@example.com"
+    with patch("app.web._send_confirmation_email", return_value=False):
         r = client.post("/subscribe", data=_form(email=email),
                         headers={"X-Forwarded-For": "9.9.9.9"})
     assert r.status_code == 302, r.data[:300]
-    assert "subscribe_error=mail" in r.headers.get("Location", "")
-    # The pending row must not linger as an unconfirmable orphan.
+    assert "confirmed=queued" in r.headers.get("Location", "")
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT deleted_at, confirmed_at FROM subscriptions "
+                       "WHERE email=?", (email,)).fetchone()
+    assert row is not None
+    assert row["deleted_at"] is None      # kept, not discarded
+    assert row["confirmed_at"] is None    # still awaiting confirmation
+
+def test_subscribe_mail_error_keeps_registration_not_discarded(client):
+    """Even an unexpected send error must not lose the sign-up: keep it pending
+    and let the retry pass handle it (shown to the user as 'queued')."""
+    import os
+    from unittest.mock import patch
+    from app.db import connect
+    email = "mailerr@example.com"
+    with patch("app.web._send_confirmation_email",
+               side_effect=RuntimeError("mail provider exploded")):
+        r = client.post("/subscribe", data=_form(email=email),
+                        headers={"X-Forwarded-For": "8.8.8.8"})
+    assert r.status_code == 302
+    assert "confirmed=queued" in r.headers.get("Location", "")
     conn = connect(os.environ["DB_PATH"])
     row = conn.execute("SELECT deleted_at FROM subscriptions WHERE email=?",
                        (email,)).fetchone()
-    assert row is not None and row["deleted_at"] is not None
+    assert row is not None and row["deleted_at"] is None
 
 def test_honeypot_silently_drops_and_does_not_email(client):
     from unittest.mock import patch


### PR DESCRIPTION
Previously a confirmation-email failure discarded the pending sign-up
(soft-delete) and showed a retryable error — and the discarded row still
tripped the per-email daily limit, locking the user out for 24h. Under a
traffic spike that exhausts the email quota, most new sign-ups would be
lost.

Now the registration is kept and the confirmation is retried:

- Route confirmation emails through the quota-aware batch path. If quota
  is exhausted the send is deferred, not failed.
- On deferral the pending row is preserved (no soft-delete) and the user
  is shown a "your confirmation may arrive tomorrow, no need to sign up
  again" message (new confirmed=queued state).
- The poller runs send_pending_confirmations each cycle, re-sending
  confirmations for unconfirmed sign-ups (new confirmation_sent_at column
  marks completion; retries bounded to sign-ups from the last 7 days).

Also harden the DB for concurrency: PRAGMA busy_timeout=5000 so a sign-up
landing mid-poll-cycle queues instead of erroring "database is locked",
and bump web workers 2 -> 4.