### PR TITLE
Migrate domain to buergerwecker.de (web + email sender)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 MAILJET_API_KEY=
 MAILJET_API_SECRET=
-MAILJET_FROM_EMAIL=hallo@termine.jakubwaller.eu
-MAILJET_FROM_NAME=Leipzig-Termine
+MAILJET_FROM_EMAIL=hallo@buergerwecker.de
+MAILJET_FROM_NAME=Bürgerwecker
 # Optional. Where subscriber replies go. Lets the From be a sending subdomain
 # that doesn't receive mail; replies route here instead. Leave blank to omit.
 REPLY_TO_EMAIL=termine@jakubwaller.eu
@@ -32,7 +32,10 @@ QUOTA_ALERT_THRESHOLD_PCT=80
 TOKEN_SECRET_PRIMARY=
 TOKEN_SECRET_PREVIOUS=
 ADMIN_TOKEN=
-PUBLIC_BASE_URL=https://termine.jakubwaller.eu
+# Public site URL — all links in emails (confirm / manage / unsubscribe) are
+# built from this. The From domain above must stay verified with BOTH
+# providers (Mailjet and Resend), or fallback sends get rejected.
+PUBLIC_BASE_URL=https://buergerwecker.de
 DEDUP_WINDOW_HOURS=24
 RATE_LIMIT_MINUTES=15
 SUBSCRIPTION_TTL_DAYS=90

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,11 @@
-termine.jakubwaller.eu {
+# Primary site.
+buergerwecker.de {
     reverse_proxy web:8000
+}
+
+# Keep the old domain working: confirmation / manage / unsubscribe links in
+# emails already sent point at termine.jakubwaller.eu. A permanent redirect
+# preserves them (tokens stay valid — same backend). Keep this indefinitely.
+termine.jakubwaller.eu {
+    redir https://buergerwecker.de{uri} permanent
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -282,6 +282,10 @@
       <a href="/impressum{% if lang == 'en' %}?lang=en{% endif %}">{% if lang == 'en' %}Imprint{% else %}Impressum{% endif %}</a> ·
       <a href="/datenschutz{% if lang == 'en' %}?lang=en{% endif %}">{% if lang == 'en' %}Privacy{% else %}Datenschutz{% endif %}</a> ·
       <a href="{{ kofi_url or 'https://ko-fi.com/jakubwaller' }}">{% if lang == 'en' %}☕ Buy me a coffee{% else %}☕ Kaffee spendieren{% endif %}</a>
+      <br>
+      {% if lang == 'en' %}Built by{% else %}Erstellt von{% endif %}
+      <a href="https://jakubwaller.eu" rel="author">Jakub Waller</a> ·
+      <a href="https://github.com/jakubwaller/termine-notifier">{% if lang == 'en' %}Source code{% else %}Quellcode{% endif %}</a>
     </footer>
   </div>
 </body>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,11 +3,15 @@
 ## Prerequisites
 
 - Raspberry Pi running Docker + Docker Compose.
-- Domain `termine.jakubwaller.eu` (or replacement) pointing to the Pi's
+- Web domain `buergerwecker.de` (or replacement) pointing to the Pi's
   public IP. Ports 80 and 443 forwarded to the Pi.
 - USB HDD mounted at `/mnt/backup` (auto-mount via `/etc/fstab`).
 - Mailjet and Resend accounts with verified sender domain.
-- SPF / DKIM / DMARC records configured on `jakubwaller.eu` before any send.
+- SPF / DKIM / DMARC records configured on `buergerwecker.de` and the domain
+  validated in **both** Mailjet and Resend before any send — an unverified
+  From domain makes the fallback provider reject mail. `REPLY_TO_EMAIL`
+  points at a real mailbox on `jakubwaller.eu`; the From address itself
+  doesn't receive mail.
 
 ## First deploy
 
@@ -21,7 +25,7 @@
 3. Verify the USB HDD is mounted at `/mnt/backup`.
 4. `docker compose up -d`.
 5. Watch logs: `docker compose logs -f`.
-6. Verify healthz: `curl https://termine.jakubwaller.eu/healthz`.
+6. Verify healthz: `curl https://buergerwecker.de/healthz`.
 
 ## Email delivery & quotas
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -102,8 +102,8 @@ def test_no_fallback_on_mailjet_429_without_resend(db, monkeypatch):
 def mailjet_env(monkeypatch):
     monkeypatch.setenv("MAILJET_API_KEY", "k")
     monkeypatch.setenv("MAILJET_API_SECRET", "s")
-    monkeypatch.setenv("MAILJET_FROM_EMAIL", "hallo@termine.jakubwaller.eu")
-    monkeypatch.setenv("MAILJET_FROM_NAME", "Leipzig-Termine")
+    monkeypatch.setenv("MAILJET_FROM_EMAIL", "hallo@buergerwecker.de")
+    monkeypatch.setenv("MAILJET_FROM_NAME", "Bürgerwecker")
 
 def _capture():
     """Patch-ready post that records the json= payload and returns 200."""

--- a/tests/test_smartcjm_live.py
+++ b/tests/test_smartcjm_live.py
@@ -54,7 +54,7 @@ def appointment_types():
 @pytest.fixture
 def http():
     s = requests.Session()
-    s.headers["User-Agent"] = "termine-notifier/live-test (jakubwaller.eu)"
+    s.headers["User-Agent"] = "termine-notifier/live-test (buergerwecker.de)"
     return s
 
 


### PR DESCRIPTION
## What

- `buergerwecker.de` becomes the public site domain; `termine.jakubwaller.eu` 301-redirects to it indefinitely so confirm/manage/unsubscribe links in already-sent emails keep working (same backend, tokens stay valid).
- The email From address moves to `hallo@buergerwecker.de` / sender name `Bürgerwecker` in the same deploy. Resend's free tier allows only one verified domain — the old sender domain was replaced there, so web and sender domains can no longer be split without breaking the fallback provider.
- Footer gains author + source-code links.
- Docs and live-test User-Agent updated.

## Deploy notes

- DNS (A/AAAA/www), Mailjet validation + SPF/DKIM, Resend DKIM + send-subdomain records are already live on the new zone; dynamic-IP updates cover the new domain.
- On the Pi: update `PUBLIC_BASE_URL`, `MAILJET_FROM_EMAIL`, `MAILJET_FROM_NAME` in `.env`, apply the Caddyfile change to the shared Caddy, reload, verify cert issuance + healthz + a test mail.