### PR TITLE
Add Leipzig Ausländerbehörde (residence-document pickup) as second tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Termine-Notifier
 
-Free email notifications for free Bürgerbüro appointments in German cities.
+Free email notifications for free Amt appointments in German cities.
 
-**v1 covers Leipzig.** Support for more cities may follow.
+**v1 covers Leipzig:** the Bürgerbüros (e.g. Wohnsitzanmeldung, Ausweise) and
+the Ausländerbehörde (residence-document pickup). Support for more cities may
+follow.
 
 ## What this does
 
 You enter your email, pick the appointment type (e.g. Wohnsitzanmeldung) and
-which Bürgerbüros work for you, and receive an email the moment a matching
+which offices work for you, and receive an email the moment a matching
 slot is available on `terminvereinbarung.leipzig.de`. You then book it
 yourself on the official city website. We never book on your behalf.
+
+For the Ausländerbehörde, booking additionally requires the personal
+Termin-Code from the office's letter — this service only tells you when a
+pickup slot is free.
 
 ## What this explicitly does NOT do
 

--- a/app/admin.py
+++ b/app/admin.py
@@ -85,13 +85,27 @@ def render_summary_text(s: dict, *, now: datetime) -> str:
             status = f"NO MATCHES since {zms}" if zms else "matching slots"
             subs = s.get("active_subscriptions_by_city", {}).get(city, 0)
             plans = s.get("current_plan_count_by_city", {}).get(city, 0)
-            out.append(f"  {city} — {status}")
+            label = s.get("city_labels", {}).get(city, city)
+            out.append(f"  {label} — {status}")
             out.append(f"    Last polled   {_ts(lp, now, missing='never')}")
             out.append(f"    Active subs   {subs} · Plans {plans}")
             out.append(f"    Polls         {up.get('polls_today', 0)} today "
                        f"· {up.get('polls_total', 0)} total")
             out.append(f"    Requests      {up.get('requests_today', 0)} today "
                        f"· {up.get('requests_total', 0)} total")
+    # Combined load per physical upstream host — several tenants can share one
+    # server, and the rate-limit/ban-risk number is the host total.
+    hosts = s.get("upstream_by_host") or {}
+    if hosts:
+        out += ["", "UPSTREAM HOSTS (combined load across tenants)"]
+        for host in sorted(hosts):
+            agg = hosts[host]
+            out.append(f"  {host}")
+            out.append(f"    Requests      {agg.get('requests_today', 0)} today "
+                       f"· {agg.get('requests_total', 0)} total")
+            out.append(f"    Polls         {agg.get('polls_today', 0)} today "
+                       f"· {agg.get('polls_total', 0)} total")
+            out.append(f"    Tenants       {', '.join(agg.get('tenants', []))}")
     out += ["",
             "SYSTEM",
             f"  Last housekeeping  {_ts(s.get('last_housekeeping_at'), now, missing='never')}",
@@ -160,6 +174,46 @@ def stats(conn: sqlite3.Connection) -> dict:
                 last_polled_at_by_city[r["city"]] = r["last_polled_at"]
     except sqlite3.OperationalError:
         pass  # pre-migration DB; counters not available yet
+    # Human labels + upstream host per tenant, from the catalog. The "city"
+    # key is a tenant (leipzig, leipzig-abh), not a geography; the label comes
+    # from display.json. A key whose catalog dir no longer exists renders as
+    # the raw key and is left out of host aggregation.
+    from urllib.parse import urlsplit
+    from app.catalog import load_catalog
+    city_labels: dict[str, str] = {}
+    city_hosts: dict[str, str] = {}
+    for c in set(list(by_city_subs) + list(upstream_by_city)
+                 + list(last_polled_at_by_city)):
+        try:
+            cat = load_catalog(c)
+        except Exception:
+            continue
+        label = cat.display_text("label", "en")  # admin is English-only
+        if label:
+            city_labels[c] = label
+        host = urlsplit(cat.scraper_config.get("base_url", "")).netloc
+        if host:
+            city_hosts[c] = host
+    # Aggregate upstream counters per physical host: several tenants can share
+    # one upstream (leipzig + leipzig-abh both poll
+    # terminvereinbarung.leipzig.de), and the number that matters for
+    # rate-limit/ban risk is the HOST total, not the per-tenant split. The
+    # *_today values are already normalized to 0 for stale counts_date above,
+    # so summing is safe.
+    upstream_by_host: dict[str, dict] = {}
+    for c, up in upstream_by_city.items():
+        host = city_hosts.get(c)
+        if not host:
+            continue
+        agg = upstream_by_host.setdefault(host, {
+            "polls_today": 0, "polls_total": 0,
+            "requests_today": 0, "requests_total": 0, "tenants": [],
+        })
+        for k in ("polls_today", "polls_total", "requests_today", "requests_total"):
+            agg[k] += up[k]
+        agg["tenants"].append(c)
+    for agg in upstream_by_host.values():
+        agg["tenants"].sort()
     # Slot-match notifications actually delivered to subscribers. `last_notified_at`
     # is set only when a real appointment slot matched and a digest went out, so it
     # is the truest "a subscriber was served" signal — distinct from emails_sent_total,
@@ -200,6 +254,8 @@ def stats(conn: sqlite3.Connection) -> dict:
                    "WHERE sent_at > datetime('now','-7 days') "
                    "AND provider != 'pending'"),
         "upstream_by_city": upstream_by_city,
+        "upstream_by_host": upstream_by_host,
+        "city_labels": city_labels,
         "last_polled_at_by_city": last_polled_at_by_city,
         "slots_cached": scalar("SELECT COUNT(*) FROM slots_cache"),
         "emails_sent_total":

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -118,7 +118,10 @@ def available_cities() -> list[str]:
 
 
 def _read_optional_json(path: Path) -> dict:
+    """Optional catalog files (EN labels, display.json) degrade to defaults —
+    a missing OR malformed optional file must never take a page down.
+    (json.JSONDecodeError subclasses ValueError.)"""
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
+    except (FileNotFoundError, ValueError):
         return {}

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -43,6 +43,15 @@ class Catalog:
     scraper_config: dict               # vendor-specific, opaque to web layer
     appointment_types_en: dict[str, str] = field(default_factory=dict)
     locations_en: dict[str, str] = field(default_factory=dict)
+    # Optional per-tenant UI copy from display.json: keys like "label",
+    # "heading", "note", each a {"de": …, "en": …} map. Missing file or keys →
+    # the templates fall back to their built-in default copy.
+    display: dict = field(default_factory=dict)
+
+    def display_text(self, key: str, lang: str) -> str | None:
+        """Localized display.json text for `key`; falls back to German; None if unset."""
+        entry = self.display.get(key) or {}
+        return entry.get(lang) or entry.get("de") or None
 
     def appointment_type_name_for(self, uuid: str) -> str | None:
         return next((n for n, u in self.appointment_types.items() if u == uuid), None)
@@ -91,9 +100,21 @@ def load_catalog(city: str) -> Catalog:
     # back to the German names everywhere (see Catalog.appointment_types_for).
     ats_en = _read_optional_json(city_dir / "appointment_type.en.json")
     locs_en = _read_optional_json(city_dir / "locations.en.json")
+    display = _read_optional_json(city_dir / "display.json")
     return Catalog(city=city, appointment_types=ats, locations=locs,
                    scraper_config=scfg,
-                   appointment_types_en=ats_en, locations_en=locs_en)
+                   appointment_types_en=ats_en, locations_en=locs_en,
+                   display=display)
+
+
+def available_cities() -> list[str]:
+    """Catalog directory names that hold a complete tenant config, sorted.
+
+    Drives the cross-links between tenants on the sign-up form; a directory
+    without a scraper_config.json (e.g. a scaffold) is not offered.
+    """
+    return sorted(d.name for d in CATALOG_ROOT.iterdir()
+                  if d.is_dir() and (d / "scraper_config.json").is_file())
 
 
 def _read_optional_json(path: Path) -> dict:

--- a/app/catalog_sync.py
+++ b/app/catalog_sync.py
@@ -69,15 +69,16 @@ def sync_city(city: str,
 
     # Single-location tenants (e.g. leipzig-abh-h) have no locations step in
     # their flow, so there is nothing to probe: the location list is static in
-    # the catalog and never drift-checked.
-    has_locations_step = "locations" in scfg["steps"]
+    # the catalog and never drift-checked. The topology decision is shared
+    # with the poller (smartcjm._run_flow) so the two can never disagree.
+    from app.scrapers.smartcjm import has_locations_step
 
     try:
         live_services, live_services_en = fetch_services(http, scfg["base_url"], scfg["uid"])
         live_locations = (fetch_locations(http, scfg["base_url"], scfg["uid"],
                                           list(live_services.values()),
                                           scfg["steps"])
-                          if has_locations_step else current_locations)
+                          if has_locations_step(scfg) else current_locations)
     except (requests.RequestException, RuntimeError) as exc:
         return {"error": str(exc),
                 "service_drift": {}, "location_drift": {}}

--- a/app/catalog_sync.py
+++ b/app/catalog_sync.py
@@ -67,11 +67,17 @@ def sync_city(city: str,
     current_services = json.loads(svc_path.read_text())
     current_locations = json.loads(loc_path.read_text())
 
+    # Single-location tenants (e.g. leipzig-abh-h) have no locations step in
+    # their flow, so there is nothing to probe: the location list is static in
+    # the catalog and never drift-checked.
+    has_locations_step = "locations" in scfg["steps"]
+
     try:
         live_services, live_services_en = fetch_services(http, scfg["base_url"], scfg["uid"])
-        live_locations = fetch_locations(http, scfg["base_url"], scfg["uid"],
+        live_locations = (fetch_locations(http, scfg["base_url"], scfg["uid"],
                                           list(live_services.values()),
                                           scfg["steps"])
+                          if has_locations_step else current_locations)
     except (requests.RequestException, RuntimeError) as exc:
         return {"error": str(exc),
                 "service_drift": {}, "location_drift": {}}

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -131,19 +131,32 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
         # own upstream URL format; ask them via the catalog.
         from app.catalog import load_catalog
         scfg = load_catalog(sub.city).scraper_config
-        for slot in candidates:
-            upstream = _build_upstream_url(scfg, slot)
-            # The booking_token is a URL-encoded datetime (e.g. ...T17%3a20%3a00%2b02%3a00).
-            # The email links to /go/<booking_token>, and Flask URL-DECODES the path
-            # param on click — so the slots_cache key must be the DECODED form, or the
-            # /go lookup misses and every link 410s. (upstream_url keeps the encoded
-            # token: it sits in a query string the city site decodes itself.)
-            slot_token = urllib.parse.unquote(slot.booking_token)
-            conn.execute(
-                "INSERT INTO slots_cache (slot_token, city, upstream_url) "
-                "VALUES (?, ?, ?) ON CONFLICT (slot_token) DO NOTHING",
-                (slot_token, sub.city, upstream),
-            )
+        # One transaction for the whole candidate batch: in autocommit each
+        # INSERT is its own fsync, and an abundant tenant (leipzig-abh holds
+        # 1000+ open slots) times N subscribers would overrun the one-minute
+        # cycle on fsyncs alone.
+        with transaction(conn):
+            for slot in candidates:
+                upstream = _build_upstream_url(scfg, slot)
+                # The booking_token is a URL-encoded datetime (e.g.
+                # ...T17%3a20%3a00%2b02%3a00). The email links to
+                # /go/<city>:<booking_token>, and Flask URL-DECODES the path
+                # param on click — so the slots_cache key must use the DECODED
+                # form, or the /go lookup misses and every link 410s.
+                # (upstream_url keeps the encoded token: it sits in a query
+                # string the city site decodes itself.)
+                #
+                # The key is prefixed with the tenant because the bare token is
+                # just a wall-clock datetime: two tenants (leipzig, leipzig-abh)
+                # sharing the same instant would otherwise collide on the
+                # single-column primary key and /go would 302 subscribers to
+                # whichever tenant's URL was cached first.
+                slot_token = f"{sub.city}:{urllib.parse.unquote(slot.booking_token)}"
+                conn.execute(
+                    "INSERT INTO slots_cache (slot_token, city, upstream_url) "
+                    "VALUES (?, ?, ?) ON CONFLICT (slot_token) DO NOTHING",
+                    (slot_token, sub.city, upstream),
+                )
         # Stage for batched delivery. seen_slots + last_notified are recorded
         # inside flush_digests, but only for digests that were actually sent —
         # quota-deferred ones stay unrecorded so a later cycle re-sends them.

--- a/app/digest.py
+++ b/app/digest.py
@@ -95,7 +95,9 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
     for office_uuid in sorted(by_office, key=loc_label):
         lines.append(loc_label(office_uuid))
         for s in sorted(by_office[office_uuid], key=lambda s: (s.date, s.time_str)):
-            go_url = f"{public_base_url}/go/{s.booking_token}"
+            # Tenant-prefixed to match the slots_cache key (see cycle.py): the
+            # bare token is only a datetime and would collide across tenants.
+            go_url = f"{public_base_url}/go/{sub.city}:{s.booking_token}"
             date_str = _format_date(s.date, lang)
             if multi_service:
                 lines.append(f"  {date_str}  {s.time_str}  ·  "

--- a/app/digest.py
+++ b/app/digest.py
@@ -56,10 +56,15 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
         locations = ", ".join(loc_label(u) for u in f.locations)
     svc_lbl = t(lang, "digest.selection_service_label")
     loc_lbl = t(lang, "digest.selection_locations_label")
-    pad = max(len(svc_lbl), len(loc_lbl)) + 1  # width of the longest "label:"
+    win_lbl = t(lang, "digest.selection_window_label") if f.max_days_ahead else ""
+    labels = [l for l in (svc_lbl, loc_lbl, win_lbl) if l]
+    pad = max(len(l) for l in labels) + 1  # width of the longest "label:"
     lines.append(t(lang, "digest.selection_heading"))
     lines.append(f"  {(svc_lbl + ':').ljust(pad)} {services}")
     lines.append(f"  {(loc_lbl + ':').ljust(pad)} {locations}")
+    if f.max_days_ahead:
+        lines.append(f"  {(win_lbl + ':').ljust(pad)} "
+                     f"{t(lang, 'digest.window_days', n=f.max_days_ahead)}")
     lines.append("")
 
     # Slots grouped by office (offices sorted by display name); within an

--- a/app/digest.py
+++ b/app/digest.py
@@ -7,6 +7,11 @@ from app.models import Subscription, Slot
 from app.mail import (send, send_batch, maybe_quota_alert, Outgoing,
                       _idem_key)
 
+# Render at most this many slots per digest email (soonest first). Keeps even
+# an abundant tenant's digest far under Gmail's ~102KB clipping threshold;
+# anything beyond is summarized in a single count line.
+MAX_SLOTS_PER_DIGEST = 25
+
 # Weekday abbreviations for the date line (i18n.t is string-only, so the
 # per-language lists live here rather than in the JSON bundles). Index 0 = Mon.
 _WEEKDAY_ABBR = {
@@ -67,6 +72,18 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
                      f"{t(lang, 'digest.window_days', n=f.max_days_ahead)}")
     lines.append("")
 
+    # Cap the rendered slots at the soonest MAX_SLOTS_PER_DIGEST. Abundant
+    # tenants (the Ausländerbehörde calendar can hold 1000+ open slots) would
+    # otherwise produce a digest past Gmail's ~102KB clipping threshold —
+    # hiding the unsubscribe link in the clipped tail. Omitted slots are
+    # summarized in one count line; the caller still marks ALL matched slots
+    # seen (flush_digests works off the full candidate list), so the omission
+    # does not drip-feed follow-up emails.
+    omitted = 0
+    if len(slots) > MAX_SLOTS_PER_DIGEST:
+        omitted = len(slots) - MAX_SLOTS_PER_DIGEST
+        slots = sorted(slots, key=lambda s: (s.date, s.time_str))[:MAX_SLOTS_PER_DIGEST]
+
     # Slots grouped by office (offices sorted by display name); within an
     # office, sorted by day then time. The per-slot service label is shown
     # only when the filter spans more than one type — otherwise the header
@@ -85,6 +102,9 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
                              f"{svc_label(s.service_uuid)}  →  {go_url}")
             else:
                 lines.append(f"  {date_str}  {s.time_str}  →  {go_url}")
+    if omitted:
+        lines.append("")
+        lines.append(t(lang, "digest.more_available", n=omitted))
     lines.append("")
 
     lines.append(t(lang, "digest.burst_warning"))

--- a/app/filters.py
+++ b/app/filters.py
@@ -11,6 +11,8 @@ def matches(f: Filter, slot: Slot) -> bool:
         d = date.fromisoformat(slot.date)
     except ValueError:
         return False
+    if f.max_days_ahead is not None and (d - date.today()).days > f.max_days_ahead:
+        return False
     if d.isoweekday() not in f.weekdays:
         return False
     try:

--- a/app/filters.py
+++ b/app/filters.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
-from datetime import date, time
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
 from app.models import Filter, Slot
+
+# Slot dates are Europe/Berlin local dates (the city sites' timezone), while
+# the poller container runs UTC. "Today" for the max_days_ahead window must be
+# the Berlin date, or the window silently shrinks by a day between the Berlin
+# and UTC midnights (~22:00/23:00–00:00 UTC every night).
+_BERLIN = ZoneInfo("Europe/Berlin")
 
 def matches(f: Filter, slot: Slot) -> bool:
     if slot.service_uuid not in f.appointment_types:
@@ -11,8 +18,10 @@ def matches(f: Filter, slot: Slot) -> bool:
         d = date.fromisoformat(slot.date)
     except ValueError:
         return False
-    if f.max_days_ahead is not None and (d - date.today()).days > f.max_days_ahead:
-        return False
+    if f.max_days_ahead is not None:
+        today = datetime.now(_BERLIN).date()
+        if (d - today).days > f.max_days_ahead:
+            return False
     if d.isoweekday() not in f.weekdays:
         return False
     try:

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -8,5 +8,7 @@
   "digest.all_locations": "Alle Standorte",
   "digest.burst_warning": "Viele Termine öffnen sich gleichzeitig — schneller Klick gewinnt.",
   "digest.unsubscribe": "Abmelden: {unsubscribe_url}",
-  "digest.kofi": "Hat dir diese Benachrichtigung geholfen? Du kannst mir einen Kaffee spendieren: {kofi_url} (aber nur, wenn du magst — der Dienst bleibt kostenlos.)"
+  "digest.kofi": "Hat dir diese Benachrichtigung geholfen? Du kannst mir einen Kaffee spendieren: {kofi_url} (aber nur, wenn du magst — der Dienst bleibt kostenlos.)",
+  "digest.selection_window_label": "Zeitraum",
+  "digest.window_days": "innerhalb der nächsten {n} Tage"
 }

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -10,5 +10,6 @@
   "digest.unsubscribe": "Abmelden: {unsubscribe_url}",
   "digest.kofi": "Hat dir diese Benachrichtigung geholfen? Du kannst mir einen Kaffee spendieren: {kofi_url} (aber nur, wenn du magst — der Dienst bleibt kostenlos.)",
   "digest.selection_window_label": "Zeitraum",
-  "digest.window_days": "innerhalb der nächsten {n} Tage"
+  "digest.window_days": "innerhalb der nächsten {n} Tage",
+  "digest.more_available": "… und {n} weitere passende Termine sind aktuell online buchbar — die frühesten stehen oben."
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -8,5 +8,7 @@
   "digest.all_locations": "All locations",
   "digest.burst_warning": "Many appointments open at once — the fastest click wins.",
   "digest.unsubscribe": "Unsubscribe: {unsubscribe_url}",
-  "digest.kofi": "Did this notification help? You can buy me a coffee: {kofi_url} (only if you want — the service stays free.)"
+  "digest.kofi": "Did this notification help? You can buy me a coffee: {kofi_url} (only if you want — the service stays free.)",
+  "digest.selection_window_label": "Window",
+  "digest.window_days": "within the next {n} days"
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -10,5 +10,6 @@
   "digest.unsubscribe": "Unsubscribe: {unsubscribe_url}",
   "digest.kofi": "Did this notification help? You can buy me a coffee: {kofi_url} (only if you want — the service stays free.)",
   "digest.selection_window_label": "Window",
-  "digest.window_days": "within the next {n} days"
+  "digest.window_days": "within the next {n} days",
+  "digest.more_available": "… and {n} more matching appointments are currently bookable online — the soonest are listed above."
 }

--- a/app/models.py
+++ b/app/models.py
@@ -43,7 +43,10 @@ class Filter:
             time_window_start=_parse_hhmm(tw["start"]),
             time_window_end=_parse_hhmm(tw["end"]),
             # Absent in rows written before this field existed → no limit.
-            max_days_ahead=d.get("max_days_ahead"),
+            # 0 also normalizes to no-limit: the form can't produce it, and the
+            # consumers (matches() vs digest/manage truthiness) would otherwise
+            # disagree on what 0 means.
+            max_days_ahead=d.get("max_days_ahead") or None,
         )
 
 def _parse_hhmm(s: str) -> time:

--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,10 @@ class Filter:
     weekdays: list[int]                # ISO 8601: 1=Mon … 7=Sun
     time_window_start: time
     time_window_end: time
+    # Only notify about slots within the next N days (None = no limit). A slot
+    # further out is deliberately not marked seen: if it is still free once it
+    # enters the window, a later cycle notifies about it then.
+    max_days_ahead: int | None = None
 
     def to_json(self) -> str:
         return json.dumps({
@@ -25,6 +29,7 @@ class Filter:
                 "start": self.time_window_start.strftime("%H:%M"),
                 "end":   self.time_window_end.strftime("%H:%M"),
             },
+            "max_days_ahead": self.max_days_ahead,
         })
 
     @classmethod
@@ -37,6 +42,8 @@ class Filter:
             weekdays=list(d.get("weekdays", [1, 2, 3, 4, 5, 6, 7])),
             time_window_start=_parse_hhmm(tw["start"]),
             time_window_end=_parse_hhmm(tw["end"]),
+            # Absent in rows written before this field existed → no limit.
+            max_days_ahead=d.get("max_days_ahead"),
         )
 
 def _parse_hhmm(s: str) -> time:

--- a/app/scrapers/smartcjm.py
+++ b/app/scrapers/smartcjm.py
@@ -47,8 +47,8 @@ def parse_slots(html: str, *, service_uuid: str) -> list[Slot]:
         return []
     soup = BeautifulSoup(html, "html.parser")
     slots: list[Slot] = []
-    for btn in soup.find_all("button", attrs={"onclick": APPOINTMENT_RESERVE_RE}):
-        m = APPOINTMENT_RESERVE_RE.search(btn.get("onclick", ""))
+    for btn in soup.find_all("button", onclick=True):
+        m = APPOINTMENT_RESERVE_RE.search(btn["onclick"])
         if not m:
             continue
         encoded_dt, _duration, location_uuid, resource_uuid = m.groups()
@@ -66,6 +66,18 @@ def parse_slots(html: str, *, service_uuid: str) -> list[Slot]:
             resource_uuid=resource_uuid,
         ))
     return slots
+
+
+def has_locations_step(scfg: dict) -> bool:
+    """Whether this tenant's booking flow includes a locations step.
+
+    Single source of truth for the flow-topology decision — both poll()
+    (_run_flow) and catalog_sync.sync_city branch on it, and the two must
+    never disagree. `steps` is the vendor's delimiter-less concatenation
+    (e.g. "servicessearch_resultsbookingfinish"), posted back verbatim, so
+    substring containment is the only test available.
+    """
+    return "locations" in scfg["steps"]
 
 
 def _rewrite_8443(url: str) -> str:
@@ -189,7 +201,7 @@ def _run_flow(http: requests.Session, wsid: str, csrf: str, rev: str,
     like leipzig-abh-h skip the locations step entirely — there the services
     POST (with action_type=search) already returns the results page.
     """
-    if "locations" in scfg["steps"]:
+    if has_locations_step(scfg):
         _post_services(http, wsid, csrf, rev, plan, scfg)
         return _post_locations(http, wsid, csrf, rev, plan, catalog, scfg)
     return _post_services(http, wsid, csrf, rev, plan, scfg,

--- a/app/scrapers/smartcjm.py
+++ b/app/scrapers/smartcjm.py
@@ -24,7 +24,6 @@ APPOINTMENT_RESERVE_RE = re.compile(
     r"'([^']+)'\s*,\s*"   # location uuid
     r"'([^']+)'\s*\)"     # resource uuid (counter/staff — NOT the service; see parse_slots)
 )
-SLOT_LI_TESTID_RE = re.compile(r"^slot_button_li-\d+$")
 
 
 def parse_slots(html: str, *, service_uuid: str) -> list[Slot]:
@@ -35,17 +34,21 @@ def parse_slots(html: str, *, service_uuid: str) -> list[Slot]:
     service. The search is server-side filtered to a single service, so the
     service every returned slot belongs to is `service_uuid` (the one we
     searched for, supplied by the caller from the plan).
+
+    Slot buttons are matched by their onclick handler rather than markup
+    decoration: the leipzig-ba tenant wraps them in
+    `<li data-testid="slot_button_li-N">`, but the leipzig-abh-h tenant renders
+    the same buttons without any data-testid. The page's <script> block also
+    contains the appointment_reserve function *definition*, but that lives in
+    script text, never in a button's onclick attribute, so scanning onclick
+    attributes cannot false-positive on it.
     """
     if "Session abgelaufen" in html:
         return []
     soup = BeautifulSoup(html, "html.parser")
     slots: list[Slot] = []
-    for li in soup.find_all("li", attrs={"data-testid": SLOT_LI_TESTID_RE}):
-        btn = li.find("button")
-        if not btn:
-            continue
-        onclick = btn.get("onclick", "")
-        m = APPOINTMENT_RESERVE_RE.search(onclick)
+    for btn in soup.find_all("button", attrs={"onclick": APPOINTMENT_RESERVE_RE}):
+        m = APPOINTMENT_RESERVE_RE.search(btn.get("onclick", ""))
         if not m:
             continue
         encoded_dt, _duration, location_uuid, resource_uuid = m.groups()
@@ -124,16 +127,22 @@ def _invalidate_wsid(scfg: dict) -> None:
 
 
 def _post_services(http: requests.Session, wsid: str, csrf: str, rev: str,
-                   plan: PollPlan, scfg: dict) -> None:
+                   plan: PollPlan, scfg: dict, *,
+                   action_type: str = "") -> str:
     # Submit ONLY the selected service, amount 1 — mirroring the browser's
     # `autoSelectServiceAndSubmit` (one `services=<uid>` + `service_<uid>_amount`).
     # Blasting every catalog service at once makes the server fall back to the
     # global "earliest" slot regardless of the chosen service (amount_min is 1
     # for every Leipzig service).
+    #
+    # `action_type` is "" when a locations step follows (leipzig-ba), and
+    # "search" on single-location tenants whose flow goes straight from
+    # services to search_results (leipzig-abh-h) — there the returned page IS
+    # the results page.
     sel = plan.appointment_type
     body = (
         f"__RequestVerificationToken={csrf}&"
-        f"action_type=&steps={scfg['steps']}&"
+        f"action_type={action_type}&steps={scfg['steps']}&"
         "step_current=services&step_current_index=0&step_goto=%2B1&services=&"
         f"services={sel}&service_{sel}_amount=1"
     )
@@ -143,7 +152,8 @@ def _post_services(http: requests.Session, wsid: str, csrf: str, rev: str,
         data=body, timeout=30, allow_redirects=False,
     )
     # Follow :8443 redirect if the load balancer injects one.
-    _follow_if_redirect(http, r)
+    r = _follow_if_redirect(http, r)
+    return r.text
 
 
 def _post_locations(http: requests.Session, wsid: str, csrf: str, rev: str,
@@ -170,6 +180,22 @@ def _post_locations(http: requests.Session, wsid: str, csrf: str, rev: str,
     return r.text
 
 
+def _run_flow(http: requests.Session, wsid: str, csrf: str, rev: str,
+              plan: PollPlan, catalog, scfg: dict) -> str:
+    """Drive the tenant's step sequence to the search-results page.
+
+    Tenants differ in their configured step list (`scfg["steps"]`): leipzig-ba
+    is services → locations → search_results, while single-location tenants
+    like leipzig-abh-h skip the locations step entirely — there the services
+    POST (with action_type=search) already returns the results page.
+    """
+    if "locations" in scfg["steps"]:
+        _post_services(http, wsid, csrf, rev, plan, scfg)
+        return _post_locations(http, wsid, csrf, rev, plan, catalog, scfg)
+    return _post_services(http, wsid, csrf, rev, plan, scfg,
+                          action_type="search")
+
+
 def poll(plan: PollPlan, http: requests.Session) -> list[Slot]:
     """Run the Smart-CJM flow against the city's tenant. Returns parsed slots.
 
@@ -185,11 +211,9 @@ def poll(plan: PollPlan, http: requests.Session) -> list[Slot]:
             f"(vendor={scfg.get('vendor')})"
         )
     wsid, csrf, rev = _get_session_state(http, scfg)
-    _post_services(http, wsid, csrf, rev, plan, scfg)
-    html = _post_locations(http, wsid, csrf, rev, plan, catalog, scfg)
+    html = _run_flow(http, wsid, csrf, rev, plan, catalog, scfg)
     if "Session abgelaufen" in html:
         _invalidate_wsid(scfg)
         wsid, csrf, rev = _get_session_state(http, scfg)
-        _post_services(http, wsid, csrf, rev, plan, scfg)
-        html = _post_locations(http, wsid, csrf, rev, plan, catalog, scfg)
+        html = _run_flow(http, wsid, csrf, rev, plan, catalog, scfg)
     return parse_slots(html, service_uuid=plan.appointment_type)

--- a/app/templates/_fields.html
+++ b/app/templates/_fields.html
@@ -1,0 +1,18 @@
+{# Shared form fields used by both the sign-up form and the manage page. #}
+
+{% macro max_days_select(lang, mda=None) %}
+  {% set day_options = [3, 7, 14, 30] %}
+  <label>{% if lang == 'en' %}Only appointments within the next …{% else %}Nur Termine innerhalb der nächsten …{% endif %}
+    <select name="max_days_ahead">
+      <option value="" {% if not mda %}selected{% endif %}>{% if lang == 'en' %}no limit{% else %}ohne Begrenzung{% endif %}</option>
+      {# A stored value outside the standard list (e.g. set via an older
+         option set) must stay selectable, not silently reset on save. #}
+      {% if mda and mda not in day_options %}
+        <option value="{{ mda }}" selected>{{ mda }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
+      {% endif %}
+      {% for n in day_options %}
+        <option value="{{ n }}" {% if mda == n %}selected{% endif %}>{{ n }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
+      {% endfor %}
+    </select>
+  </label>
+{% endmacro %}

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -98,7 +98,7 @@
         {% set lp = s.last_polled_at_by_city.get(city) %}
         <div class="city">
           <div class="city-head">
-            <span class="city-name">{{ city|capitalize }}</span>
+            <span class="city-name">{{ s.city_labels.get(city, city|capitalize) }}</span>
             {% if zms %}
               <span class="status"><span class="dot dot-warn"></span>No matches since <time class="ts" data-ts="{{ zms }}">{{ zms }}</time></span>
             {% else %}
@@ -118,6 +118,27 @@
       <p class="adm-muted">No polling activity yet.</p>
     {% endif %}
   </section>
+
+  {% if s.upstream_by_host %}
+  <section class="adm-section">
+    <h2>Upstream hosts</h2>
+    {# Combined load per physical server: several tenants can share one host
+       (leipzig + leipzig-abh both poll terminvereinbarung.leipzig.de), and the
+       rate-limit / ban-risk number is the host total, not the tenant split. #}
+    <table class="adm-table">
+      {% for host, agg in s.upstream_by_host|dictsort %}
+        <tr>
+          <td class="k">{{ host }}</td>
+          <td class="v">
+            Requests {{ agg.requests_today }} today · {{ agg.requests_total }} total
+            &nbsp;·&nbsp; Polls {{ agg.polls_today }} today · {{ agg.polls_total }} total
+            <br><span class="adm-muted">Tenants: {{ agg.tenants|join(', ') }}</span>
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  </section>
+  {% endif %}
 
   <section class="adm-section">
     <h2>System</h2>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -232,6 +232,12 @@
       margin: 0 0.25rem;
     }
     footer a:hover { color: var(--accent); }
+    .city-switch {
+      font-size: 0.9375rem;
+      margin: -0.5rem 0 1.25rem;
+    }
+    .city-switch a { text-decoration: none; }
+    .city-switch a:hover { text-decoration: underline; }
     .hidden { position: absolute; left: -9999px; }
     @media (max-width: 480px) {
       .container { padding: 1rem 0 3rem; }

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -112,6 +112,15 @@
       <input type="time" name="time_end" value="23:59">
     </label>
 
+    <label>{% if lang == 'en' %}Only appointments within the next …{% else %}Nur Termine innerhalb der nächsten …{% endif %}
+      <select name="max_days_ahead">
+        <option value="" selected>{% if lang == 'en' %}no limit{% else %}ohne Begrenzung{% endif %}</option>
+        {% for n in [3, 7, 14, 30] %}
+          <option value="{{ n }}">{{ n }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
+        {% endfor %}
+      </select>
+    </label>
+
     <fieldset>
       <legend>{% if lang == 'en' %}Days of week{% else %}Wochentage{% endif %}</legend>
       {% for n, label_de, label_en in [(1,'Mo','Mon'),(2,'Di','Tue'),(3,'Mi','Wed'),(4,'Do','Thu'),(5,'Fr','Fri'),(6,'Sa','Sat'),(7,'So','Sun')] %}

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_fields.html" import max_days_select %}
 {% block content %}
   {% if confirmed == 'pending' %}
     <div class="notice notice-success" role="status">
@@ -112,14 +113,7 @@
       <input type="time" name="time_end" value="23:59">
     </label>
 
-    <label>{% if lang == 'en' %}Only appointments within the next …{% else %}Nur Termine innerhalb der nächsten …{% endif %}
-      <select name="max_days_ahead">
-        <option value="" selected>{% if lang == 'en' %}no limit{% else %}ohne Begrenzung{% endif %}</option>
-        {% for n in [3, 7, 14, 30] %}
-          <option value="{{ n }}">{{ n }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
-        {% endfor %}
-      </select>
-    </label>
+    {{ max_days_select(lang) }}
 
     <fieldset>
       <legend>{% if lang == 'en' %}Days of week{% else %}Wochentage{% endif %}</legend>

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -49,21 +49,34 @@
   {% endif %}
 
   <h1>
-    {% if lang == 'en' %}Never miss a Leipzig appointment again
+    {% if heading %}{{ heading }}
+    {% elif lang == 'en' %}Never miss a Leipzig appointment again
     {% else %}Nie wieder freie Bürgerbüro-Termine verpassen{% endif %}
   </h1>
+
+  {% if other_cities %}
+    <p class="city-switch">
+      {% for label, url in other_cities %}
+        <a href="{{ url }}">→ {{ label }}</a>{% if not loop.last %} · {% endif %}
+      {% endfor %}
+    </p>
+  {% endif %}
 
   <p class="disclaimer">
     {% if lang == 'en' %}
       This website is not officially affiliated with the City of Leipzig or
-      its Bürgerbüros. We are an independent service that only informs
+      its authorities. We are an independent service that only informs
       about available appointments.
     {% else %}
-      Diese Website ist nicht offiziell mit der Stadt Leipzig oder den
-      Bürgerbüros der Stadt Leipzig verbunden. Wir sind ein unabhängiger
-      Dienst, der ausschließlich über verfügbare Termine informiert.
+      Diese Website ist nicht offiziell mit der Stadt Leipzig oder ihren
+      Behörden verbunden. Wir sind ein unabhängiger Dienst, der
+      ausschließlich über verfügbare Termine informiert.
     {% endif %}
   </p>
+
+  {% if note %}
+    <p class="disclaimer">{{ note }}</p>
+  {% endif %}
 
   <form action="/subscribe" method="post">
     <input type="hidden" name="lang" value="{{ lang }}">

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -35,6 +35,20 @@
       <input type="time" name="time_end" value="{{ current.time_window_end.strftime('%H:%M') }}">
     </label>
 
+    {% set mda = current.max_days_ahead %}
+    {% set day_options = [3, 7, 14, 30] %}
+    <label>{% if lang == 'en' %}Only appointments within the next …{% else %}Nur Termine innerhalb der nächsten …{% endif %}
+      <select name="max_days_ahead">
+        <option value="" {% if not mda %}selected{% endif %}>{% if lang == 'en' %}no limit{% else %}ohne Begrenzung{% endif %}</option>
+        {% if mda and mda not in day_options %}
+          <option value="{{ mda }}" selected>{{ mda }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
+        {% endif %}
+        {% for n in day_options %}
+          <option value="{{ n }}" {% if mda == n %}selected{% endif %}>{{ n }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
+        {% endfor %}
+      </select>
+    </label>
+
     <fieldset>
       <legend>{% if lang == 'en' %}Days of week{% else %}Wochentage{% endif %}</legend>
       {% for n, label_de, label_en in [(1,'Mo','Mon'),(2,'Di','Tue'),(3,'Mi','Wed'),(4,'Do','Thu'),(5,'Fr','Fri'),(6,'Sa','Sat'),(7,'So','Sun')] %}

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_fields.html" import max_days_select %}
 {% block content %}
   <h1>
     {% if lang == 'en' %}Manage your subscription{% else %}Abonnement verwalten{% endif %}
@@ -35,19 +36,7 @@
       <input type="time" name="time_end" value="{{ current.time_window_end.strftime('%H:%M') }}">
     </label>
 
-    {% set mda = current.max_days_ahead %}
-    {% set day_options = [3, 7, 14, 30] %}
-    <label>{% if lang == 'en' %}Only appointments within the next …{% else %}Nur Termine innerhalb der nächsten …{% endif %}
-      <select name="max_days_ahead">
-        <option value="" {% if not mda %}selected{% endif %}>{% if lang == 'en' %}no limit{% else %}ohne Begrenzung{% endif %}</option>
-        {% if mda and mda not in day_options %}
-          <option value="{{ mda }}" selected>{{ mda }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
-        {% endif %}
-        {% for n in day_options %}
-          <option value="{{ n }}" {% if mda == n %}selected{% endif %}>{{ n }} {% if lang == 'en' %}days{% else %}Tage{% endif %}</option>
-        {% endfor %}
-      </select>
-    </label>
+    {{ max_days_select(lang, current.max_days_ahead) }}
 
     <fieldset>
       <legend>{% if lang == 'en' %}Days of week{% else %}Wochentage{% endif %}</legend>

--- a/app/web.py
+++ b/app/web.py
@@ -227,14 +227,19 @@ def create_app() -> Flask:
             catalog = load_catalog(city)
         except CatalogError:
             # Unknown/garbage ?city= — land on the default tenant, not a 500.
-            return redirect("/")
+            return redirect("/?lang=en" if lang == "en" else "/")
         # Cross-links to the other tenants (e.g. Bürgerbüro ⇄ Ausländerbehörde),
         # labeled from each catalog's display.json.
         other_cities = []
         for other in available_cities():
             if other == city:
                 continue
-            ocat = load_catalog(other)
+            try:
+                ocat = load_catalog(other)
+            except CatalogError:
+                # An incomplete tenant dir (e.g. a scaffold with only a
+                # scraper_config.json) must not take down every tenant's page.
+                continue
             label = ocat.display_text("label", lang) or other
             url = f"/?city={other}" + ("&lang=en" if lang == "en" else "")
             other_cities.append((label, url))

--- a/app/web.py
+++ b/app/web.py
@@ -125,6 +125,14 @@ def _parse_hhmm(s: str) -> time_cls:
     return time_cls(int(h), int(m))
 
 
+def _parse_max_days(raw: str | None) -> int | None:
+    """Form value for 'only slots within the next N days'; ''/invalid → no limit."""
+    raw = (raw or "").strip()
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw)
+    return None
+
+
 def _send_confirmation_email(conn, sub_id: int, email: str, lang: str, cfg) -> bool:
     """Try to send the confirmation now. Returns True if delivered, False if
     deferred (quota exhausted) — the sign-up stays pending and the poller's
@@ -285,6 +293,7 @@ def create_app() -> Flask:
             weekdays=weekdays,
             time_window_start=_parse_hhmm(ts),
             time_window_end=_parse_hhmm(te),
+            max_days_ahead=_parse_max_days(request.form.get("max_days_ahead")),
         )
         # 5. plan-cap overflow check + insert atomically (spec 3.2.6).
         conn = connect(cfg.db_path)
@@ -382,7 +391,9 @@ def create_app() -> Flask:
             f = Filter(appointment_types=[atype], locations=locations,
                        weekdays=weekdays,
                        time_window_start=_parse_hhmm(ts),
-                       time_window_end=_parse_hhmm(te))
+                       time_window_end=_parse_hhmm(te),
+                       max_days_ahead=_parse_max_days(
+                           request.form.get("max_days_ahead")))
             conn.execute("UPDATE subscriptions SET filters_json=? WHERE id=?",
                          (f.to_json(), sub_id))
             row = conn.execute("SELECT language FROM subscriptions WHERE id=?",

--- a/app/web.py
+++ b/app/web.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from flask import Flask, request, render_template, redirect
 from app.config import load_config
 from app.db import connect, init_schema, transaction
-from app.catalog import load_catalog
+from app.catalog import load_catalog, available_cities, CatalogError
 from app.models import Filter
 from app.repo import insert_pending, active_subscriptions, confirm, soft_delete
 from app.ratelimit import GLOBAL_IP_LIMITER, email_rate_limit_ok
@@ -215,12 +215,29 @@ def create_app() -> Flask:
         # retryable error instead of silently re-rendering.
         confirmed = request.args.get("confirmed")
         error = request.args.get("subscribe_error")
-        catalog = load_catalog(city)
+        try:
+            catalog = load_catalog(city)
+        except CatalogError:
+            # Unknown/garbage ?city= — land on the default tenant, not a 500.
+            return redirect("/")
+        # Cross-links to the other tenants (e.g. Bürgerbüro ⇄ Ausländerbehörde),
+        # labeled from each catalog's display.json.
+        other_cities = []
+        for other in available_cities():
+            if other == city:
+                continue
+            ocat = load_catalog(other)
+            label = ocat.display_text("label", lang) or other
+            url = f"/?city={other}" + ("&lang=en" if lang == "en" else "")
+            other_cities.append((label, url))
         return render_template("form.html",
                                lang=lang,
                                city=city,
                                confirmed=confirmed,
                                error=error,
+                               heading=catalog.display_text("heading", lang),
+                               note=catalog.display_text("note", lang),
+                               other_cities=other_cities,
                                appointment_types=catalog.appointment_types_for(lang),
                                locations=catalog.locations_for(lang),
                                kofi_url=app.config["TERMINE_CONFIG"].kofi_url)

--- a/catalog/leipzig-abh/appointment_type.en.json
+++ b/catalog/leipzig-abh/appointment_type.en.json
@@ -1,0 +1,3 @@
+{
+  "Issuance of residence document": "6d72c63a-31a8-4aca-9d46-c9f3f90d39ec"
+}

--- a/catalog/leipzig-abh/appointment_type.json
+++ b/catalog/leipzig-abh/appointment_type.json
@@ -1,0 +1,3 @@
+{
+  "Ausgabe  Aufenthaltsdokument": "6d72c63a-31a8-4aca-9d46-c9f3f90d39ec"
+}

--- a/catalog/leipzig-abh/display.json
+++ b/catalog/leipzig-abh/display.json
@@ -1,0 +1,14 @@
+{
+  "label": {
+    "de": "Ausländerbehörde: Abholung Aufenthaltsdokument",
+    "en": "Foreigners' office: residence document pickup"
+  },
+  "heading": {
+    "de": "Nie wieder freie Abhol-Termine bei der Ausländerbehörde verpassen",
+    "en": "Never miss a pickup slot at the Leipzig foreigners' office"
+  },
+  "note": {
+    "de": "Hinweis: Zum Buchen brauchst du den persönlichen Termin-Code aus dem Schreiben der Ausländerbehörde. Dieser Dienst informiert nur über freie Abhol-Termine für Aufenthaltsdokumente — gebucht wird weiterhin selbst auf der offiziellen Seite der Stadt.",
+    "en": "Note: booking requires the personal appointment code (Termin-Code) from your letter from the foreigners' office. This service only notifies you about free pickup slots for residence documents — you still book yourself on the city's official site."
+  }
+}

--- a/catalog/leipzig-abh/locations.en.json
+++ b/catalog/leipzig-abh/locations.en.json
@@ -1,0 +1,3 @@
+{
+  "Foreigners' office (Prager Straße 126, ground floor)": "8e470125-efec-47cc-bb60-4e3a072e7e67"
+}

--- a/catalog/leipzig-abh/locations.json
+++ b/catalog/leipzig-abh/locations.json
@@ -1,0 +1,3 @@
+{
+  "Ausländerbehörde (Prager Straße 126, Erdgeschoss)": "8e470125-efec-47cc-bb60-4e3a072e7e67"
+}

--- a/catalog/leipzig-abh/scraper_config.json
+++ b/catalog/leipzig-abh/scraper_config.json
@@ -1,0 +1,6 @@
+{
+  "vendor": "smartcjm",
+  "base_url": "https://terminvereinbarung.leipzig.de/m/leipzig-abh-h/extern/calendar",
+  "uid": "435a0539-e829-4660-ae0b-99a9c418cf68",
+  "steps": "servicessearch_resultsbookingfinish"
+}

--- a/catalog/leipzig/display.json
+++ b/catalog/leipzig/display.json
@@ -1,0 +1,10 @@
+{
+  "label": {
+    "de": "Bürgerbüro-Termine (Anmeldung, Ausweise u. a.)",
+    "en": "Citizen office appointments (registration, ID cards, …)"
+  },
+  "heading": {
+    "de": "Nie wieder freie Bürgerbüro-Termine verpassen",
+    "en": "Never miss a Leipzig appointment again"
+  }
+}

--- a/tests/fixtures/leipzig_abh_with_slots.html
+++ b/tests/fixtures/leipzig_abh_with_slots.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!-- Trimmed from a real leipzig-abh-h search_results page (2026-07-01).
+     Key differences from the leipzig-ba fixture this exercises:
+       * slot buttons carry NO data-testid attributes (older Smart-CJM skin),
+       * the <script> block contains the appointment_reserve function
+         DEFINITION — the parser must not false-positive on script text. -->
+<html lang="de">
+<head><meta charset="utf-8"><title>Stadt Leipzig | Ausländerbehörde | Ausgabe</title></head>
+<body>
+<script>
+	function day_show(date) {
+		$('.day_' + date).show().attr("aria-hidden", "false");
+		$('.timeslot_cards .actions').show().attr("aria-hidden", "false");;
+		window.location.hash = "day_" + date;
+	}
+
+	function appointment_reserve(appointment_datetime, appointment_duration, location, resource) {
+		window.location='/m/leipzig-abh-h/extern/calendar/appointment_reserve?uid=435a0539-e829-4660-ae0b-99a9c418cf68';
+	}
+</script>
+<main>
+  <h1>Auswahl des Termins</h1>
+  <h2>Tage mit verfügbaren Terminen</h2>
+
+  <section class="day_2026-07-02">
+    <h3>Termine Donnerstag, 02.07.2026</h3>
+    <ol>
+      <li><button class="card" id="slot_3da7cfe2-ac16-4668-b6e7-36a6cb51a454" aria-label="Termin um 11:50 Uhr auswählen und zum nächsten Schritt wechseln." onclick="return appointment_reserve('2026-07-02T11%3a50%3a00%2b02%3a00', '10', '8e470125-efec-47cc-bb60-4e3a072e7e67', 'd401d84d-045d-4680-a01e-50150094c435');"><strong>11:50</strong></button></li>
+      <li><button class="card" id="slot_8f704397-8fbd-41ec-8146-6c85bfa0dfb3" aria-label="Termin um 13:20 Uhr auswählen und zum nächsten Schritt wechseln." onclick="return appointment_reserve('2026-07-02T13%3a20%3a00%2b02%3a00', '10', '8e470125-efec-47cc-bb60-4e3a072e7e67', 'd401d84d-045d-4680-a01e-50150094c435');"><strong>13:20</strong></button></li>
+    </ol>
+  </section>
+
+  <section class="day_2026-07-13">
+    <h3>Termine Montag, 13.07.2026</h3>
+    <ol>
+      <li><button class="card" id="slot_11f0a2aa-9d6f-4f2f-8e6c-0f8e3b7c9a10" aria-label="Termin um 08:30 Uhr auswählen und zum nächsten Schritt wechseln." onclick="return appointment_reserve('2026-07-13T08%3a30%3a00%2b02%3a00', '10', '8e470125-efec-47cc-bb60-4e3a072e7e67', 'd401d84d-045d-4680-a01e-50150094c435');"><strong>08:30</strong></button></li>
+    </ol>
+  </section>
+
+  <button id="dates_back" onclick="days_show();">Zurück</button>
+
+  <h2>Ihre bisherigen Angaben</h2>
+  <dl>
+    <dt>Dienstleistung</dt><dd>1x&nbsp;Ausgabe Aufenthaltsdokument</dd>
+    <dt>Standort</dt><dd>Ausländerbehörde Wartebereich Erdgeschoss Prager Straße 126 04317 Leipzig</dd>
+    <dt>Termindauer</dt><dd>10 min.</dd>
+  </dl>
+</main>
+</body>
+</html>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -303,3 +303,34 @@ def test_go_tokens_do_not_collide_across_tenants(client):
     r_abh = client.get(f"/go/leipzig-abh:{enc}", follow_redirects=False)
     assert r_ba.headers["Location"] == "https://up/ba"
     assert r_abh.headers["Location"] == "https://up/abh"
+
+def test_admin_aggregates_upstream_load_per_host_and_labels_tenants(client):
+    """Both Leipzig tenants poll the same physical host: the dashboard must
+    show the combined host load (the rate-limit-relevant number) and label
+    tenant cards from display.json instead of the raw catalog key."""
+    from app.db import connect
+    conn = connect(os.environ["DB_PATH"])
+    today = datetime.utcnow().date().isoformat()
+    for city, polls, reqs in [("leipzig", 10, 30), ("leipzig-abh", 4, 8)]:
+        conn.execute(
+            "INSERT INTO city_state (city, polls_today, polls_total, "
+            "requests_today, requests_total, counts_date, last_polled_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+            (city, polls, polls, reqs, reqs, today))
+    s = stats(conn)
+    host = s["upstream_by_host"]["terminvereinbarung.leipzig.de"]
+    assert host["requests_today"] == 38          # 30 + 8, combined
+    assert host["polls_today"] == 14
+    assert host["tenants"] == ["leipzig", "leipzig-abh"]
+    # Tenant labels come from display.json (admin is English-only).
+    assert "Ausländerbehörde" in s["city_labels"]["leipzig-abh"] or \
+           "Foreigners" in s["city_labels"]["leipzig-abh"]
+    # Dashboard renders the labeled card + the host section.
+    html = client.get("/admin?token=admin-tok").data.decode()
+    assert "Upstream hosts" in html
+    assert "terminvereinbarung.leipzig.de" in html
+    assert "Leipzig-abh" not in html             # raw key no longer shown
+    # Text summary mirrors both.
+    body = render_summary_text(s, now=datetime.utcnow())
+    assert "UPSTREAM HOSTS" in body
+    assert "38 today" in body

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -77,8 +77,9 @@ def test_go_link_from_email_resolves_for_datetime_token(client):
     with patch("app.cycle.get_scraper") as gs, patch("app.cycle.send_digest"):
         sc = MagicMock(); sc.poll.return_value = [slot]; gs.return_value = sc
         run_cycle(conn, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
-    # The email link is /go/<booking_token>; the browser/Flask decodes the path on click.
-    r = client.get(f"/go/{booking_token}", follow_redirects=False)
+    # The email link is /go/<city>:<booking_token> (tenant-prefixed so equal
+    # datetimes on different tenants cannot collide); Flask decodes the path.
+    r = client.get(f"/go/leipzig:{booking_token}", follow_redirects=False)
     assert r.status_code == 302
     assert "appointment_reserve" in r.headers["Location"]
 
@@ -285,3 +286,20 @@ def test_stats_today_counts_gated_by_stale_date(tmp_path):
     up = stats(conn)["upstream_by_city"]["leipzig"]
     assert up["polls_today"] == 0 and up["requests_today"] == 0   # stale day -> 0
     assert up["polls_total"] == 50 and up["requests_total"] == 120  # totals intact
+
+def test_go_tokens_do_not_collide_across_tenants(client):
+    """Two tenants can expose a slot at the SAME wall-clock datetime. The cache
+    key is tenant-prefixed, so both rows exist and each /go link redirects to
+    its own tenant's upstream URL — never the other's."""
+    from app.db import connect
+    conn = connect(os.environ["DB_PATH"])
+    dt = "2026-07-02T11:50:00+02:00"
+    conn.execute("INSERT INTO slots_cache (slot_token, city, upstream_url) "
+                 "VALUES (?, 'leipzig', 'https://up/ba')", (f"leipzig:{dt}",))
+    conn.execute("INSERT INTO slots_cache (slot_token, city, upstream_url) "
+                 "VALUES (?, 'leipzig-abh', 'https://up/abh')", (f"leipzig-abh:{dt}",))
+    enc = dt.replace(":", "%3a").replace("+", "%2b")
+    r_ba = client.get(f"/go/leipzig:{enc}", follow_redirects=False)
+    r_abh = client.get(f"/go/leipzig-abh:{enc}", follow_redirects=False)
+    assert r_ba.headers["Location"] == "https://up/ba"
+    assert r_abh.headers["Location"] == "https://up/abh"

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -338,3 +338,39 @@ def _stack_get(prefix_responses, probe_get_side_effect):
             return r
         return probe_get_side_effect(url, *a, **kw)
     return _side
+
+
+def test_sync_city_skips_location_probe_for_tenant_without_locations_step(tmp_path):
+    """Single-location tenants (e.g. leipzig-abh) have no locations step in
+    their flow — sync must not probe locations (no POSTs at all), report no
+    location drift, and leave the static locations file untouched."""
+    root = tmp_path / "catalog"
+    city = root / "leipzig-abh"
+    city.mkdir(parents=True)
+    (city / "scraper_config.json").write_text(json.dumps({
+        "vendor": "smartcjm",
+        "base_url": "https://terminvereinbarung.leipzig.de/m/leipzig-abh-h/extern/calendar",
+        "uid": "435a0539-e829-4660-ae0b-99a9c418cf68",
+        "steps": "servicessearch_resultsbookingfinish",
+    }))
+    (city / "appointment_type.json").write_text(json.dumps({
+        "Ausgabe  Aufenthaltsdokument": "svc-1",
+    }))
+    (city / "locations.json").write_text(json.dumps({
+        "Ausländerbehörde (Prager Straße 126, Erdgeschoss)": "loc-abh",
+    }))
+    loc_before = (city / "locations.json").read_text()
+
+    http = MagicMock()
+    http.get.return_value = MagicMock(status_code=200, json=lambda: {
+        "success": True,
+        "results": [{"uid": "svc-1", "display_name": "Ausgabe  Aufenthaltsdokument"}],
+    })
+    alerts = []
+    res = catalog_sync.sync_city("leipzig-abh", http,
+                                 alert_fn=lambda **kw: alerts.append(kw),
+                                 catalog_root=root)
+    assert res == {"service_drift": {}, "location_drift": {}}
+    assert alerts == []
+    http.post.assert_not_called()          # no location probing whatsoever
+    assert (city / "locations.json").read_text() == loc_before

--- a/tests/test_delivery_quota.py
+++ b/tests/test_delivery_quota.py
@@ -72,3 +72,36 @@ def test_quota_limited_cycle_serves_longest_waiting_first_and_defers_rest(db):
     assert _has_seen(db, s_new) and not _has_seen(db, s_recent)
     # The deferred subscriber was left untouched → it will resurface next cycle.
     assert _last_notified(db, s_recent) is not None  # unchanged (its old value)
+
+
+def test_render_cap_still_marks_all_matched_slots_seen(db):
+    """More matches than the digest render cap → ONE email, but ALL matched
+    slots recorded as seen, so the omitted ones don't drip-feed follow-up
+    emails on later cycles."""
+    from app.digest import MAX_SLOTS_PER_DIGEST
+    import os
+    os.environ["RESEND_DAILY_QUOTA"] = "100"; os.environ["MAILJET_HOURLY_QUOTA"] = "10"
+    sid = insert_pending(db, email="cap@x.com", city="leipzig", language="de",
+                         filter_=_f(), ttl_days=90); confirm(db, sid)
+    n_total = MAX_SLOTS_PER_DIGEST + 15
+    slots = [Slot(f"2026-07-{(i % 28) + 1:02d}", f"{8 + (i % 10)}:00",
+                  "loc-1", "svc-A", f"tok-{i}") for i in range(n_total)]
+    scraper = MagicMock(); scraper.poll.return_value = slots
+    with patch("app.cycle.get_scraper", return_value=scraper), \
+         patch("app.mail._call_mailjet_batch", return_value=True) as mb, \
+         patch("app.mail._call_resend_batch", return_value=True):
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+    sent_bodies = [i.body for i in mb.call_args_list[0].args[0]]
+    assert len(sent_bodies) == 1                       # one email, not a flood
+    assert sent_bodies[0].count("/go/") == MAX_SLOTS_PER_DIGEST
+    seen = db.execute("SELECT COUNT(*) AS n FROM seen_slots WHERE subscription_id=?",
+                      (sid,)).fetchone()["n"]
+    assert seen == n_total                             # omitted ones seen too
+
+    # A later cycle with the SAME slots sends nothing.
+    db.execute("UPDATE subscriptions SET last_notified_at=NULL WHERE id=?", (sid,))
+    with patch("app.cycle.get_scraper", return_value=scraper), \
+         patch("app.mail._call_mailjet_batch", return_value=True) as mb2, \
+         patch("app.mail._call_resend_batch", return_value=True):
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c2")
+    mb2.assert_not_called()

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -143,3 +143,20 @@ def test_out_of_catalog_location_uuid_renders_uuid_not_crash():
     slots = [Slot("2026-06-12", "09:20", "ghost-loc", "svc-A", "tA")]
     text = _render(sub, slots, catalog=_cat())
     assert "ghost-loc" in text  # raw uuid as the office header, no exception
+
+
+def test_digest_echoes_max_days_ahead_window():
+    from dataclasses import replace
+    sub = _sub("de")
+    sub = replace(sub, sub_filter=replace(sub.sub_filter, max_days_ahead=7))
+    slots = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")]
+    text = _render(sub, slots, catalog=_cat())
+    assert "innerhalb der nächsten 7 Tage" in text
+    text_en = _render(replace(sub, language="en"), slots, catalog=_cat())
+    assert "within the next 7 days" in text_en
+
+
+def test_digest_omits_window_line_when_unlimited():
+    text = _render(_sub("de"), [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")],
+                   catalog=_cat())
+    assert "Zeitraum" not in text

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -112,7 +112,7 @@ def test_slot_line_has_weekday_date_time_and_link():
     text = _render(sub, slots, catalog=_cat())
     line = next(ln for ln in text.splitlines() if "09:20" in ln)
     assert "Fr 12.06." in line                       # 2026-06-12 is a Friday
-    assert "https://x/go/tok-A" in line
+    assert "https://x/go/leipzig:tok-A" in line
 
 
 # ---------- per-slot service only when the filter spans >1 type ----------
@@ -172,7 +172,7 @@ def test_digest_caps_slots_at_soonest_and_summarizes_rest():
     slots = [Slot(f"2026-07-{(i % 28) + 1:02d}", f"{8 + (i % 10)}:00",
                   "loc-1", "svc-A", f"tok-{i}") for i in range(n_total)]
     text = _render(_sub("de"), slots, catalog=_cat())
-    rendered = text.count("/go/tok-")
+    rendered = text.count("/go/leipzig:tok-")
     assert rendered == MAX_SLOTS_PER_DIGEST
     assert "40 weitere passende Termine" in text
     # soonest-first selection: the earliest (day 01, 08:00) is in, and a

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -160,3 +160,35 @@ def test_digest_omits_window_line_when_unlimited():
     text = _render(_sub("de"), [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")],
                    catalog=_cat())
     assert "Zeitraum" not in text
+
+
+def test_digest_caps_slots_at_soonest_and_summarizes_rest():
+    """More matches than MAX_SLOTS_PER_DIGEST → render only the soonest N and
+    one count line for the rest (keeps abundant tenants under Gmail's ~102KB
+    clipping threshold). The soonest slot must survive the cut; the latest
+    must not."""
+    from app.digest import MAX_SLOTS_PER_DIGEST
+    n_total = MAX_SLOTS_PER_DIGEST + 40
+    slots = [Slot(f"2026-07-{(i % 28) + 1:02d}", f"{8 + (i % 10)}:00",
+                  "loc-1", "svc-A", f"tok-{i}") for i in range(n_total)]
+    text = _render(_sub("de"), slots, catalog=_cat())
+    rendered = text.count("/go/tok-")
+    assert rendered == MAX_SLOTS_PER_DIGEST
+    assert "40 weitere passende Termine" in text
+    # soonest-first selection: the earliest (day 01, 08:00) is in, and a
+    # late-July slot beyond the cap horizon is out.
+    soonest = min(slots, key=lambda s: (s.date, s.time_str))
+    latest = max(slots, key=lambda s: (s.date, s.time_str))
+    assert soonest.booking_token in text
+    assert latest.booking_token not in text
+    # sanity: body stays far below Gmail's clipping threshold
+    assert len(text.encode()) < 20_000
+
+
+def test_digest_no_summary_line_when_under_cap():
+    from app.digest import MAX_SLOTS_PER_DIGEST
+    slots = [Slot("2026-07-01", "09:00", "loc-1", "svc-A", f"t{i}")
+             for i in range(MAX_SLOTS_PER_DIGEST)]
+    text = _render(_sub("de"), slots, catalog=_cat())
+    assert "weitere passende Termine" not in text
+    assert text.count("/go/") == MAX_SLOTS_PER_DIGEST

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -70,3 +70,17 @@ def test_max_days_ahead_none_means_no_limit():
                time_window_start=time(0,0), time_window_end=time(23,59))
     assert f.max_days_ahead is None
     assert matches(f, make_slot(date_str="2099-01-01")) is True
+
+def test_max_days_ahead_uses_berlin_local_today_not_utc():
+    """At 22:30 UTC Berlin has already rolled to the next day. 'Today' for the
+    window must be the Berlin date: a slot exactly one Berlin-day ahead matches
+    max_days_ahead=1 even though it is two UTC-days ahead."""
+    from freezegun import freeze_time
+    f = Filter(appointment_types=["svc-A"], locations="all",
+               weekdays=[1,2,3,4,5,6,7],
+               time_window_start=time(0,0), time_window_end=time(23,59),
+               max_days_ahead=1)
+    # 2026-06-01 22:30 UTC == 2026-06-02 00:30 Europe/Berlin (CEST)
+    with freeze_time("2026-06-01 22:30:00"):
+        assert matches(f, make_slot(date_str="2026-06-03")) is True   # Berlin: +1 day
+        assert matches(f, make_slot(date_str="2026-06-04")) is False  # Berlin: +2 days

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -51,3 +51,22 @@ def test_match_time_window():
 def test_invalid_date_string_does_not_match():
     f = make_filter()
     assert matches(f, make_slot(date_str="not-a-date")) is False
+
+def test_max_days_ahead_boundary():
+    from freezegun import freeze_time
+    f = make_filter(weekdays=(1,2,3,4,5,6,7))
+    f = Filter(appointment_types=["svc-A"], locations="all",
+               weekdays=[1,2,3,4,5,6,7],
+               time_window_start=time(0,0), time_window_end=time(23,59),
+               max_days_ahead=7)
+    with freeze_time("2026-06-01"):
+        assert matches(f, make_slot(date_str="2026-06-01")) is True   # today
+        assert matches(f, make_slot(date_str="2026-06-08")) is True   # day 7: inclusive
+        assert matches(f, make_slot(date_str="2026-06-09")) is False  # day 8: out
+
+def test_max_days_ahead_none_means_no_limit():
+    f = Filter(appointment_types=["svc-A"], locations="all",
+               weekdays=[1,2,3,4,5,6,7],
+               time_window_start=time(0,0), time_window_end=time(23,59))
+    assert f.max_days_ahead is None
+    assert matches(f, make_slot(date_str="2099-01-01")) is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,3 +59,23 @@ def test_slot_resource_uuid_is_captured_and_excluded_from_hash():
     c = Slot(date="2026-06-10", time_str="10:30", location_uuid="loc-1",
              service_uuid="svc-B", booking_token="t1", resource_uuid="res-1")
     assert a.hash() != c.hash()
+
+
+def test_filter_json_roundtrip_max_days_ahead():
+    from datetime import time
+    from app.models import Filter
+    f = Filter(appointment_types=["a"], locations="all", weekdays=[1],
+               time_window_start=time(9, 0), time_window_end=time(17, 0),
+               max_days_ahead=7)
+    assert Filter.from_json(f.to_json()).max_days_ahead == 7
+
+
+def test_filter_from_json_without_max_days_ahead_defaults_to_none():
+    """Rows written before the field existed must load as 'no limit'."""
+    import json as _json
+    from app.models import Filter
+    legacy = _json.dumps({
+        "appointment_types": ["a"], "locations": "all", "weekdays": [1],
+        "time_window": {"start": "09:00", "end": "17:00"},
+    })
+    assert Filter.from_json(legacy).max_days_ahead is None

--- a/tests/test_polling_cycle.py
+++ b/tests/test_polling_cycle.py
@@ -163,3 +163,46 @@ def test_cycle_respects_rate_limit(db):
         run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15,
                   cycle_id="c1")
     send_d.assert_not_called()
+
+def test_cycle_window_filter_defers_far_slots_until_they_enter_window(db):
+    """A subscriber with max_days_ahead=7 must only be notified about slots
+    inside the window — and a farther slot must NOT be marked seen, so a later
+    cycle (once the slot is within 7 days) still notifies about it."""
+    from datetime import date, timedelta
+    from freezegun import freeze_time
+    from app.repo import has_seen_slot
+    f = Filter(appointment_types=["svc-A"], locations="all",
+               weekdays=[1,2,3,4,5,6,7],
+               time_window_start=time(0,0), time_window_end=time(23,59),
+               max_days_ahead=7)
+    sid = insert_pending(db, email="w@x.com", city="leipzig",
+                         language="de", filter_=f, ttl_days=90)
+    confirm(db, sid)
+    near = Slot("2026-06-03", "10:00", "loc-1", "svc-A", "t-near")
+    far = Slot("2026-06-20", "10:00", "loc-1", "svc-A", "t-far")
+    with freeze_time("2026-06-01"), \
+         patch("app.cycle.get_scraper") as gs, \
+         patch("app.cycle.send_digest") as send_d:
+        gs.return_value.poll.return_value = [near, far]
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+    send_d.assert_called_once()
+    sent = send_d.call_args.kwargs["matched_slots"]
+    assert [s.booking_token for s in sent] == ["t-near"]
+    # The far slot was never presented, so it must not be marked seen —
+    # otherwise it could never be notified once it enters the window.
+    assert has_seen_slot(db, sid, far.hash()) is False
+
+    # Mocking send_digest bypasses flush_digests, where delivered slots get
+    # recorded — record the near slot's delivery manually, as the flush would.
+    from app.repo import record_seen_slot
+    record_seen_slot(db, sid, near.hash())
+
+    # Two weeks later the same slot is inside the window: it fires now.
+    db.execute("UPDATE subscriptions SET last_notified_at=NULL WHERE id=?", (sid,))
+    with freeze_time("2026-06-15"), \
+         patch("app.cycle.get_scraper") as gs2, \
+         patch("app.cycle.send_digest") as send_d2:
+        gs2.return_value.poll.return_value = [near, far]
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c2")
+    send_d2.assert_called_once()
+    assert [s.booking_token for s in send_d2.call_args.kwargs["matched_slots"]] == ["t-far"]

--- a/tests/test_smartcjm_client.py
+++ b/tests/test_smartcjm_client.py
@@ -216,3 +216,54 @@ def test_poll_session_expired_returns_empty_after_retry():
         MagicMock(text="Session abgelaufen", status_code=200, url="", headers={}),
     ]
     assert poll(plan, http=sess) == []
+
+
+# --- single-location tenant (leipzig-abh: no locations step in the flow) ---
+
+ABH_BASE = "https://terminvereinbarung.leipzig.de/m/leipzig-abh-h/extern/calendar"
+ABH_SVC = "6d72c63a-31a8-4aca-9d46-c9f3f90d39ec"
+
+
+def test_poll_abh_uses_single_search_post_without_locations_step():
+    """leipzig-abh's steps have no locations step: poll must issue exactly ONE
+    POST (services with action_type=search) and parse ITS response as the
+    results page — never a second locations POST."""
+    plan = PollPlan(city="leipzig-abh", appointment_type=ABH_SVC, locations="all")
+    results_html = (
+        '<ol><li><button class="card" onclick="return appointment_reserve('
+        "'2026-07-02T11%3a50%3a00%2b02%3a00', '10', "
+        "'8e470125-efec-47cc-bb60-4e3a072e7e67', 'res-1');\">"
+        '<strong>11:50</strong></button></li></ol>'
+    )
+    sess = _make_session(wsid_redirect_url=f"{ABH_BASE}/?wsid=w&uid=435a0539",
+                         services_html=results_html,
+                         locations_html="<never-requested/>")
+    slots = poll(plan, http=sess)
+    assert sess.post.call_count == 1
+    body = sess.post.call_args_list[0].kwargs["data"]
+    assert "action_type=search" in body
+    assert "step_current=services" in body
+    assert len(slots) == 1
+    assert slots[0].date == "2026-07-02" and slots[0].time_str == "11:50"
+    assert slots[0].service_uuid == ABH_SVC
+
+
+def test_poll_abh_session_expired_retries_single_step_flow():
+    """'Session abgelaufen' on the abh flow must invalidate and retry the
+    SAME single-POST flow once."""
+    plan = PollPlan(city="leipzig-abh", appointment_type=ABH_SVC, locations="all")
+    sess = MagicMock()
+
+    def _get(url, *a, **kw):
+        if "search_result" in url:
+            return MagicMock(url=f"{ABH_BASE}/?wsid=w&uid=4", text="",
+                             status_code=200, headers={})
+        return MagicMock(url=url, text=SERVICES_PAGE_HTML, status_code=200, headers={})
+
+    sess.get.side_effect = _get
+    sess.post.side_effect = [
+        MagicMock(text="Session abgelaufen", status_code=200, url="", headers={}),
+        MagicMock(text="<ol></ol>", status_code=200, url="", headers={}),
+    ]
+    assert poll(plan, http=sess) == []
+    assert sess.post.call_count == 2  # one failed attempt + one retry, no locations POSTs

--- a/tests/test_smartcjm_live.py
+++ b/tests/test_smartcjm_live.py
@@ -110,3 +110,21 @@ def test_live_locations_probe_returns_known_uids(http, scfg, appointment_types):
     assert intersection, \
         f"NO overlap between catalog locations and live probe — flow may have broken.\n" \
         f"catalog={catalog_loc_uids}\nlive={live_loc_uids}"
+
+
+# ---------- leipzig-abh (Ausländerbehörde, single-location tenant) ----------
+
+def test_live_abh_poll_completes_without_raising(http):
+    """Smoke: the abh-h tenant's single-POST flow (no locations step) returns a
+    list without raising, with every slot stamped with the searched service."""
+    abh_dir = REPO_ROOT / "catalog" / "leipzig-abh"
+    types = json.loads((abh_dir / "appointment_type.json").read_text())
+    (target_uid,) = types.values()
+    plan = PollPlan(city="leipzig-abh", appointment_type=target_uid, locations="all")
+    slots = smartcjm.poll(plan, http=http)
+    assert isinstance(slots, list)
+    if slots:
+        assert all(s.service_uuid == target_uid for s in slots)
+        # single-location tenant: every slot is at the ABH building
+        locs = json.loads((abh_dir / "locations.json").read_text())
+        assert {s.location_uuid for s in slots} <= set(locs.values())

--- a/tests/test_smartcjm_parser.py
+++ b/tests/test_smartcjm_parser.py
@@ -33,3 +33,26 @@ def test_parse_no_slots():
 def test_session_expired_returns_empty():
     html = (FIXTURES / "leipzig_session_expired.html").read_text(encoding="utf-8")
     assert parse_slots(html, service_uuid=SVC) == []
+
+
+# --- leipzig-abh-h tenant (Ausländerbehörde): no data-testid on slot buttons ---
+
+ABH_SVC = "6d72c63a-31a8-4aca-9d46-c9f3f90d39ec"   # Ausgabe Aufenthaltsdokument
+ABH_LOC = "8e470125-efec-47cc-bb60-4e3a072e7e67"
+
+
+def test_parse_abh_slots_without_testid_markup():
+    """The abh-h tenant renders the same appointment_reserve buttons but WITHOUT
+    data-testid attributes; the parser must match on the onclick handler. The
+    fixture's <script> block contains the appointment_reserve function
+    definition — it must not produce a phantom slot."""
+    html = (FIXTURES / "leipzig_abh_with_slots.html").read_text(encoding="utf-8")
+    slots = parse_slots(html, service_uuid=ABH_SVC)
+    assert len(slots) == 3   # exactly the fixture's buttons, nothing from <script>
+    assert {(s.date, s.time_str) for s in slots} == {
+        ("2026-07-02", "11:50"), ("2026-07-02", "13:20"), ("2026-07-13", "08:30"),
+    }
+    assert all(s.location_uuid == ABH_LOC for s in slots)
+    assert all(s.service_uuid == ABH_SVC for s in slots)
+    # booking_token keeps the URL-encoded datetime for the upstream query string
+    assert any(s.booking_token == "2026-07-02T11%3a50%3a00%2b02%3a00" for s in slots)

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -101,3 +101,30 @@ def test_ip_ratelimit(client):
         r = client.post("/subscribe", data=_form(email="c@x.com"),
                         headers={"X-Forwarded-For":"1.2.3.4"})
         assert r.status_code == 429
+
+def test_subscribe_stores_max_days_ahead(client):
+    import os, json
+    from unittest.mock import patch
+    from app.db import connect
+    f = _form(email="window@example.com")
+    f["max_days_ahead"] = "7"
+    with patch("app.web._send_confirmation_email", return_value=True):
+        r = client.post("/subscribe", data=f, headers={"X-Forwarded-For": "7.7.7.7"})
+    assert r.status_code == 302
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT filters_json FROM subscriptions WHERE email=?",
+                       ("window@example.com",)).fetchone()
+    assert json.loads(row["filters_json"])["max_days_ahead"] == 7
+
+def test_subscribe_empty_max_days_ahead_means_no_limit(client):
+    import os, json
+    from unittest.mock import patch
+    from app.db import connect
+    f = _form(email="nolimit@example.com")
+    f["max_days_ahead"] = ""
+    with patch("app.web._send_confirmation_email", return_value=True):
+        client.post("/subscribe", data=f, headers={"X-Forwarded-For": "7.7.7.8"})
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT filters_json FROM subscriptions WHERE email=?",
+                       ("nolimit@example.com",)).fetchone()
+    assert json.loads(row["filters_json"])["max_days_ahead"] is None

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -115,7 +115,8 @@ def test_manage_get_prefills_current_filter(tmp_path, monkeypatch):
                locations=[loc_uuid_a, loc_uuid_b],
                weekdays=[2, 4],  # Tue + Thu only
                time_window_start=time(9, 30),
-               time_window_end=time(17, 0))
+               time_window_end=time(17, 0),
+               max_days_ahead=14)
     sid = insert_pending(conn, email="m@x.com", city="leipzig", language="de",
                          filter_=f, ttl_days=90)
     conn.execute("UPDATE subscriptions SET confirmed_at=datetime('now') WHERE id=?", (sid,))
@@ -141,6 +142,8 @@ def test_manage_get_prefills_current_filter(tmp_path, monkeypatch):
     # Time window values.
     assert 'value="09:30"' in html
     assert 'value="17:00"' in html
+    # Max-days-ahead window preselected.
+    assert 'value="14" selected' in html
 
 def test_manage_get_prefills_all_locations(tmp_path, monkeypatch):
     """When `locations == 'all'`, the All-locations checkbox must be checked

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -142,3 +142,22 @@ def test_no_error_banner_on_bare_form(client):
     assert "leider nicht geklappt" not in body
     body_en = client.get("/?lang=en").data.decode().lower()
     assert "didn't go through" not in body_en
+
+
+def test_abh_tenant_form_renders_with_own_copy_and_cross_links(client):
+    """/?city=leipzig-abh renders the Ausländerbehörde tenant: its display.json
+    heading, the Termin-Code note, its service, and a cross-link back to the
+    Bürgerbüro tenant (and vice versa)."""
+    abh = client.get("/?city=leipzig-abh").data.decode()
+    assert "Abhol-Termine bei der Ausländerbehörde" in abh
+    assert "Termin-Code" in abh
+    assert "Ausgabe  Aufenthaltsdokument" in abh
+    assert 'city=leipzig' in abh                      # link back
+    ba = client.get("/").data.decode()
+    assert "city=leipzig-abh" in ba                   # link over
+
+
+def test_unknown_city_redirects_to_default(client):
+    r = client.get("/?city=nope-nothing-here")
+    assert r.status_code == 302
+    assert r.headers["Location"].endswith("/")


### PR DESCRIPTION
The Ausländerbehörde's pickup appointments live on the same Smart-CJM host
as the Bürgerbüros but on their own tenant (leipzig-abh-h). The slot search
is openly viewable; only finalizing a booking needs the personal Termin-Code
from the office's letter — which fits this service's model exactly: we
notify about free pickup slots, the user books on the city site with their
code.

Supporting changes, verified against the live tenant end-to-end:

- parse_slots matches slot buttons by their appointment_reserve onclick
  handler instead of the leipzig-ba skin's data-testid decoration, which
  the abh-h tenant does not render. Verified on a captured real results
  page (1065 slots) and locked in with a trimmed fixture that includes the
  <script> function definition to prove no false positives.
- The scraper flow is now steps-driven: tenants without a locations step
  (single location) go straight from the services POST (action_type=search)
  to the results page. The Session-abgelaufen retry covers both flows.
- New catalog/leipzig-abh (service, location, EN labels, scraper config).
  Service names match the live API byte-for-byte so catalog sync stays
  quiet; sync now skips the locations probe for tenants without a
  locations step.
- Catalogs can carry optional display.json UI copy (label/heading/note).
  The form renders per-tenant heading, an Ausländerbehörde note explaining
  the Termin-Code requirement, and cross-links between tenants. Unknown
  ?city= values redirect to the default instead of erroring.
- Opt-in live smoke test for the abh tenant (LIVE_TESTS=1), run once
  against production during development: full poll flow returns parsed
  slots.