### PR TITLE
Fix List-Unsubscribe: real per-recipient URL + RFC 8058 one-click POST

### DIFF
--- a/app/cycle.py
+++ b/app/cycle.py
@@ -8,7 +8,7 @@ from app.planning import build_plans
 from app.repo import active_subscriptions, has_seen_slot
 from app.scrapers import get_scraper
 from app.http_session import CountingSession
-from app.models import Subscription, Slot, PollPlan
+from app.models import Slot
 
 # Imported here so tests can monkey-patch it.
 from app.digest import send_digest, flush_digests  # noqa: E402

--- a/app/digest.py
+++ b/app/digest.py
@@ -148,7 +148,8 @@ def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
                     [s.hash() for s in matched_slots],
                     cycle_id)
     queued = QueuedDigest(
-        item=Outgoing(to=subscription.email, subject=subj, body=body, idem_key=key),
+        item=Outgoing(to=subscription.email, subject=subj, body=body,
+                      idem_key=key, unsub_url=unsub_url),
         subscription=subscription,
         slots=list(matched_slots),
     )

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -92,6 +92,10 @@ def _send_heartbeats(conn, cfg, *, milestone_days: int, milestone_col: str):
                           primary=cfg.token_secret_primary,
                           previous=cfg.token_secret_previous)
         manage_url = f"{cfg.public_base_url}/manage/{manage_tok}"
+        unsub_tok = sign(row["id"], "unsubscribe",
+                         primary=cfg.token_secret_primary,
+                         previous=cfg.token_secret_previous)
+        unsub_url = f"{cfg.public_base_url}/unsubscribe/{unsub_tok}"
         body = (f"Du bist weiterhin abonniert — dein Filter passt einfach noch nicht. "
                 f"Hier verwalten: {manage_url}"
                 if row["language"] == "de" else
@@ -109,7 +113,8 @@ def _send_heartbeats(conn, cfg, *, milestone_days: int, milestone_col: str):
                 )
                 mail_send(conn, row["email"], subj, body,
                           idem_key=_idem_key(row["id"], [],
-                                             f"heartbeat-{milestone_days}d-{row['id']}"))
+                                             f"heartbeat-{milestone_days}d-{row['id']}"),
+                          unsub_url=unsub_url)
         except Exception:
             pass
 

--- a/app/mail.py
+++ b/app/mail.py
@@ -14,7 +14,19 @@ def _idem_key(subscription_id: int, slot_hashes: list[str], cycle_id: str) -> st
     payload = f"{subscription_id}|{','.join(sorted(slot_hashes))}|{cycle_id}"
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-def _mailjet_message(to: str, subject: str, body: str) -> dict:
+def _unsub_headers(unsub_url: str | None) -> dict:
+    """RFC 8058 one-click unsubscribe headers, only when a REAL per-recipient
+    unsubscribe URL exists. Gmail/Yahoo bulk-sender rules require the target to
+    actually work — a placeholder URL is worse than no header, so mails without
+    a subscriber unsubscribe token (confirmations, developer alerts) send none.
+    """
+    if not unsub_url:
+        return {}
+    return {"List-Unsubscribe": f"<{unsub_url}>",
+            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"}
+
+def _mailjet_message(to: str, subject: str, body: str,
+                     unsub_url: str | None = None) -> dict:
     """One entry of Mailjet's v3.1 `Messages` array (shared by single + batch)."""
     message = {
         "From": {"Email": os.environ["MAILJET_FROM_EMAIL"],
@@ -22,11 +34,10 @@ def _mailjet_message(to: str, subject: str, body: str) -> dict:
         "To":   [{"Email": to}],
         "Subject":  subject,
         "TextPart": body,
-        "Headers":  {
-            "List-Unsubscribe": _list_unsub_header(to),
-            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-        },
     }
+    headers = _unsub_headers(unsub_url)
+    if headers:
+        message["Headers"] = headers
     # From is the validated sending subdomain; Reply-To (optional) routes
     # replies to a real mailbox so the From address can be a subdomain that
     # doesn't itself receive mail.
@@ -35,46 +46,43 @@ def _mailjet_message(to: str, subject: str, body: str) -> dict:
         message["ReplyTo"] = {"Email": reply_to}
     return message
 
-def _resend_email(to: str, subject: str, body: str) -> dict:
+def _resend_email(to: str, subject: str, body: str,
+                  unsub_url: str | None = None) -> dict:
     """One Resend email object (shared by single `/emails` + `/emails/batch`)."""
     payload = {
         "from": f"{os.environ['MAILJET_FROM_NAME']} <{os.environ['MAILJET_FROM_EMAIL']}>",
         "to": [to],
         "subject": subject,
         "text": body,
-        "headers": {
-            "List-Unsubscribe": _list_unsub_header(to),
-            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-        },
     }
+    headers = _unsub_headers(unsub_url)
+    if headers:
+        payload["headers"] = headers
     reply_to = os.environ.get("REPLY_TO_EMAIL")
     if reply_to:
         payload["reply_to"] = reply_to
     return payload
 
-def _call_mailjet(to: str, subject: str, body: str) -> Any:
+def _call_mailjet(to: str, subject: str, body: str,
+                  unsub_url: str | None = None) -> Any:
     return requests.post(
         "https://api.mailjet.com/v3.1/send",
         auth=(os.environ["MAILJET_API_KEY"], os.environ["MAILJET_API_SECRET"]),
-        json={"Messages": [_mailjet_message(to, subject, body)]},
+        json={"Messages": [_mailjet_message(to, subject, body, unsub_url)]},
         timeout=30,
     )
 
-def _call_resend(to: str, subject: str, body: str) -> Any:
+def _call_resend(to: str, subject: str, body: str,
+                 unsub_url: str | None = None) -> Any:
     return requests.post(
         "https://api.resend.com/emails",
         headers={"Authorization": f"Bearer {os.environ['RESEND_API_KEY']}"},
-        json=_resend_email(to, subject, body),
+        json=_resend_email(to, subject, body, unsub_url),
         timeout=30,
     )
 
-def _list_unsub_header(to_email: str) -> str:
-    # Caller is expected to inject the actual unsubscribe URL via the
-    # mail-template flow; this is a placeholder header until tied in.
-    return f"<{os.environ.get('PUBLIC_BASE_URL', '')}/unsubscribe>"
-
 def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
-         *, idem_key: str) -> None:
+         *, idem_key: str, unsub_url: str | None = None) -> None:
     """Send `body` to `to`. Idempotent on `idem_key`.
 
     Order: claim the idempotency row FIRST (atomic INSERT OR IGNORE), then
@@ -91,13 +99,13 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
     if cur.rowcount == 0:
         return  # already claimed by an earlier call
     try:
-        resp = _call_mailjet(to, subject, body)
+        resp = _call_mailjet(to, subject, body, unsub_url)
         provider = "mailjet"
         # Fail over to Resend on ANY Mailjet error (4xx incl. 401/403 account
         # blocks, and 5xx/429), not just transient ones — a blocked Mailjet
         # account returns 401, and that's exactly when the fallback must engage.
         if resp.status_code >= 400 and os.environ.get("RESEND_API_KEY"):
-            resp = _call_resend(to, subject, body)
+            resp = _call_resend(to, subject, body, unsub_url)
             provider = "resend"
         if resp.status_code >= 400:
             raise MailFailed(f"provider failed; last status {resp.status_code}")
@@ -127,6 +135,9 @@ class Outgoing:
     subject: str
     body: str
     idem_key: str
+    # Per-recipient one-click unsubscribe URL; None for mails that have no
+    # subscriber unsubscribe semantics (confirmations, developer alerts).
+    unsub_url: str | None = None
 
 @dataclass
 class BatchResult:
@@ -138,7 +149,8 @@ def _call_mailjet_batch(items: list[Outgoing]) -> bool:
     resp = requests.post(
         "https://api.mailjet.com/v3.1/send",
         auth=(os.environ["MAILJET_API_KEY"], os.environ["MAILJET_API_SECRET"]),
-        json={"Messages": [_mailjet_message(i.to, i.subject, i.body) for i in items]},
+        json={"Messages": [_mailjet_message(i.to, i.subject, i.body, i.unsub_url)
+              for i in items]},
         timeout=60,
     )
     return resp.status_code < 400
@@ -147,7 +159,7 @@ def _call_resend_batch(items: list[Outgoing]) -> bool:
     resp = requests.post(
         "https://api.resend.com/emails/batch",
         headers={"Authorization": f"Bearer {os.environ['RESEND_API_KEY']}"},
-        json=[_resend_email(i.to, i.subject, i.body) for i in items],
+        json=[_resend_email(i.to, i.subject, i.body, i.unsub_url) for i in items],
         timeout=60,
     )
     return resp.status_code < 400

--- a/app/web.py
+++ b/app/web.py
@@ -5,7 +5,7 @@ from datetime import time as time_cls
 from urllib.parse import urlencode
 from flask import Flask, request, render_template, redirect
 from app.config import load_config
-from app.db import connect, init_schema, transaction
+from app.db import connect, transaction
 from app.catalog import load_catalog, available_cities, CatalogError
 from app.models import Filter
 from app.repo import insert_pending, active_subscriptions, confirm, soft_delete
@@ -352,7 +352,9 @@ def create_app() -> Flask:
         return render_template("confirmed.html", lang=lang,
                                kofi_url=cfg.kofi_url), 200
 
-    @app.route("/unsubscribe/<token>")
+    # POST is the RFC 8058 one-click unsubscribe mail clients send to the
+    # List-Unsubscribe URL; GET is the human clicking the link in the body.
+    @app.route("/unsubscribe/<token>", methods=["GET", "POST"])
     def unsubscribe_route(token):
         cfg = app.config["TERMINE_CONFIG"]
         try:

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -147,3 +147,16 @@ def test_pending_row_blocks_second_call_after_crash(db):
         send(db, "alice@example.com", "subj", "body", idem_key="k5")
     mj.assert_not_called()
     re_.assert_not_called()
+
+def test_unsub_headers_only_with_real_url(monkeypatch, mailjet_env):
+    """RFC 8058 headers must carry the per-recipient unsubscribe URL when given,
+    and be ABSENT otherwise — a placeholder/dead URL is worse than no header."""
+    seen, fake = _capture()
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_mailjet("a@x.com", "s", "b", "https://x/unsubscribe/tok123")
+    h = seen["json"]["Messages"][0]["Headers"]
+    assert h["List-Unsubscribe"] == "<https://x/unsubscribe/tok123>"
+    assert h["List-Unsubscribe-Post"] == "List-Unsubscribe=One-Click"
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_mailjet("a@x.com", "s", "b")   # no unsub semantics (e.g. confirmation)
+    assert "Headers" not in seen["json"]["Messages"][0]

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -183,3 +183,15 @@ def test_manage_get_prefills_all_locations(tmp_path, monkeypatch):
     # No individual location should be checked.
     for loc_uuid in cat.locations.values():
         assert f'value="{loc_uuid}" checked' not in html
+
+def test_one_click_unsubscribe_post(client):
+    """Mail clients POST to the List-Unsubscribe URL (RFC 8058); the route must
+    accept it and actually unsubscribe."""
+    c, sid = client
+    r = c.post(f"/unsubscribe/{_sign(sid, 'unsubscribe')}")
+    assert r.status_code == 200
+    import os
+    from app.db import connect
+    row = connect(os.environ["DB_PATH"]).execute(
+        "SELECT deleted_at FROM subscriptions WHERE id=?", (sid,)).fetchone()
+    assert row["deleted_at"] is not None


### PR DESCRIPTION
Repo-wide review follow-up. One real deliverability bug found and fixed, plus minor hygiene.

## The bug
Every outgoing email set `List-Unsubscribe: <PUBLIC_BASE_URL/unsubscribe>` — a **dead URL** (the route requires a token) — and declared `List-Unsubscribe-Post: One-Click`, while `/unsubscribe/<token>` only accepted GET. Gmail/Yahoo bulk-sender rules require a *working* one-click target; a broken one is worse for deliverability than none.

## The fix
- `Outgoing` / `send()` carry an optional per-recipient `unsub_url`; the RFC 8058 headers are emitted **only when a real URL exists** and omitted otherwise (confirmations, developer alerts).
- **Digests** and **heartbeat emails** now put the subscriber's real tokenized unsubscribe URL in the header.
- `/unsubscribe/<token>` accepts **POST** (the one-click request) in addition to GET, and actually unsubscribes on it.
- Hygiene: dropped unused imports (`web.init_schema`, `cycle.Subscription/PollPlan`).

## Tests
206 pass (+2): header carries the real URL when given / absent otherwise; one-click POST soft-deletes the subscription.

Reviewed but intentionally untouched: the `datetime.utcnow()` deprecation warnings (broad, cosmetic) and the pre-existing `catalog_sync`/`smartcjm` POST-body duplication.