### PR TITLE
Add per-tenant poll_interval_seconds

### DIFF
--- a/app/cycle.py
+++ b/app/cycle.py
@@ -13,6 +13,49 @@ from app.models import Slot
 # Imported here so tests can monkey-patch it.
 from app.digest import send_digest, flush_digests  # noqa: E402
 
+
+def _poll_interval_s(city: str) -> int:
+    """Per-tenant minimum seconds between polls (scraper_config key
+    `poll_interval_seconds`, default 60 = every cycle). Lets a tenant honor a
+    mandated slower cadence — e.g. Berlin's ZMS team requires >=180s between
+    requests — without changing the poller's one-minute heartbeat."""
+    try:
+        from app.catalog import load_catalog
+        return int(load_catalog(city).scraper_config.get("poll_interval_seconds", 60))
+    except Exception:
+        return 60
+
+
+def _due_cities(conn: sqlite3.Connection, cities: set[str]) -> set[str]:
+    """Cities whose poll interval has elapsed since city_state.last_polled_at.
+
+    Default-cadence cities (<=60s) are always due. The 5s grace absorbs cycle
+    -boundary jitter so a 180s interval polls every 3rd cycle, not every 4th.
+    Unparseable or missing timestamps count as due (fail open: poll)."""
+    due: set[str] = set()
+    now = datetime.utcnow()
+    for city in cities:
+        interval = _poll_interval_s(city)
+        if interval <= 60:
+            due.add(city)
+            continue
+        row = conn.execute(
+            "SELECT last_polled_at FROM city_state WHERE city=?", (city,)
+        ).fetchone()
+        last = row["last_polled_at"] if row else None
+        if not last:
+            due.add(city)
+            continue
+        try:
+            elapsed = (now - datetime.fromisoformat(last)).total_seconds()
+        except ValueError:
+            due.add(city)
+            continue
+        if elapsed >= interval - 5:
+            due.add(city)
+    return due
+
+
 def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
               rate_limit_minutes: int, cycle_id: str,
               cfg=None,
@@ -32,7 +75,14 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
     cities_polled: set[str] = set()
     polls_delta: dict[str, int] = {}
     requests_delta: dict[str, int] = {}
+    # Skip tenants whose per-tenant poll interval hasn't elapsed. A skipped
+    # city is left out of cities_polled entirely: its canary, counters, and
+    # last_polled_at stay untouched, and its subscribers simply see no new
+    # candidates this cycle.
+    due = _due_cities(conn, {p.city for p in plans})
     for p in plans:
+        if p.city not in due:
+            continue
         cities_polled.add(p.city)
         # Snapshot the HTTP-request counter so we can attribute the requests
         # this single poll makes to its city (a CountingSession exposes it; a

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,6 +54,14 @@ failing:
 
 Delivery mix over the last 7 days is visible on `/admin`.
 
+## Polling cadence
+
+The poller wakes once a minute, but each tenant can set
+`poll_interval_seconds` in its `catalog/<tenant>/scraper_config.json` to be
+polled less often (e.g. 180 for a city that mandates one request per three
+minutes). Skipped cycles leave the tenant's counters, canary, and
+last-polled timestamp untouched.
+
 ## Load testing
 
 `scripts/loadtest.py` measures sign-up write contention and `run_cycle` time at

--- a/tests/test_polling_cycle.py
+++ b/tests/test_polling_cycle.py
@@ -206,3 +206,46 @@ def test_cycle_window_filter_defers_far_slots_until_they_enter_window(db):
         run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c2")
     send_d2.assert_called_once()
     assert [s.booking_token for s in send_d2.call_args.kwargs["matched_slots"]] == ["t-far"]
+
+def test_poll_interval_skips_city_until_due(db):
+    """A tenant with poll_interval_seconds=180 is skipped while its interval
+    hasn't elapsed (no poll, no counter/last_polled_at update) and polled once
+    it has. Default-cadence tenants are unaffected (covered by every other
+    test in this file)."""
+    sid = insert_pending(db, email="a@x.com", city="leipzig",
+                         language="de", filter_=_f(["svc-A"]), ttl_days=90)
+    confirm(db, sid)
+    # last polled 60s ago; interval 180 → not due
+    db.execute("INSERT INTO city_state (city, last_polled_at, polls_total) "
+               "VALUES ('leipzig', datetime('now','-60 seconds'), 7)")
+    with patch("app.cycle._poll_interval_s", return_value=180), \
+         patch("app.cycle.get_scraper") as gs, \
+         patch("app.cycle.send_digest") as send_d:
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+    gs.return_value.poll.assert_not_called()
+    send_d.assert_not_called()
+    row = db.execute("SELECT polls_total FROM city_state WHERE city='leipzig'").fetchone()
+    assert row["polls_total"] == 7          # untouched — not even a zero-delta write
+
+    # 200s ago → due
+    db.execute("UPDATE city_state SET last_polled_at=datetime('now','-200 seconds') "
+               "WHERE city='leipzig'")
+    with patch("app.cycle._poll_interval_s", return_value=180), \
+         patch("app.cycle.get_scraper") as gs2, \
+         patch("app.cycle.send_digest"):
+        gs2.return_value.poll.return_value = []
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c2")
+    assert gs2.return_value.poll.called
+
+
+def test_poll_interval_fails_open_without_last_polled(db):
+    """No city_state row yet (first ever cycle) → the tenant is due."""
+    sid = insert_pending(db, email="b@x.com", city="leipzig",
+                         language="de", filter_=_f(["svc-A"]), ttl_days=90)
+    confirm(db, sid)
+    with patch("app.cycle._poll_interval_s", return_value=600), \
+         patch("app.cycle.get_scraper") as gs, \
+         patch("app.cycle.send_digest"):
+        gs.return_value.poll.return_value = []
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15, cycle_id="c1")
+    assert gs.return_value.poll.called


### PR DESCRIPTION
Groundwork for new cities: some upstreams mandate a slower polling cadence than our one-minute heartbeat (Berlin's ZMS team requires ≥180s between requests; SaaS-hosted Smart-CJM instances like Halle sit behind stricter WAFs where gentler is wiser).

## What
- A tenant can set `poll_interval_seconds` in its `catalog/<tenant>/scraper_config.json`; the poller then polls it only when that interval has elapsed since `city_state.last_polled_at`.
- Skipped cycles leave the tenant's canary, counters, and last-polled timestamp untouched.
- Absent key (or ≤60) keeps today's every-cycle behavior — **no change for existing tenants**.
- 5s grace absorbs cycle-boundary jitter (a 180s interval polls every 3rd cycle, not every 4th); missing/unparseable timestamps fail open (poll).
- Documented under "Polling cadence" in the deployment guide.

## Tests
208 pass (+2): interval tenant skipped while not due (no poll, counters untouched) then polled once due; first-ever cycle (no city_state row) polls immediately.

## Why now
This is the concrete "we already honor any rate you set" capability to cite in the Berlin API-access request, and it's needed before onboarding any mandated-cadence tenant.