### PR TITLE
Add live-site link to README; update repo links after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Termine-Notifier
+# Bürgerwecker
 
 Free email notifications for free Amt appointments in German cities.
+
+**Live: [buergerwecker.de](https://buergerwecker.de)**
 
 **v1 covers Leipzig:** the Bürgerbüros (e.g. Wohnsitzanmeldung, Ausweise) and
 the Ausländerbehörde (residence-document pickup). Support for more cities may

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -285,7 +285,7 @@
       <br>
       {% if lang == 'en' %}Built by{% else %}Erstellt von{% endif %}
       <a href="https://jakubwaller.eu" rel="author">Jakub Waller</a> ·
-      <a href="https://github.com/jakubwaller/termine-notifier">{% if lang == 'en' %}Source code{% else %}Quellcode{% endif %}</a>
+      <a href="https://github.com/jakubwaller/buergerwecker">{% if lang == 'en' %}Source code{% else %}Quellcode{% endif %}</a>
     </footer>
   </div>
 </body>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,7 +134,7 @@ If `terminvereinbarung.leipzig.de` starts returning 403 for the Pi's IP:
    booking, polling once per minute (a handful of requests per minute; well
    under 1 req/sec even at the `MAX_PLANS_PER_CITY` cap), GDPR-compliant,
    open source at
-   `github.com/jakubwaller/termine-notifier`. Ask if there is a way to
+   `github.com/jakubwaller/buergerwecker`. Ask if there is a way to
    continue operation that the city would accept.
 3. Do NOT attempt to rotate IPs or use proxies — this is ethically
    worse than the polling itself and undermines the legal posture.


### PR DESCRIPTION
- README: retitle to Bürgerwecker, add prominent link to the live site (repo visitors — e.g. from the article's source-code link — should find the service in one click).
- Footer + deployment docs: point at the renamed repo `jakubwaller/buergerwecker` (old URL redirects, but no reason to rely on it).