### PR TITLE
Rename page titles to Bürgerwecker

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>{% block title %}Termine-Notifier{% endblock %}</title>
+  <title>{% block title %}Bürgerwecker{% endblock %}</title>
   <style>
     :root {
       --bg: #f5f5f7;

--- a/app/templates/confirmed.html
+++ b/app/templates/confirmed.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{% if lang == 'en' %}Subscription confirmed{% else %}Anmeldung bestätigt{% endif %} · Termine-Notifier{% endblock %}
+{% block title %}{% if lang == 'en' %}Subscription confirmed{% else %}Anmeldung bestätigt{% endif %} · Bürgerwecker{% endblock %}
 {% block content %}
   <div class="notice notice-success" role="status">
     {% if lang == 'en' %}

--- a/app/templates/result.html
+++ b/app/templates/result.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ heading }} · Termine-Notifier{% endblock %}
+{% block title %}{{ heading }} · Bürgerwecker{% endblock %}
 {% block content %}
   <div class="notice notice-{{ kind or 'success' }}" role="status">
     <strong>{{ badge }}</strong>


### PR DESCRIPTION
Browser tab still showed Termine-Notifier; page titles now match the brand/domain. Developer-alert subject prefixes ([termine-notifier]) left unchanged.