### PR TITLE
Brand admin page as Bürgerwecker; identify poller via User-Agent

### DIFF
--- a/app/http_session.py
+++ b/app/http_session.py
@@ -14,6 +14,11 @@ class CountingSession(requests.Session):
     def __init__(self) -> None:
         super().__init__()
         self.request_count = 0
+        # Identify ourselves to upstream (ethical-scraping stance: cities can
+        # see who is polling and how to reach us).
+        self.headers["User-Agent"] = (
+            "Buergerwecker/1.0 (+https://buergerwecker.de)"
+        )
 
     def request(self, *args, **kwargs):  # type: ignore[override]
         self.request_count += 1

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Admin · Leipzig-Termine{% endblock %}
+{% block title %}Admin · Bürgerwecker{% endblock %}
 
 {% block head %}
 <style>
@@ -60,7 +60,7 @@
 
 {% block content %}
   {% set s = stats %}
-  <h1>Admin <span class="adm-title-sub">· Leipzig-Termine</span></h1>
+  <h1>Admin <span class="adm-title-sub">· Bürgerwecker</span></h1>
   <p class="adm-caption">Internal ops dashboard · times in your local zone (hover for UTC).</p>
 
   <section class="adm-section">


### PR DESCRIPTION
- Admin page title/heading: Leipzig-Termine → Bürgerwecker.
- CountingSession now sends `Buergerwecker/1.0 (+https://buergerwecker.de)` instead of requests' default UA — the city can see who is polling and where to find the project.