### PR TITLE
Rename dev-alert subject prefix to [buergerwecker]

### DIFF
--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -160,7 +160,7 @@ def _check_parser_canary(conn, cfg):
                 f"(> {cfg.parser_canary_threshold_hours}h).")
         try:
             mail_send(conn, cfg.developer_email,
-                      f"[termine-notifier] parser canary: {city}",
+                      f"[buergerwecker] parser canary: {city}",
                       body,
                       idem_key=_idem_key(0, [], f"canary-{city}-{now.date()}"))
             conn.execute(
@@ -188,7 +188,7 @@ def _check_backup_health(conn, cfg):
         return
     try:
         mail_send(conn, cfg.developer_email,
-                  "[termine-notifier] backup is stale",
+                  "[buergerwecker] backup is stale",
                   "meta.last_backup_at is missing or older than 48h. "
                   "Check the backup container logs and /mnt/backup for "
                   "BACKUP-FAIL / BACKUP-METAFAIL sentinel files.",
@@ -223,7 +223,7 @@ def _sync_catalogs(conn, cfg):
         body = "\n".join(lines)
         try:
             mail_send(conn, cfg.developer_email,
-                      f"[termine-notifier] catalog drift: {city}",
+                      f"[buergerwecker] catalog drift: {city}",
                       body,
                       idem_key=_idem_key(0, [],
                                          f"catalog-drift-{city}-{datetime.utcnow().date()}"))
@@ -243,7 +243,7 @@ def _send_summary_email(conn, cfg):
     s = stats(conn)
     body = render_summary_text(s, now=datetime.utcnow())
     try:
-        mail_send(conn, cfg.developer_email, "[termine-notifier] ops summary", body,
+        mail_send(conn, cfg.developer_email, "[buergerwecker] ops summary", body,
                   idem_key=_idem_key(0, [], f"summary-{datetime.utcnow().date()}"))
     except Exception:
         pass

--- a/app/mail.py
+++ b/app/mail.py
@@ -299,7 +299,7 @@ def maybe_quota_alert(conn: sqlite3.Connection, cfg, *, deferred: int) -> None:
         except ValueError:
             pass
     pct = round(used / cfg.resend_daily_quota * 100) if cfg.resend_daily_quota else 0
-    subject = "[termine-notifier] email quota running low"
+    subject = "[buergerwecker] email quota running low"
     body = (
         f"Resend usage in the last 24h: {used}/{cfg.resend_daily_quota} ({pct}%).\n"
         f"Notifications deferred this cycle for lack of quota: {deferred}.\n\n"

--- a/app/poller.py
+++ b/app/poller.py
@@ -57,7 +57,7 @@ def _maybe_alert(conn, cfg, last_error: str) -> None:
         body = (f"Poller has been failing repeatedly. Last error:\n\n{last_error}\n\n"
                 f"Check logs: docker compose logs poller")
         mail_send(conn, cfg.developer_email,
-                  "[termine-notifier] poller failure burst",
+                  "[buergerwecker] poller failure burst",
                   body,
                   idem_key=_idem_key(0, [], f"alert-{datetime.utcnow().date()}"))
         conn.execute(

--- a/tests/test_smartcjm_live.py
+++ b/tests/test_smartcjm_live.py
@@ -54,7 +54,7 @@ def appointment_types():
 @pytest.fixture
 def http():
     s = requests.Session()
-    s.headers["User-Agent"] = "termine-notifier/live-test (buergerwecker.de)"
+    s.headers["User-Agent"] = "Buergerwecker/live-test (+https://buergerwecker.de)"
     return s
 
 


### PR DESCRIPTION
Developer alert/ops emails now use the [buergerwecker] prefix; live-test UA aligned with the new poller UA format.