### PR TITLE
fix(scrapers): register leipzig-abh in the scraper registry

### DIFF
--- a/app/scrapers/__init__.py
+++ b/app/scrapers/__init__.py
@@ -26,6 +26,7 @@ class UnsupportedCity(Exception):
 
 _REGISTRY: dict[str, ModuleType] = {
     "leipzig": smartcjm,
+    "leipzig-abh": smartcjm,
     # When adding Hamburg, etc.:
     #   from app.scrapers import odcontrols
     #   "hamburg": odcontrols,

--- a/tests/test_scraper_registry.py
+++ b/tests/test_scraper_registry.py
@@ -1,0 +1,16 @@
+"""Every city the catalog offers MUST resolve to a scraper.
+
+run_cycle swallows per-plan scraper errors (a broken city must not take down
+the others), so an unregistered city fails silently: people sign up, the
+poller raises UnsupportedCity every cycle, and nobody is ever notified.
+leipzig-abh shipped exactly this way — catalog present, registry entry
+missing — which this invariant would have caught.
+"""
+from app.catalog import available_cities
+from app.scrapers import get_scraper
+
+
+def test_every_catalog_city_resolves_to_a_scraper():
+    for city in available_cities():
+        module = get_scraper(city)
+        assert callable(module.poll), city


### PR DESCRIPTION
get_scraper("leipzig-abh") raised `UnsupportedCity` — the registry only listed `leipzig`. Because `run_cycle` swallows per-plan scraper errors, the failure mode was fully silent: an ABH subscriber signs up, every poll raises, nobody is notified, nothing is logged loudly.

Nobody was hit yet only because a tenant is polled exclusively once it has an active subscription.

**Fix:** one-line registry entry (`leipzig-abh` → smartcjm) + an invariant test that every `available_cities()` entry resolves to a scraper, so a future catalog-without-registry city fails CI instead of failing subscribers.

Recommend merging + deploying before Wednesday.