### PR TITLE
feat(admin): show per-provider monthly email quota usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ RESEND_API_KEY=
 # Raise these to match your plan after upgrading.
 RESEND_DAILY_QUOTA=100
 MAILJET_HOURLY_QUOTA=10
+# Monthly caps, display-only: the /admin "Email quota" section shows
+# month-to-date sends against these (free tiers: Mailjet 6000/mo, Resend
+# 3000/mo). They do NOT gate delivery — the rolling-window caps above do.
+MAILJET_MONTHLY_QUOTA=6000
+RESEND_MONTHLY_QUOTA=3000
 # Order digests try providers. Mailjet-first routes notification volume through
 # Mailjet so its account sees traffic (needed to get the new-sender throttle
 # lifted); Resend takes the overflow. Flip to "resend,mailjet" once Mailjet's

--- a/app/admin.py
+++ b/app/admin.py
@@ -58,8 +58,14 @@ def render_summary_text(s: dict, *, now: datetime) -> str:
            f"  Signups                24h {s['signups_last_24h']} · 7d {s['signups_last_7d']}",
            f"  Digests sent (7d)      {s['digests_sent_last_7d']}",
            f"  Emails sent (total)    {s['emails_sent_total']}",
-           f"  Delivery (7d)          {prov_str}",
-           f"  Slots cached           {s['slots_cached']}",
+           f"  Delivery (7d)          {prov_str}"]
+    for p, u in sorted((s.get("email_usage") or {}).items()):
+        month = (f"{u['month']}/{u['month_quota']}" if u.get("month_quota")
+                 else str(u.get("month", 0)))
+        today = (f"{u['today']}/{u['day_quota']}" if u.get("day_quota")
+                 else str(u.get("today", 0)))
+        out.append(f"  Quota {p:<17}month {month} · today {today}")
+    out += [f"  Slots cached           {s['slots_cached']}",
            "",
            "NOTIFICATIONS (appointment slots delivered to subscribers)",
            f"  Subscribers notified   24h {s.get('notifications_24h', 0)}"
@@ -114,7 +120,41 @@ def render_summary_text(s: dict, *, now: datetime) -> str:
     return "\n".join(out)
 
 
-def stats(conn: sqlite3.Connection) -> dict:
+def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
+    """Month-to-date + today send counts per provider, with configured caps.
+
+    Reads the durable email_send_counts table (survives the 14-day
+    sent_idempotency prune), so the admin page answers "how far into the
+    free-tier quota are we?" without logging into the provider dashboards.
+    Days/months are UTC — an approximation of each provider's own reset cycle.
+    """
+    caps = {
+        "mailjet": {"month_quota": getattr(cfg, "mailjet_monthly_quota", None),
+                    "day_quota":   getattr(cfg, "mailjet_daily_quota", None)},
+        "resend":  {"month_quota": getattr(cfg, "resend_monthly_quota", None),
+                    "day_quota":   getattr(cfg, "resend_daily_quota", None)},
+    }
+    usage = {p: {"month": 0, "today": 0, **caps[p]} for p in caps}
+    try:
+        rows = conn.execute(
+            "SELECT provider, "
+            "  SUM(n) AS month, "
+            "  SUM(CASE WHEN day = date('now') THEN n ELSE 0 END) AS today "
+            "FROM email_send_counts "
+            "WHERE day >= date('now', 'start of month') "
+            "GROUP BY provider"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return usage  # pre-migration DB; counters not available yet
+    for r in rows:
+        u = usage.setdefault(r["provider"],
+                             {"month_quota": None, "day_quota": None})
+        u["month"] = r["month"]
+        u["today"] = r["today"]
+    return usage
+
+
+def stats(conn: sqlite3.Connection, cfg=None) -> dict:
     def scalar(q, *args):
         row = conn.execute(q, args).fetchone()
         return row[0] if row else 0
@@ -274,6 +314,7 @@ def stats(conn: sqlite3.Connection) -> dict:
                    "AND last_notified_at IS NULL"),
         "last_notification": last_notification,
         "emails_by_provider_7d": provider_7d,
+        "email_usage": _email_usage(conn, cfg),
         "last_failure_alert_at": meta_val("last_failure_alert_at"),
         "last_housekeeping_at": meta_val("last_housekeeping_at"),
         "last_backup_at":       meta_val("last_backup_at"),

--- a/app/config.py
+++ b/app/config.py
@@ -9,8 +9,10 @@ class Config:
     mailjet_from_email: str
     mailjet_from_name: str
     mailjet_daily_quota: int
+    mailjet_monthly_quota: int
     resend_api_key: str
     resend_daily_quota: int
+    resend_monthly_quota: int
     mailjet_hourly_quota: int
     quota_alert_threshold_pct: int
     email_provider_order: tuple
@@ -56,6 +58,10 @@ def load_config() -> Config:
         # match Resend's free tier (100/day) and the current Mailjet allowance
         # (10/hour). Raise these after upgrading to a paid plan.
         resend_daily_quota=int(os.environ.get("RESEND_DAILY_QUOTA", "100")),
+        # Monthly caps are display-only (admin quota view): free tiers allow
+        # Mailjet 6000/mo and Resend 3000/mo.
+        mailjet_monthly_quota=int(os.environ.get("MAILJET_MONTHLY_QUOTA", "6000")),
+        resend_monthly_quota=int(os.environ.get("RESEND_MONTHLY_QUOTA", "3000")),
         mailjet_hourly_quota=int(os.environ.get("MAILJET_HOURLY_QUOTA", "10")),
         quota_alert_threshold_pct=int(os.environ.get("QUOTA_ALERT_THRESHOLD_PCT", "80")),
         # Order in which providers are tried for notification digests. Default

--- a/app/db.py
+++ b/app/db.py
@@ -41,6 +41,13 @@ CREATE TABLE IF NOT EXISTS sent_idempotency (
 );
 CREATE INDEX IF NOT EXISTS idx_sent_idem_at ON sent_idempotency(sent_at);
 
+CREATE TABLE IF NOT EXISTS email_send_counts (
+  provider TEXT NOT NULL,
+  day      TEXT NOT NULL,
+  n        INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (provider, day)
+);
+
 CREATE TABLE IF NOT EXISTS meta (
   key        TEXT PRIMARY KEY,
   value      TEXT NOT NULL,
@@ -134,6 +141,20 @@ def init_schema(conn: sqlite3.Connection) -> None:
     _add_missing_columns(conn, "subscriptions", {
         "confirmation_sent_at": "TIMESTAMP",
     })
+    # Durable per-day send counters power the admin page's provider-quota view.
+    # sent_idempotency only lives 14 days (housekeeping prune), so month-to-date
+    # can't be derived from it — seed the counters once from whatever history is
+    # still there. INSERT OR IGNORE keeps the concurrent poller+web init race
+    # harmless (first writer wins, second is a no-op).
+    empty = conn.execute(
+        "SELECT NOT EXISTS (SELECT 1 FROM email_send_counts)"
+    ).fetchone()[0]
+    if empty:
+        conn.execute(
+            "INSERT OR IGNORE INTO email_send_counts (provider, day, n) "
+            "SELECT provider, date(sent_at), COUNT(*) FROM sent_idempotency "
+            "WHERE provider != 'pending' GROUP BY provider, date(sent_at)"
+        )
     conn.execute(
         "INSERT INTO meta (key, value) VALUES ('schema_version', ?) "
         "ON CONFLICT (key) DO UPDATE SET value=excluded.value, "

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -240,7 +240,7 @@ def _sync_catalogs(conn, cfg):
 
 def _send_summary_email(conn, cfg):
     from app.admin import stats, render_summary_text
-    s = stats(conn)
+    s = stats(conn, cfg)
     body = render_summary_text(s, now=datetime.utcnow())
     try:
         mail_send(conn, cfg.developer_email, "[buergerwecker] ops summary", body,

--- a/app/mail.py
+++ b/app/mail.py
@@ -81,6 +81,17 @@ def _call_resend(to: str, subject: str, body: str,
         timeout=30,
     )
 
+def _record_send_count(conn: sqlite3.Connection, provider: str, n: int = 1) -> None:
+    """Bump the durable per-day counter behind the admin quota view. Days are
+    UTC (matching sent_at's CURRENT_TIMESTAMP), an approximation of the
+    providers' own daily/monthly reset boundaries."""
+    conn.execute(
+        "INSERT INTO email_send_counts (provider, day, n) "
+        "VALUES (?, date('now'), ?) "
+        "ON CONFLICT (provider, day) DO UPDATE SET n = n + excluded.n",
+        (provider, n),
+    )
+
 def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
          *, idem_key: str, unsub_url: str | None = None) -> None:
     """Send `body` to `to`. Idempotent on `idem_key`.
@@ -116,6 +127,7 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
         "UPDATE sent_idempotency SET provider=? WHERE idem_key=?",
         (provider, idem_key),
     )
+    _record_send_count(conn, provider)
 
 
 # --------------------------------------------------------------------------
@@ -262,6 +274,7 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
                     "WHERE idem_key=?",
                     [(name, c.idem_key) for c in chunk],
                 )
+                _record_send_count(conn, name, take)
             for c in chunk:
                 result.delivered.add(c.idem_key)
             result.sent_by_provider[name] = result.sent_by_provider.get(name, 0) + take

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -54,6 +54,7 @@
   .dot-bad { background: #dc2626; }
 
   time.ts.stale { color: #dc2626; font-weight: 600; }
+  .quota-hot { color: #dc2626; font-weight: 600; }
   .adm-muted { color: var(--text-muted); }
 </style>
 {% endblock %}
@@ -82,6 +83,24 @@
       <tr><td class="k">Awaiting first match</td><td class="v">{{ s.active_awaiting_first_match }} of {{ s.active_subscriptions }} active</td></tr>
       <tr><td class="k">Most recent</td><td class="v">{% if s.last_notification %}<time class="ts" data-ts="{{ s.last_notification.at }}">{{ s.last_notification.at }}</time> · sub #{{ s.last_notification.sub_id }}{% else %}<span class="adm-muted">none yet</span>{% endif %}</td></tr>
       <tr><td class="k">Delivery · 7d</td><td class="v">{% set prov = s.emails_by_provider_7d %}{% if prov %}{% for p, n in prov|dictsort %}{{ p }} {{ n }}{% if not loop.last %} · {% endif %}{% endfor %}{% else %}<span class="adm-muted">none</span>{% endif %}</td></tr>
+    </table>
+  </section>
+
+  <section class="adm-section">
+    <h2>Email quota <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· sends counted here, UTC calendar · caps from config</span></h2>
+    <table class="adm-table">
+      {% for p, u in s.email_usage|dictsort %}
+        <tr>
+          <td class="k">{{ p }}</td>
+          <td class="v">
+            {% set mpct = (100 * u.month / u.month_quota)|round|int if u.month_quota else 0 %}
+            {% set dpct = (100 * u.today / u.day_quota)|round|int if u.day_quota else 0 %}
+            month <span{% if mpct >= 80 %} class="quota-hot"{% endif %}>{{ u.month }}{% if u.month_quota %} / {{ u.month_quota }} ({{ mpct }}%){% endif %}</span>
+            &nbsp;·&nbsp;
+            today <span{% if dpct >= 80 %} class="quota-hot"{% endif %}>{{ u.today }}{% if u.day_quota %} / {{ u.day_quota }}{% endif %}</span>
+          </td>
+        </tr>
+      {% endfor %}
     </table>
   </section>
 

--- a/app/web.py
+++ b/app/web.py
@@ -491,7 +491,7 @@ def create_app() -> Flask:
         conn = connect(cfg.db_path)
         # Admin is an internal, English-only stats page — hide the (no-op)
         # DE/EN switcher that base.html otherwise renders.
-        return render_template("admin.html", stats=stats(conn),
+        return render_template("admin.html", stats=stats(conn, cfg),
                                show_lang_switcher=False)
 
     @app.route("/datenschutz")

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,7 +56,13 @@ failing:
   the cue to ask Mailjet to raise the throttle, upgrade to a paid plan, and/or
   raise the quota vars above.
 
-Delivery mix over the last 7 days is visible on `/admin`.
+Delivery mix over the last 7 days is visible on `/admin`, along with an
+**Email quota** section showing month-to-date and today's sends per provider
+against `MAILJET_MONTHLY_QUOTA` / `RESEND_MONTHLY_QUOTA` (display-only caps,
+free tiers: 6000/mo and 3000/mo) — so you can watch quota burn without logging
+into the provider dashboards. Counts come from the app's own durable
+`email_send_counts` table (UTC days, an approximation of each provider's reset
+cycle) and only include mail this app sent.
 
 ## Polling cadence
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -351,3 +351,57 @@ def test_admin_aggregates_upstream_load_per_host_and_labels_tenants(client):
     body = render_summary_text(s, now=datetime.utcnow())
     assert "UPSTREAM HOSTS" in body
     assert "38 today" in body
+
+
+# ---------- email quota view (durable per-day counters) ----------
+
+def test_stats_email_usage_windows_and_caps(tmp_path):
+    from types import SimpleNamespace
+    conn = connect(str(tmp_path / "u.db")); init_schema(conn)
+    conn.execute("INSERT INTO email_send_counts (provider, day, n) "
+                 "VALUES ('mailjet', date('now'), 3)")
+    # A day from a long-gone month must not count toward month-to-date.
+    conn.execute("INSERT INTO email_send_counts (provider, day, n) "
+                 "VALUES ('mailjet', '2000-01-15', 99)")
+    cfg = SimpleNamespace(mailjet_monthly_quota=6000, mailjet_daily_quota=200,
+                          resend_monthly_quota=3000, resend_daily_quota=100)
+    u = stats(conn, cfg)["email_usage"]
+    assert u["mailjet"] == {"month": 3, "today": 3,
+                            "month_quota": 6000, "day_quota": 200}
+    # Resend has sent nothing yet but still shows up with its caps.
+    assert u["resend"] == {"month": 0, "today": 0,
+                           "month_quota": 3000, "day_quota": 100}
+
+def test_init_schema_backfills_counters_once(tmp_path):
+    conn = connect(str(tmp_path / "b.db")); init_schema(conn)
+    for k, p in (("k1", "mailjet"), ("k2", "mailjet"), ("k3", "resend"),
+                 ("k4", "pending")):
+        conn.execute("INSERT INTO sent_idempotency (idem_key, provider) "
+                     "VALUES (?, ?)", (k, p))
+    conn.execute("DELETE FROM email_send_counts")  # simulate pre-feature DB
+    init_schema(conn)                              # first init after upgrade
+    u = stats(conn)["email_usage"]
+    assert u["mailjet"]["today"] == 2
+    assert u["resend"]["today"] == 1
+    assert "pending" not in u
+    init_schema(conn)                              # re-run must not double-count
+    assert stats(conn)["email_usage"]["mailjet"]["today"] == 2
+
+def test_admin_renders_email_quota_section(client):
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("INSERT INTO email_send_counts (provider, day, n) "
+                 "VALUES ('mailjet', date('now'), 483)")
+    html = client.get("/admin?token=admin-tok").data.decode()
+    assert "Email quota" in html
+    assert "483 / 6000" in html          # MAILJET_MONTHLY_QUOTA default
+    assert "0 / 3000" in html            # RESEND_MONTHLY_QUOTA default
+
+def test_summary_email_quota_lines():
+    text = render_summary_text(_summary_stats(email_usage={
+        "mailjet": {"month": 483, "today": 12, "month_quota": 6000, "day_quota": 200},
+        "resend":  {"month": 1, "today": 0, "month_quota": 3000, "day_quota": 100},
+    }), now=NOW)
+    mj = _line(text, "Quota mailjet")
+    assert "month 483/6000" in mj and "today 12/200" in mj
+    re_ = _line(text, "Quota resend")
+    assert "month 1/3000" in re_ and "today 0/100" in re_

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -160,3 +160,32 @@ def test_unsub_headers_only_with_real_url(monkeypatch, mailjet_env):
     with patch("app.mail.requests.post", side_effect=fake):
         _call_mailjet("a@x.com", "s", "b")   # no unsub semantics (e.g. confirmation)
     assert "Headers" not in seen["json"]["Messages"][0]
+
+# ---------- durable per-day send counters (admin quota view) ----------
+
+def _day_count(db, provider):
+    row = db.execute(
+        "SELECT n FROM email_send_counts WHERE provider=? AND day=date('now')",
+        (provider,)).fetchone()
+    return row["n"] if row else 0
+
+def test_send_bumps_daily_counter(db):
+    with patch("app.mail._call_mailjet", return_value=_ok()):
+        send(db, "a@x.com", "s", "b", idem_key="cnt1")
+        send(db, "a@x.com", "s", "b", idem_key="cnt2")
+        send(db, "a@x.com", "s", "b", idem_key="cnt2")  # idempotent repeat
+    assert _day_count(db, "mailjet") == 2
+
+def test_send_counter_follows_failover_provider(db, resend_configured):
+    with patch("app.mail._call_mailjet", return_value=_resp(503)), \
+         patch("app.mail._call_resend", return_value=_ok()):
+        send(db, "a@x.com", "s", "b", idem_key="cnt3")
+    assert _day_count(db, "resend") == 1
+    assert _day_count(db, "mailjet") == 0
+
+def test_failed_send_does_not_bump_counter(db, monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with patch("app.mail._call_mailjet", return_value=_resp(500)):
+        with pytest.raises(MailFailed):
+            send(db, "a@x.com", "s", "b", idem_key="cnt4")
+    assert _day_count(db, "mailjet") == 0

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -189,3 +189,17 @@ def test_quota_alert_silent_when_healthy(db):
     with patch("app.mail.send") as snd:
         maybe_quota_alert(db, _cfg(resend_daily_quota=100), deferred=0)
     snd.assert_not_called()
+
+
+def test_batch_bumps_daily_counters_per_provider(db, resend_on):
+    # Mailjet's hourly quota (10) takes the first ten; the rest overflow to Resend.
+    with patch("app.mail._call_mailjet_batch", return_value=True), \
+         patch("app.mail._call_resend_batch", return_value=True):
+        send_batch(db, _items(13), _cfg())
+    def day_count(p):
+        row = db.execute(
+            "SELECT n FROM email_send_counts WHERE provider=? AND day=date('now')",
+            (p,)).fetchone()
+        return row["n"] if row else 0
+    assert day_count("mailjet") == 10
+    assert day_count("resend") == 3


### PR DESCRIPTION
Adds an **Email quota** section to /admin showing month-to-date and today's sends per provider against the free-tier caps (Mailjet 6000/mo, Resend 3000/mo), so quota burn is visible without logging into the provider dashboards. Matching quota lines in the daily ops summary email.

- New durable `email_send_counts` table (provider × UTC day); `send()` / `send_batch()` bump it on success. Survives the 14-day `sent_idempotency` prune.
- One-time backfill in `init_schema` from remaining `sent_idempotency` history (skipped when the table is already populated).
- Display-only config: `MAILJET_MONTHLY_QUOTA` / `RESEND_MONTHLY_QUOTA`; delivery gating is unchanged.
- Numbers turn red at ≥80% of a cap.