### PR TITLE
fix(web): per-tenant city name in disclaimer/labels; raise per-email signup limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,10 @@ PARSER_CANARY_THRESHOLD_HOURS=2
 # so a low per-IP cap turns away legitimate sign-ups during a traffic spike.
 # Abuse is still bounded by SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY below.
 SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR=30
-SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY=1
+# 5, not 1: one address may legitimately create several subscriptions in one
+# sitting (three tenants, plus separate Anliegen per city). Counts every row
+# created in the last 24h, including unconfirmed and soft-deleted ones.
+SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY=5
 DEVELOPER_EMAIL=
 KOFI_URL=https://ko-fi.com/jakubwaller
 DB_PATH=/data/app.db

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -44,8 +44,8 @@ class Catalog:
     appointment_types_en: dict[str, str] = field(default_factory=dict)
     locations_en: dict[str, str] = field(default_factory=dict)
     # Optional per-tenant UI copy from display.json: keys like "label",
-    # "heading", "note", each a {"de": …, "en": …} map. Missing file or keys →
-    # the templates fall back to their built-in default copy.
+    # "heading", "note", "city_name", each a {"de": …, "en": …} map. Missing
+    # file or keys → the templates fall back to their built-in default copy.
     display: dict = field(default_factory=dict)
 
     def display_text(self, key: str, lang: str) -> str | None:

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -65,12 +65,14 @@
 
   <p class="disclaimer">
     {% if lang == 'en' %}
-      This website is not officially affiliated with the City of Leipzig or
-      its authorities. We are an independent service that only informs
+      This website is not officially affiliated with
+      {% if city_name %}the City of {{ city_name }}{% else %}the city{% endif %}
+      or its authorities. We are an independent service that only informs
       about available appointments.
     {% else %}
-      Diese Website ist nicht offiziell mit der Stadt Leipzig oder ihren
-      Behörden verbunden. Wir sind ein unabhängiger Dienst, der
+      Diese Website ist nicht offiziell mit der
+      {% if city_name %}Stadt {{ city_name }}{% else %}Stadt{% endif %} oder
+      ihren Behörden verbunden. Wir sind ein unabhängiger Dienst, der
       ausschließlich über verfügbare Termine informiert.
     {% endif %}
   </p>

--- a/app/web.py
+++ b/app/web.py
@@ -251,6 +251,7 @@ def create_app() -> Flask:
                                confirmed=confirmed,
                                error=error,
                                heading=catalog.display_text("heading", lang),
+                               city_name=catalog.display_text("city_name", lang),
                                note=catalog.display_text("note", lang),
                                other_cities=other_cities,
                                appointment_types=catalog.appointment_types_for(lang),

--- a/catalog/dresden/display.json
+++ b/catalog/dresden/display.json
@@ -1,4 +1,8 @@
 {
+  "city_name": {
+    "de": "Dresden",
+    "en": "Dresden"
+  },
   "label": {
     "de": "Dresden: Bürgerbüros & Meldestellen",
     "en": "Dresden: citizens' offices (Bürgerbüros)"

--- a/catalog/leipzig-abh/display.json
+++ b/catalog/leipzig-abh/display.json
@@ -1,7 +1,11 @@
 {
+  "city_name": {
+    "de": "Leipzig",
+    "en": "Leipzig"
+  },
   "label": {
-    "de": "Ausländerbehörde: Abholung Aufenthaltsdokument",
-    "en": "Foreigners' office: residence document pickup"
+    "de": "Leipzig: Ausländerbehörde, Abholung Aufenthaltsdokument",
+    "en": "Leipzig: foreigners' office, residence document pickup"
   },
   "heading": {
     "de": "Nie wieder freie Abhol-Termine bei der Ausländerbehörde verpassen",

--- a/catalog/leipzig/display.json
+++ b/catalog/leipzig/display.json
@@ -1,7 +1,11 @@
 {
+  "city_name": {
+    "de": "Leipzig",
+    "en": "Leipzig"
+  },
   "label": {
-    "de": "Bürgerbüro-Termine (Anmeldung, Ausweise u. a.)",
-    "en": "Citizen office appointments (registration, ID cards, …)"
+    "de": "Leipzig: Bürgerbüro-Termine (Anmeldung, Ausweise u. a.)",
+    "en": "Leipzig: citizen office appointments (registration, ID cards, …)"
   },
   "heading": {
     "de": "Nie wieder freie Bürgerbüro-Termine verpassen",

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -340,8 +340,8 @@ def test_admin_aggregates_upstream_load_per_host_and_labels_tenants(client):
     assert host["polls_today"] == 14
     assert host["tenants"] == ["leipzig", "leipzig-abh"]
     # Tenant labels come from display.json (admin is English-only).
-    assert "Ausländerbehörde" in s["city_labels"]["leipzig-abh"] or \
-           "Foreigners" in s["city_labels"]["leipzig-abh"]
+    assert "ausländerbehörde" in s["city_labels"]["leipzig-abh"].lower() or \
+           "foreigners" in s["city_labels"]["leipzig-abh"].lower()
     # Dashboard renders the labeled card + the host section.
     html = client.get("/admin?token=admin-tok").data.decode()
     assert "Upstream hosts" in html


### PR DESCRIPTION
Two issues found on the Dresden page after launch:

**1. "Zu viele Anfragen" on signup** — not the scraper. `SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY=1` counts every subscriptions row for the address in the last 24h across all tenants (including unconfirmed/soft-deleted), so anyone who signed up for one tenant that day gets a 429 on Dresden. `.env.example` raised to 5/day — still bounds abuse, but allows legit multi-tenant/multi-Anliegen signups.

**2. Leipzig copy on the Dresden page**
- The disclaimer hardcoded "Stadt Leipzig" for every tenant. `display.json` now carries a `city_name` per tenant; the template falls back to a neutral "der Stadt" if unset.
- The Leipzig tenants' cross-link labels didn't mention Leipzig, so on the Dresden page they read as Dresden links. Now prefixed "Leipzig: …" (matching Dresden's label style).

One admin test assertion relaxed to case-insensitive (label now lowercases "foreigners" after the city prefix, like Dresden's label).

Verified: 234 tests pass + rendered-page smoke check of all three tenants in de/en.