### PR TITLE
fix(web): render tenant cross-links as a sorted one-per-line list

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -235,7 +235,10 @@
     .city-switch {
       font-size: 0.9375rem;
       margin: -0.5rem 0 1.25rem;
+      list-style: none;
+      padding: 0;
     }
+    .city-switch li { margin: 0.25rem 0; }
     .city-switch a { text-decoration: none; }
     .city-switch a:hover { text-decoration: underline; }
     .hidden { position: absolute; left: -9999px; }

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -56,11 +56,11 @@
   </h1>
 
   {% if other_cities %}
-    <p class="city-switch">
+    <ul class="city-switch">
       {% for label, url in other_cities %}
-        <a href="{{ url }}">→ {{ label }}</a>{% if not loop.last %} · {% endif %}
+        <li><a href="{{ url }}">→ {{ label }}</a></li>
       {% endfor %}
-    </p>
+    </ul>
   {% endif %}
 
   <p class="disclaimer">

--- a/app/web.py
+++ b/app/web.py
@@ -245,6 +245,9 @@ def create_app() -> Flask:
             label = ocat.display_text("label", lang) or other
             url = f"/?city={other}" + ("&lang=en" if lang == "en" else "")
             other_cities.append((label, url))
+        # Labels start with the city name, so a label sort orders the links
+        # by city, then service.
+        other_cities.sort(key=lambda pair: pair[0].casefold())
         return render_template("form.html",
                                lang=lang,
                                city=city,


### PR DESCRIPTION
The '·'-separated inline row wraps awkwardly now that there are three tenants with longer city-prefixed labels. The form page renders them as a plain list instead — one link per line, sorted by label (labels start with the city name, so the order is city, then service).

Verified: 234 tests pass + rendered-page check of link markup and sort order.