### PR TITLE
fix(web): name the city in German tenant headings

### DIFF
--- a/catalog/leipzig-abh/display.json
+++ b/catalog/leipzig-abh/display.json
@@ -8,7 +8,7 @@
     "en": "Leipzig: foreigners' office, residence document pickup"
   },
   "heading": {
-    "de": "Nie wieder freie Abhol-Termine bei der Ausländerbehörde verpassen",
+    "de": "Nie wieder freie Abhol-Termine bei der Leipziger Ausländerbehörde verpassen",
     "en": "Never miss a pickup slot at the Leipzig foreigners' office"
   },
   "note": {

--- a/catalog/leipzig/display.json
+++ b/catalog/leipzig/display.json
@@ -8,7 +8,7 @@
     "en": "Leipzig: citizen office appointments (registration, ID cards, …)"
   },
   "heading": {
-    "de": "Nie wieder freie Bürgerbüro-Termine verpassen",
+    "de": "Nie wieder freie Bürgerbüro-Termine in Leipzig verpassen",
     "en": "Never miss a Leipzig appointment again"
   }
 }

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -149,7 +149,7 @@ def test_abh_tenant_form_renders_with_own_copy_and_cross_links(client):
     heading, the Termin-Code note, its service, and a cross-link back to the
     Bürgerbüro tenant (and vice versa)."""
     abh = client.get("/?city=leipzig-abh").data.decode()
-    assert "Abhol-Termine bei der Ausländerbehörde" in abh
+    assert "Abhol-Termine bei der Leipziger Ausländerbehörde" in abh
     assert "Termin-Code" in abh
     assert "Ausgabe  Aufenthaltsdokument" in abh
     assert 'city=leipzig' in abh                      # link back


### PR DESCRIPTION
Journalist feedback (T. Köhler): on the start page the German heading never names the city, so next to the Dresden cross-link it looks as if only the Ausländerbehörde entry applies to Leipzig.

English headings already carry the city name; this brings the German ones in line:

- **leipzig**: „Nie wieder freie Bürgerbüro-Termine **in Leipzig** verpassen"
- **leipzig-abh**: „Nie wieder freie Abhol-Termine bei der **Leipziger** Ausländerbehörde verpassen"

Dresden already says „im Dresdner Bürgerbüro" — unchanged. Test assertion updated; full suite green (234 passed).