### PR TITLE
feat(mail): name the city in digest, confirmation, and manage-link emails

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -107,6 +107,15 @@ def load_catalog(city: str) -> Catalog:
                    display=display)
 
 
+def city_display_name(city: str, lang: str) -> str | None:
+    """Localized city_name from the tenant's display.json; None if unset or the
+    catalog can't be loaded. Email paths must never fail on a missing catalog."""
+    try:
+        return load_catalog(city).display_text("city_name", lang)
+    except Exception:
+        return None
+
+
 def booking_start_url(scfg: dict, lang: str = "de") -> str:
     """Entry URL of the city's booking flow, per vendor.
 

--- a/app/confirmations.py
+++ b/app/confirmations.py
@@ -13,15 +13,24 @@ from app.repo import set_confirmation_sent, pending_confirmations
 from app.tokens import sign
 
 
-def build_confirmation(sub_id: int, email: str, lang: str, cfg) -> Outgoing:
+def build_confirmation(sub_id: int, email: str, lang: str, city: str,
+                       cfg) -> Outgoing:
+    from app.catalog import city_display_name
     tok = sign(sub_id, "confirm",
                primary=cfg.token_secret_primary,
                previous=cfg.token_secret_previous)
     url = f"{cfg.public_base_url}/confirm/{tok}"
+    city_name = city_display_name(city, lang)
     if lang == "en":
-        subject, body = "Confirmation needed", f"Please confirm your subscription: {url}"
+        subject = (f"Confirmation needed ({city_name})" if city_name
+                   else "Confirmation needed")
+        body = (f"Please confirm your subscription for {city_name}: {url}"
+                if city_name else f"Please confirm your subscription: {url}")
     else:
-        subject, body = "Bestätigung benötigt", f"Bitte bestätige dein Abonnement: {url}"
+        subject = (f"Bestätigung benötigt ({city_name})" if city_name
+                   else "Bestätigung benötigt")
+        body = (f"Bitte bestätige dein Abonnement für {city_name}: {url}"
+                if city_name else f"Bitte bestätige dein Abonnement: {url}")
     # Stable per-subscription key: a deferred send and its later retry share it,
     # so the idempotency layer never double-sends a confirmation.
     return Outgoing(to=email, subject=subject, body=body,
@@ -29,11 +38,11 @@ def build_confirmation(sub_id: int, email: str, lang: str, cfg) -> Outgoing:
 
 
 def send_confirmation_now(conn: sqlite3.Connection, sub_id: int, email: str,
-                          lang: str, cfg) -> bool:
+                          lang: str, city: str, cfg) -> bool:
     """Try to send this sign-up's confirmation immediately. Returns True if it
     went out, False if it was deferred (quota exhausted) — in which case the
     pending row stays put and `send_pending_confirmations` retries it later."""
-    item = build_confirmation(sub_id, email, lang, cfg)
+    item = build_confirmation(sub_id, email, lang, city, cfg)
     result = send_batch(conn, [item], cfg)
     if item.idem_key in result.delivered:
         set_confirmation_sent(conn, sub_id)
@@ -48,10 +57,10 @@ def send_pending_confirmations(conn: sqlite3.Connection, cfg, *,
     pending = pending_confirmations(conn, max_age_days=max_age_days)
     if not pending:
         return
-    items = [build_confirmation(sub_id, email, lang, cfg)
-             for (sub_id, email, lang) in pending]
+    items = [build_confirmation(sub_id, email, lang, city, cfg)
+             for (sub_id, email, lang, city) in pending]
     key_to_sub = {item.idem_key: sub_id
-                  for item, (sub_id, _e, _l) in zip(items, pending)}
+                  for item, (sub_id, _e, _l, _c) in zip(items, pending)}
     result = send_batch(conn, items, cfg)
     for idem_key in result.delivered:
         set_confirmation_sent(conn, key_to_sub[idem_key])

--- a/app/digest.py
+++ b/app/digest.py
@@ -59,12 +59,16 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
         locations = t(lang, "digest.all_locations")
     else:
         locations = ", ".join(loc_label(u) for u in f.locations)
+    city_name = catalog.display_text("city_name", lang) if catalog else None
+    city_lbl = t(lang, "digest.selection_city_label") if city_name else ""
     svc_lbl = t(lang, "digest.selection_service_label")
     loc_lbl = t(lang, "digest.selection_locations_label")
     win_lbl = t(lang, "digest.selection_window_label") if f.max_days_ahead else ""
-    labels = [l for l in (svc_lbl, loc_lbl, win_lbl) if l]
+    labels = [l for l in (city_lbl, svc_lbl, loc_lbl, win_lbl) if l]
     pad = max(len(l) for l in labels) + 1  # width of the longest "label:"
     lines.append(t(lang, "digest.selection_heading"))
+    if city_name:
+        lines.append(f"  {(city_lbl + ':').ljust(pad)} {city_name}")
     lines.append(f"  {(svc_lbl + ':').ljust(pad)} {services}")
     lines.append(f"  {(loc_lbl + ':').ljust(pad)} {locations}")
     if f.max_days_ahead:
@@ -164,7 +168,10 @@ def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
                               unsubscribe_url=unsub_url,
                               public_base_url=cfg.public_base_url,
                               kofi_url=cfg.kofi_url)
-    subj = t(subscription.language, "digest.subject")
+    from app.catalog import city_display_name
+    city_name = city_display_name(subscription.city, subscription.language)
+    subj = (t(subscription.language, "digest.subject_city", city=city_name)
+            if city_name else t(subscription.language, "digest.subject"))
     key = _idem_key(subscription.id,
                     [s.hash() for s in matched_slots],
                     cycle_id)

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -1,5 +1,7 @@
 {
   "digest.subject": "Neue Termine verfügbar",
+  "digest.subject_city": "Neue Termine in {city} verfügbar",
+  "digest.selection_city_label": "Stadt",
   "digest.greeting": "Hallo,",
   "digest.intro": "Es wurden neue passende Termine gefunden:",
   "digest.selection_heading": "Deine Auswahl",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1,5 +1,7 @@
 {
   "digest.subject": "New appointments available",
+  "digest.subject_city": "New appointments in {city} available",
+  "digest.selection_city_label": "City",
   "digest.greeting": "Hello,",
   "digest.intro": "We found new matching appointments:",
   "digest.selection_heading": "Your selection",

--- a/app/repo.py
+++ b/app/repo.py
@@ -33,19 +33,19 @@ def set_confirmation_sent(conn: sqlite3.Connection, sub_id: int) -> None:
     )
 
 def pending_confirmations(conn: sqlite3.Connection, *,
-                          max_age_days: int = 7) -> list[tuple[int, str, str]]:
+                          max_age_days: int = 7) -> list[tuple[int, str, str, str]]:
     """Sign-ups still awaiting a confirmation email: unconfirmed, not deleted,
     no confirmation delivered yet, created within `max_age_days` (older ones are
     abandoned rather than retried forever). Oldest first for fair delivery."""
     rows = conn.execute(
-        "SELECT id, email, language FROM subscriptions "
+        "SELECT id, email, language, city FROM subscriptions "
         "WHERE confirmed_at IS NULL AND deleted_at IS NULL "
         "AND confirmation_sent_at IS NULL "
         "AND created_at > datetime('now', ?) "
         "ORDER BY created_at",
         (f"-{max_age_days} days",),
     ).fetchall()
-    return [(r["id"], r["email"], r["language"]) for r in rows]
+    return [(r["id"], r["email"], r["language"], r["city"]) for r in rows]
 
 def _row_to_subscription(row: sqlite3.Row) -> Subscription:
     from datetime import datetime

--- a/app/web.py
+++ b/app/web.py
@@ -8,7 +8,7 @@ from flask import Flask, request, render_template, redirect
 from app.config import load_config
 from app.db import connect, transaction
 from app.catalog import (load_catalog, available_cities, booking_start_url,
-                         CatalogError)
+                         city_display_name, CatalogError)
 from app.models import Filter
 from app.repo import insert_pending, active_subscriptions, confirm, soft_delete
 from app.ratelimit import GLOBAL_IP_LIMITER, email_rate_limit_ok
@@ -135,18 +135,19 @@ def _parse_max_days(raw: str | None) -> int | None:
     return None
 
 
-def _send_confirmation_email(conn, sub_id: int, email: str, lang: str, cfg) -> bool:
+def _send_confirmation_email(conn, sub_id: int, email: str, lang: str,
+                             city: str, cfg) -> bool:
     """Try to send the confirmation now. Returns True if delivered, False if
     deferred (quota exhausted) — the sign-up stays pending and the poller's
     retry pass sends it later (e.g. next day once quota resets)."""
     from app.confirmations import send_confirmation_now
-    return send_confirmation_now(conn, sub_id, email, lang, cfg)
+    return send_confirmation_now(conn, sub_id, email, lang, city, cfg)
 
 
 def _send_manage_link_email(conn, sub_id: int, cfg) -> None:
     """Sends a separate email with the /manage link - NEVER in digests."""
     row = conn.execute(
-        "SELECT email, language FROM subscriptions WHERE id=?",
+        "SELECT email, language, city FROM subscriptions WHERE id=?",
         (sub_id,),
     ).fetchone()
     if not row:
@@ -155,14 +156,16 @@ def _send_manage_link_email(conn, sub_id: int, cfg) -> None:
                primary=cfg.token_secret_primary,
                previous=cfg.token_secret_previous)
     url = f"{cfg.public_base_url}/manage/{tok}"
+    city_name = city_display_name(row["city"], row["language"])
+    suffix = f" ({city_name})" if city_name else ""
     if row["language"] == "de":
         body = (f"Dein Verwaltungs-Link: {url}\nMit diesem Link kannst du deine "
                 f"Einstellungen jederzeit ändern oder dich abmelden.")
-        subj = "Verwaltungs-Link"
+        subj = f"Verwaltungs-Link{suffix}"
     else:
         body = (f"Your management link: {url}\nUse it any time to change your "
                 f"settings or unsubscribe.")
-        subj = "Management link"
+        subj = f"Management link{suffix}"
     key = _idem_key(sub_id, [], f"manage-link-{sub_id}")
     mail_send(conn, row["email"], subj, body, idem_key=key)
 
@@ -322,7 +325,8 @@ def create_app() -> Flask:
         # registration is never lost. Only the message differs: "check your
         # inbox" vs "it may arrive tomorrow". No soft-delete, no lockout.
         try:
-            delivered = _send_confirmation_email(conn, sub_id, email, lang, cfg)
+            delivered = _send_confirmation_email(conn, sub_id, email, lang,
+                                                 city, cfg)
         except Exception:
             log.exception("confirmation email errored for sub %s; will retry", sub_id)
             delivered = False

--- a/tests/test_confirmations.py
+++ b/tests/test_confirmations.py
@@ -49,7 +49,7 @@ def test_deferred_confirmation_is_kept_then_delivered_by_retry(db):
     # All quota exhausted → the immediate send defers.
     with patch("app.mail._call_mailjet_batch", return_value=True), \
          patch("app.mail._call_resend_batch", return_value=True):
-        delivered = send_confirmation_now(db, sid, "a@x.com", "de",
+        delivered = send_confirmation_now(db, sid, "a@x.com", "de", "leipzig",
                                           _cfg(mailjet_hourly_quota=0,
                                                mailjet_daily_quota=0,
                                                resend_daily_quota=0))
@@ -68,7 +68,7 @@ def test_deferred_confirmation_is_kept_then_delivered_by_retry(db):
 def test_retry_is_idempotent_once_delivered(db):
     sid = _sub(db)
     with patch("app.mail._call_mailjet_batch", return_value=True):
-        assert send_confirmation_now(db, sid, "a@x.com", "de", _cfg()) is True
+        assert send_confirmation_now(db, sid, "a@x.com", "de", "leipzig", _cfg()) is True
     # A second retry pass must not re-send an already-confirmed-sent sign-up.
     with patch("app.mail._call_mailjet_batch", return_value=True) as mb:
         send_pending_confirmations(db, _cfg())

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -247,3 +247,41 @@ def test_digest_no_summary_line_when_under_cap():
     assert "weitere passende Termine" not in text
     assert len(_slot_lines(text)) == MAX_SLOTS_PER_DIGEST
     assert text.count("/go/") == 1                   # just the city booking link
+
+
+# ---------- city naming (multi-tenant disambiguation) ----------
+
+def _cat_with_city():
+    import dataclasses
+    return dataclasses.replace(
+        _cat(), display={"city_name": {"de": "Leipzig", "en": "Leipzig"}})
+
+
+def test_selection_header_names_city():
+    slots = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")]
+    de = _render(_sub("de"), slots, catalog=_cat_with_city())
+    en = _render(_sub("en"), slots, catalog=_cat_with_city())
+    assert re.search(r"^  Stadt: +Leipzig$", de, re.M)
+    assert re.search(r"^  City: +Leipzig$", en, re.M)
+
+
+def test_selection_header_omits_city_without_display_name():
+    slots = [Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")]
+    text = _render(_sub("de"), slots, catalog=_cat())
+    assert "Stadt:" not in text
+
+
+def test_digest_subject_names_city():
+    # send_digest resolves the real per-city catalog; leipzig's display.json
+    # carries city_name, so the subject must name the city.
+    from app.digest import send_digest
+    from types import SimpleNamespace
+    conn = connect(":memory:")
+    init_schema(conn)
+    cfg = SimpleNamespace(token_secret_primary="x" * 32, token_secret_previous="",
+                          public_base_url="https://x", kofi_url="https://ko-fi.com/me")
+    sink = []
+    send_digest(conn=conn, subscription=_sub("de"),
+                matched_slots=[Slot("2026-06-10", "10:30", "loc-1", "svc-A", "t")],
+                cycle_id="c1", cfg=cfg, sink=sink)
+    assert sink[0].item.subject == "Neue Termine in Leipzig verfügbar"


### PR DESCRIPTION
With Leipzig and Dresden both live, a subscriber in two cities couldn't tell the emails apart — the city appeared only inside the `/go/<city>` URL.

**Digest**
- Subject: „Neue Termine in Leipzig verfügbar" / "New appointments in Dresden available" — falls back to the old generic subject when a tenant's `display.json` has no `city_name`.
- Body: „Stadt: <Name>" as the first line of the „Deine Auswahl" block.

**Confirmation email**: „Bestätigung benötigt (Dresden)" + city in the body line.

**Manage-link email**: city suffix in the subject.

New `catalog.city_display_name(city, lang)` helper — localized via display.json, returns None instead of raising so email paths never fail on catalog problems.

Tests: 3 new (city line de/en, omission without city_name, subject via send_digest); full suite 237 passed.