### PR TITLE
fix(analytics): stop reading unsubscribed time as empty slots

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -436,6 +436,10 @@ def _availability(conn: sqlite3.Connection, city_labels: dict) -> list[dict]:
         r["city_label"] = city_labels.get(city, city)
         r["service"] = (cat.appointment_type_label(r["service_uuid"], "en")
                         if cat else r["service_uuid"])
-        r["location"] = (cat.location_label(r["location_uuid"], "en")
-                         if cat else r["location_uuid"])
+        if not r["location_uuid"]:
+            # Polled, but no office ever produced a slot in the window.
+            r["location"] = "all offices"
+        else:
+            r["location"] = (cat.location_label(r["location_uuid"], "en")
+                             if cat else r["location_uuid"])
     return rows

--- a/app/analytics.py
+++ b/app/analytics.py
@@ -27,19 +27,24 @@ RETENTION_DAYS = int(os.environ.get("ANALYTICS_RETENTION_DAYS", "90"))
 
 
 def record_availability(conn: sqlite3.Connection, slots_by_city: dict,
+                        polled_by_city: dict | None = None,
                         *, now: datetime | None = None) -> None:
     """Persist one availability sample per due tenant.
 
     `slots_by_city` maps city → list[Slot] (all slots seen this cycle, already
-    deduped). Counts are grouped by (service_uuid, location_uuid). A tenant
-    that was polled but returned nothing still gets rows only if it has none —
-    scarcity is visible as an *absence* of rows for that (type, office), which
-    the reader treats as zero.
+    deduped). Counts are grouped by (service_uuid, location_uuid).
+
+    `polled_by_city` maps city → set of service_uuids whose poll *succeeded*
+    this cycle. A polled service with no slot anywhere gets an explicit
+    (service_uuid, '', 0) row — that is what lets the reader tell "we looked
+    and found nothing" (scarcity) apart from "nobody was subscribed, so we
+    never looked" (coverage). A failed poll records nothing for the service.
 
     Never raises: analytics must not be able to break a polling cycle.
     """
     now = now or datetime.utcnow()
     now_iso = now.isoformat()
+    polled_by_city = polled_by_city or {}
     try:
         for city, slots in slots_by_city.items():
             row = conn.execute(
@@ -58,9 +63,13 @@ def record_availability(conn: sqlite3.Connection, slots_by_city: dict,
             for s in slots:
                 key = (s.service_uuid, s.location_uuid)
                 counts[key] = counts.get(key, 0) + 1
+            seen_services = {svc for svc, _ in counts}
+            for svc in polled_by_city.get(city, ()):
+                if svc not in seen_services:
+                    counts[(svc, "")] = 0
             if not counts:
-                # Still record the sample point, so "we looked and found zero"
-                # is distinguishable from "we never looked". Empty uuids mark it.
+                # Still record the sample point, so the city-level time series
+                # has no hole even when every poll failed. Empty uuids mark it.
                 counts[("", "")] = 0
             conn.executemany(
                 "INSERT INTO availability_samples "
@@ -80,11 +89,20 @@ def prune_availability(conn: sqlite3.Connection) -> None:
 
 
 def availability_summary(conn: sqlite3.Connection, *, days: int = 7) -> list[dict]:
-    """Per (city, type, office) averages over `days`, newest sample included.
+    """Per (city, type, office) stats over `days`, newest sample included.
 
-    `avg_slots` averages over the *samples that included this key*; `zero_rate`
-    is the share of that tenant's samples where the key had no slots at all —
-    the scarcity number that actually matters to a subscriber.
+    Every number is relative to the samples where the service was actually
+    *polled* (someone was subscribed and the scrape succeeded), so scarcity
+    and coverage don't get conflated:
+
+    - `coverage`: % of the city's samples in which this service was polled.
+    - `avg_slots`: mean free slots over polled samples, absence counted as 0.
+    - `zero_rate`: % of polled samples where this office had nothing — real
+      scarcity, the number that matters to a subscriber.
+
+    A polled service that never had a slot at any office surfaces as one row
+    with an empty location_uuid. Samples from before the polled-marker existed
+    undercount coverage (presence is the floor), never scarcity.
     """
     try:
         samples_per_city = {
@@ -95,43 +113,75 @@ def availability_summary(conn: sqlite3.Connection, *, days: int = 7) -> list[dic
                 "GROUP BY city"
             ).fetchall()
         }
+        # Any row for a service in a sample — slots seen, or the explicit
+        # (service, '', 0) marker — means the service was polled then.
+        polled = {
+            (r["city"], r["service_uuid"]): r["n"] for r in conn.execute(
+                "SELECT city, service_uuid, COUNT(DISTINCT sampled_at) AS n "
+                "FROM availability_samples "
+                f"WHERE sampled_at > datetime('now','-{int(days)} days') "
+                "  AND service_uuid != '' "
+                "GROUP BY city, service_uuid"
+            ).fetchall()
+        }
         rows = conn.execute(
             "SELECT city, service_uuid, location_uuid, "
-            "  COUNT(*) AS samples, AVG(n_slots) AS avg_slots, "
+            "  COUNT(*) AS samples, SUM(n_slots) AS sum_slots, "
             "  MAX(n_slots) AS max_slots, "
             "  SUM(CASE WHEN n_slots = 0 THEN 1 ELSE 0 END) AS zero_samples "
             "FROM availability_samples "
             f"WHERE sampled_at > datetime('now','-{int(days)} days') "
-            "  AND service_uuid != '' "
-            "GROUP BY city, service_uuid, location_uuid "
-            "ORDER BY city, avg_slots DESC"
+            "  AND service_uuid != '' AND location_uuid != '' "
+            "GROUP BY city, service_uuid, location_uuid"
         ).fetchall()
     except sqlite3.Error:
         return []
     out = []
+    seen_services = set()
     for r in rows:
-        total = samples_per_city.get(r["city"], r["samples"]) or r["samples"]
-        # Samples where this key was absent entirely count as zeros too.
-        zeros = (total - r["samples"]) + r["zero_samples"]
+        key = (r["city"], r["service_uuid"])
+        seen_services.add(key)
+        n_polled = polled.get(key, r["samples"]) or r["samples"]
+        total = samples_per_city.get(r["city"], n_polled) or n_polled
+        zeros = (n_polled - r["samples"]) + r["zero_samples"]
         out.append({
             "city": r["city"],
             "service_uuid": r["service_uuid"],
             "location_uuid": r["location_uuid"],
-            "avg_slots": round(r["avg_slots"] or 0, 1),
+            "avg_slots": round((r["sum_slots"] or 0) / n_polled, 1),
             "max_slots": r["max_slots"] or 0,
             "samples": r["samples"],
-            "zero_rate": round(100 * zeros / total) if total else 0,
+            "coverage": round(100 * n_polled / total),
+            "zero_rate": round(100 * zeros / n_polled),
         })
+    # Polled services that never produced a single slot at any office.
+    for (city, svc), n_polled in polled.items():
+        if (city, svc) in seen_services:
+            continue
+        total = samples_per_city.get(city, n_polled) or n_polled
+        out.append({
+            "city": city, "service_uuid": svc, "location_uuid": "",
+            "avg_slots": 0.0, "max_slots": 0, "samples": 0,
+            "coverage": round(100 * n_polled / total), "zero_rate": 100,
+        })
+    out.sort(key=lambda r: (r["city"], -r["avg_slots"]))
     return out
 
 
 def availability_daily(conn: sqlite3.Connection, *, days: int = 14) -> list[dict]:
-    """Per-city daily mean of total free slots per sample — the trend line."""
+    """Per-city daily mean of free slots *per polled service* — the trend line.
+
+    Normalising by the number of services polled in each sample keeps the
+    series comparable across subscription churn: a subscriber appearing for a
+    slot-flooded service no longer spikes the whole city's line. The all-failed
+    marker sample ('' service) divides 0 by 1 and correctly reads as 0.
+    """
     try:
         rows = conn.execute(
-            "SELECT city, day, AVG(total) AS avg_total FROM ("
+            "SELECT city, day, AVG(per_service) AS avg_per_service FROM ("
             "  SELECT city, date(sampled_at) AS day, sampled_at, "
-            "         SUM(n_slots) AS total "
+            "         CAST(SUM(n_slots) AS REAL) "
+            "           / COUNT(DISTINCT service_uuid) AS per_service "
             "  FROM availability_samples "
             f"  WHERE sampled_at > datetime('now','-{int(days)} days') "
             "  GROUP BY city, sampled_at"
@@ -140,7 +190,7 @@ def availability_daily(conn: sqlite3.Connection, *, days: int = 14) -> list[dict
     except sqlite3.Error:
         return []
     return [{"city": r["city"], "day": r["day"],
-             "avg_total": round(r["avg_total"] or 0, 1)} for r in rows]
+             "avg_per_service": round(r["avg_per_service"] or 0, 1)} for r in rows]
 
 
 def usage_daily(conn: sqlite3.Connection, *, days: int = 30) -> list[dict]:

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -157,6 +157,7 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
     # last_polled_at stay untouched, and its subscribers simply see no new
     # candidates this cycle.
     due = _due_cities(conn, {p.city for p in plans})
+    polled_ok: dict[str, set[str]] = {}
     for p in plans:
         if p.city not in due:
             continue
@@ -167,6 +168,9 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
         before = getattr(http, "request_count", None)
         try:
             slots_by_plan[p.key()] = get_scraper(p.city).poll(p, http=http)
+            # Only a poll that didn't raise proves the service was looked at —
+            # the availability series must not read a failed scrape as "empty".
+            polled_ok.setdefault(p.city, set()).add(p.appointment_type)
             if slots_by_plan[p.key()]:
                 cities_with_any_slot.add(p.city)
         except Exception:
@@ -235,7 +239,7 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
                 continue
             seen_hashes[p.city].add(h)
             slots_by_city[p.city].append(slot)
-    record_availability(conn, slots_by_city)
+    record_availability(conn, slots_by_city, polled_ok)
 
     now = datetime.utcnow()
     max_multiplier = getattr(cfg, "adaptive_rate_limit_max_multiplier",

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -264,23 +264,23 @@
 
   <section class="adm-section">
     <details class="adm-collapse" open>
-      <summary><h2>Daily mean free slots <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· per city, last 14 days</span></h2></summary>
+      <summary><h2>Daily free slots per service <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· mean per polled service &amp; day — churn-proof: one flooded service can't spike a city · last 14 days</span></h2></summary>
       {% if s.availability_daily %}
         {% for c in s.cities %}
           {% set rows = s.availability_daily|selectattr('city', 'equalto', c.key)|list %}
           {% if rows %}
-            {% set dmax = (rows|map(attribute='avg_total')|max) or 1 %}
+            {% set dmax = (rows|map(attribute='avg_per_service')|max) or 1 %}
             <div class="spark-row">
               <div class="spark-city" title="{{ c.label }}">{{ c.name }}{% if c.sub %}<br><span class="adm-muted" style="font-size:0.72rem;font-weight:400;">{{ c.sub|truncate(24) }}</span>{% endif %}</div>
               <div class="spark">
                 {% for r in rows %}
-                  <i class="{% if r.avg_total == 0 %}zero{% elif loop.last %}last{% endif %}"
-                     style="height: {{ (100 * r.avg_total / dmax)|round(1) if r.avg_total else 0 }}%"
-                     title="{{ r.day }} · {{ r.avg_total }} avg free"></i>
+                  <i class="{% if r.avg_per_service == 0 %}zero{% elif loop.last %}last{% endif %}"
+                     style="height: {{ (100 * r.avg_per_service / dmax)|round(1) if r.avg_per_service else 0 }}%"
+                     title="{{ r.day }} · {{ r.avg_per_service }} free per polled service"></i>
                 {% endfor %}
               </div>
               {% set latest = rows|last %}
-              <div class="spark-now"><strong>{{ latest.avg_total }}</strong> <span class="adm-muted">now</span></div>
+              <div class="spark-now"><strong>{{ latest.avg_per_service }}</strong> <span class="adm-muted">now</span></div>
             </div>
           {% endif %}
         {% endfor %}
@@ -330,7 +330,7 @@
   </section>
 
   <section class="adm-section">
-    <h2>Availability <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· free slots per office &amp; type, sampled every ~15 min · last 7 days</span></h2>
+    <h2>Availability <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· free slots per office &amp; type, ~15-min samples, last 7 days · a service is only polled while subscribed: "polled %" = coverage, "empty %" = scarcity within it</span></h2>
     {% if s.availability %}
       {# One collapsible block per city (collapsed by default), in the same
          subs-first order as the table above; the summary line carries the
@@ -346,7 +346,7 @@
             <summary title="{{ c.label }}">
               <span class="av-name">{{ c.name }}</span>
               {% if c.sub %}<span class="av-meta">{{ c.sub }}</span>{% endif %}
-              <span class="av-meta">{{ rows|length }} office/type row{{ 's' if rows|length != 1 }} · {{ c.subs }} sub{{ 's' if c.subs != 1 }} · Ø {{ rows|map(attribute='avg_slots')|sum|round|int }} free</span>
+              <span class="av-meta">{{ rows|length }} office/type row{{ 's' if rows|length != 1 }} · {{ c.subs }} sub{{ 's' if c.subs != 1 }} · Ø {{ rows|map(attribute='avg_slots')|sum|round|int }} free · polled {{ (rows|map(attribute='coverage')|sum / rows|length)|round|int }}%</span>
               {% if n_empty %}<span class="av-flag" style="color:#dc2626">{{ n_empty }} mostly empty</span>{% endif %}
               {% if n_scarce %}<span class="av-flag" style="color:#d97706">{{ n_scarce }} scarce</span>{% endif %}
             </summary>
@@ -354,13 +354,13 @@
               {% for r in rows %}
                 <div class="hbar-row">
                   <div class="hbar-lbl">{{ r.service }}<br><span class="sub">{{ r.location }}</span></div>
-                  <div class="hbar-track" title="avg {{ r.avg_slots }} · max {{ r.max_slots }} · empty {{ r.zero_rate }}% · {{ r.samples }} samples">
+                  <div class="hbar-track" title="avg {{ r.avg_slots }} over polled samples (absence = 0) · max {{ r.max_slots }} · {{ r.samples }} samples with slots">
                     <div class="hbar-bg">
                       <div class="hbar-fill{% if r.zero_rate >= 80 %} empty{% elif r.zero_rate >= 40 %} scarce{% endif %}"
                            style="width: {{ (2 + 98 * r.avg_slots / avmax)|round(1) }}%"></div>
                     </div>
-                    <div class="hbar-val"><strong>{{ r.avg_slots }}</strong> avg · max {{ r.max_slots }} ·
-                      <span{% if r.zero_rate >= 80 %} style="color:#dc2626;font-weight:600"{% elif r.zero_rate >= 40 %} style="color:#d97706;font-weight:600"{% endif %}>{{ r.zero_rate }}% empty</span></div>
+                    <div class="hbar-val"><strong>{{ r.avg_slots }}</strong> avg · polled {{ r.coverage }}% ·
+                      <span{% if r.zero_rate >= 80 %} style="color:#dc2626;font-weight:600"{% elif r.zero_rate >= 40 %} style="color:#d97706;font-weight:600"{% endif %}>empty {{ r.zero_rate }}% of polled</span></div>
                   </div>
                 </div>
               {% endfor %}
@@ -370,7 +370,7 @@
       {% endfor %}
       <div class="legend">
         <span><span class="swatch" style="background:var(--accent)"></span>Plentiful</span>
-        <span><span class="swatch" style="background:#d97706"></span>Scarce (≥40% empty)</span>
+        <span><span class="swatch" style="background:#d97706"></span>Scarce (empty ≥40% of polled time)</span>
         <span><span class="swatch" style="background:#dc2626"></span>Mostly empty (≥80%)</span>
       </div>
     {% else %}

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -47,21 +47,50 @@ def test_empty_poll_records_a_zero_marker(tmp_path):
     assert (row["service_uuid"], row["n_slots"]) == ("", 0)
     # The marker is excluded from the per-key summary...
     assert availability_summary(conn) == []
-    # ...but still counts as a sample, so a later key reads as 100% empty then.
+    # ...but still counts as a sample, so the daily series shows 0, not a hole.
     assert availability_daily(conn) == [{"city": "leipzig",
                                          "day": datetime.utcnow().date().isoformat(),
-                                         "avg_total": 0.0}]
+                                         "avg_per_service": 0.0}]
 
 
-def test_summary_counts_absent_keys_as_zero(tmp_path):
+def test_polled_service_without_slots_records_explicit_zero(tmp_path):
+    conn = _conn(tmp_path)
+    record_availability(conn, {"leipzig": []}, {"leipzig": {"S1"}})
+    row = conn.execute("SELECT service_uuid, location_uuid, n_slots "
+                       "FROM availability_samples").fetchone()
+    assert (row["service_uuid"], row["location_uuid"], row["n_slots"]) == ("S1", "", 0)
+    (r,) = availability_summary(conn)
+    assert r["location_uuid"] == ""
+    assert r["avg_slots"] == 0.0 and r["coverage"] == 100 and r["zero_rate"] == 100
+
+
+def test_summary_separates_scarcity_from_coverage(tmp_path):
     conn = _conn(tmp_path)
     now = datetime.utcnow()
-    record_availability(conn, {"leipzig": [_slot()]}, now=now - timedelta(minutes=40))
-    record_availability(conn, {"leipzig": []}, now=now - timedelta(minutes=20))
-    record_availability(conn, {"leipzig": []}, now=now)
+    # Polled 3 of 4 samples; slots in 1 of the 3 polled ones.
+    record_availability(conn, {"leipzig": [_slot(), _slot(t="09:30")]},
+                        {"leipzig": {"S1"}}, now=now - timedelta(minutes=60))
+    record_availability(conn, {"leipzig": []}, {"leipzig": {"S1"}},
+                        now=now - timedelta(minutes=40))
+    record_availability(conn, {"leipzig": []}, {"leipzig": {"S1"}},
+                        now=now - timedelta(minutes=20))
+    record_availability(conn, {"leipzig": []}, now=now)  # poll failed: not polled
     (r,) = availability_summary(conn)
-    assert r["avg_slots"] == 1.0 and r["samples"] == 1
-    assert r["zero_rate"] == 67  # present in 1 of 3 samples
+    assert r["samples"] == 1
+    assert r["avg_slots"] == 0.7           # 2 slots over 3 polled samples
+    assert r["coverage"] == 75             # polled in 3 of 4 city samples
+    assert r["zero_rate"] == 67            # empty in 2 of 3 polled samples
+
+
+def test_daily_mean_is_per_polled_service(tmp_path):
+    conn = _conn(tmp_path)
+    now = datetime.utcnow()
+    # One sample: S1 floods 3 slots, S2 polled but empty → (3+0)/2 services.
+    record_availability(conn, {"leipzig": [
+        _slot(), _slot(t="09:30"), _slot(t="10:00"),
+    ]}, {"leipzig": {"S1", "S2"}}, now=now)
+    (d,) = availability_daily(conn)
+    assert d["avg_per_service"] == 1.5
 
 
 def test_prune_drops_old_samples(tmp_path):


### PR DESCRIPTION
Bonn showed "4730 avg · 91% empty" for a service that floods thousands of slots whenever polled — because services are only polled while someone subscribes to them, and absence counted as empty. Scarcity and coverage are now separate:

- record_availability writes an explicit (service, '', 0) row for every successfully polled service that returned nothing, so "looked and found nothing" is distinguishable from "never looked". Failed polls record nothing.
- availability_summary: avg_slots is now the mean over polled samples (absence = 0), zero_rate counts empty share of *polled* time only, and a new coverage field gives % of city samples in which the service was polled. A service polled without ever producing a slot surfaces as an "all offices" row.
- availability_daily now reports mean free slots per polled service instead of the raw city total, so one subscriber to a slot-flooded service no longer spikes the whole city's sparkline.
- Admin rows read "avg · polled X% · empty Y% of polled"; city summaries gain a mean polled %.

Samples recorded before this change have no polled markers, so coverage is undercounted (presence is the floor) for up to 7 days after deploy; scarcity is never overcounted.