### PR TITLE
feat(web): city pages move to /stadt, plus canonicals, hreflang and a sitemap

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,16 @@
      come from the context processor in web.py; the form page overrides title
      and description with the city it is showing. #}
   <meta name="description" content="{{ og_description }}">
+  {% if indexable %}
+    <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="alternate" hreflang="de" href="{{ alternate_de }}">
+    <link rel="alternate" hreflang="en" href="{{ alternate_en }}">
+    <link rel="alternate" hreflang="x-default" href="{{ alternate_de }}">
+  {% else %}
+    {# Token and admin URLs: keep them out of the index entirely. One shared
+       /manage/<token> link in a forum post is enough to get one crawled. #}
+    <meta name="robots" content="noindex, nofollow">
+  {% endif %}
   <meta property="og:site_name" content="Bürgerwecker">
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ og_title }}">

--- a/app/templates/cities.html
+++ b/app/templates/cities.html
@@ -3,6 +3,19 @@
 {% block content %}
   {{ banners(confirmed, error, lang) }}
 
+  {% if unknown_city %}
+    <div class="notice notice-error" role="alert">
+      {% if lang == 'en' %}
+        <strong>We don't have that one.</strong> There's no
+        <code>{{ unknown_city }}</code> here. Pick a city from the list.
+      {% else %}
+        <strong>Die haben wir nicht.</strong> Für
+        <code>{{ unknown_city }}</code> gibt es hier nichts. Such dir eine
+        Stadt aus der Liste aus.
+      {% endif %}
+    </div>
+  {% endif %}
+
   <h1>
     {% if lang == 'en' %}Never miss a free Amt appointment
     {% else %}Nie wieder freie Bürgerbüro-Termine verpassen{% endif %}

--- a/app/web.py
+++ b/app/web.py
@@ -8,8 +8,10 @@ import time as time_mod
 from collections import Counter
 from datetime import time as time_cls
 from urllib.parse import urlencode
+from html import escape
 from pathlib import Path
-from flask import Flask, request, render_template, redirect, send_from_directory
+from flask import (Flask, Response, request, render_template, redirect,
+                   send_from_directory)
 from app.config import load_config
 from app.db import connect, transaction
 from app.catalog import (load_catalog, available_cities, booking_start_url,
@@ -235,19 +237,23 @@ _EMAIL_RE = re.compile(r"[^@\s<>,;\"]+@[^@\s<>,;\"]+\.[A-Za-z]{2,}")
 # The tenant a bare buergerwecker.de lands on.
 _DEFAULT_CITY = "leipzig"
 
-# Link previews. Only these paths may appear in og:url — every other route
-# carries a token in the path (/manage/<token>, /go/<slot_token>), and a
-# preview card is exactly the wrong place for one. Anything else points at the
-# site root, which is also the more useful thing to open.
-_PREVIEWABLE_PATHS = frozenset(("/", "/impressum", "/datenschutz", "/kontakt"))
+# The pages a search engine or a link preview may point at. Everything else —
+# /manage/<token>, /go/<slot_token>, /admin — carries a token or private data
+# in its URL, so those get noindex and a canonical pointing at the site root
+# instead of at themselves. Keyed on endpoint rather than path because the
+# tenant pages are now /<city> and would be indistinguishable from a token.
+_PUBLIC_ENDPOINTS = frozenset(("index", "city_page", "impressum_route",
+                               "datenschutz_route", "kontakt_route"))
 
 _OG_DEFAULT_TITLE = {
     "de": "Bürgerwecker – nie wieder freie Bürgerbüro-Termine verpassen",
     "en": "Bürgerwecker – never miss a free Amt appointment",
 }
+# City first: it is the word that distinguishes this page from the other 28,
+# and titles are truncated from the right in a result list.
 _OG_CITY_TITLE = {
-    "de": "Bürgerwecker – freie Termine in {city}",
-    "en": "Bürgerwecker – free appointment slots in {city}",
+    "de": "{city}: freie Termine beim Amt – Bürgerwecker",
+    "en": "{city}: free appointment slots – Bürgerwecker",
 }
 _OG_DEFAULT_DESC = {
     "de": ("Wir gucken für dich nach freien Terminen und schicken dir eine "
@@ -340,7 +346,7 @@ def _tenant_switcher(city: str | None, lang: str):
     None exactly when the city has several tenants and no single target.
     """
     def url_for_tenant(slug: str) -> str:
-        return f"/?city={slug}" + ("&lang=en" if lang == "en" else "")
+        return f"/{slug}" + ("?lang=en" if lang == "en" else "")
 
     tenants = []
     for other in available_cities():
@@ -429,11 +435,20 @@ def create_app() -> Flask:
         lang = request.args.get("lang")
         lang = lang if lang in ("de", "en") else "de"
         base = app.config["TERMINE_CONFIG"].public_base_url.rstrip("/")
-        path = request.path if request.path in _PREVIEWABLE_PATHS else "/"
+        indexable = request.endpoint in _PUBLIC_ENDPOINTS
+        path = request.path if indexable else "/"
+        # Each language version canonicalises to itself and declares the other
+        # as its alternate. Without the ?lang=en on the English canonical,
+        # Google folds the two into the German one and drops the English page.
+        suffix = "?lang=en" if lang == "en" else ""
         return {"switch_lang_url": switch_lang_url,
                 "og_title": _OG_DEFAULT_TITLE[lang],
                 "og_description": _OG_DEFAULT_DESC[lang],
-                "og_url": base + path,
+                "og_url": f"{base}{path}{suffix}",
+                "canonical_url": f"{base}{path}{suffix}",
+                "alternate_de": f"{base}{path}",
+                "alternate_en": f"{base}{path}?lang=en",
+                "indexable": indexable,
                 "og_image": f"{base}/og-image.png"}
 
     def _result_page(key: str, lang: str, *, status: int = 200,
@@ -463,6 +478,43 @@ def create_app() -> Flask:
         return send_from_directory(Path(__file__).resolve().parent / "static",
                                    "og-image.png", max_age=604800)
 
+    @app.route("/sitemap.xml")
+    def sitemap():
+        """Every indexable URL, both languages, cross-declared with hreflang.
+
+        Cloudflare serves this zone's robots.txt from its own managed content,
+        so this file cannot be advertised there — submit it in Search Console.
+        """
+        base = app.config["TERMINE_CONFIG"].public_base_url.rstrip("/")
+        # Skip a tenant whose catalog doesn't load — a scaffold directory with
+        # only a scraper_config.json is a 404, and a sitemap full of those is
+        # how a site teaches a crawler to distrust it.
+        slugs = []
+        for slug in sorted(available_cities()):
+            try:
+                load_catalog(slug)
+            except CatalogError:
+                continue
+            slugs.append(slug)
+        paths = ["/"] + [f"/{slug}" for slug in slugs] \
+            + ["/impressum", "/datenschutz", "/kontakt"]
+        urls = []
+        for path in paths:
+            de, en = f"{base}{path}", f"{base}{path}?lang=en"
+            for loc, alt_self in ((de, "de"), (en, "en")):
+                urls.append(
+                    f"  <url>\n    <loc>{escape(loc)}</loc>\n"
+                    f'    <xhtml:link rel="alternate" hreflang="de" href="{escape(de)}"/>\n'
+                    f'    <xhtml:link rel="alternate" hreflang="en" href="{escape(en)}"/>\n'
+                    f'    <xhtml:link rel="alternate" hreflang="x-default" href="{escape(de)}"/>\n'
+                    f"    <priority>{'0.8' if alt_self == 'de' else '0.5'}</priority>\n"
+                    f"  </url>")
+        body = ('<?xml version="1.0" encoding="UTF-8"?>\n'
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n'
+                '        xmlns:xhtml="http://www.w3.org/1999/xhtml">\n'
+                + "\n".join(urls) + "\n</urlset>\n")
+        return Response(body, mimetype="application/xml")
+
     @app.route("/healthz")
     def healthz():
         cfg = app.config["TERMINE_CONFIG"]
@@ -475,37 +527,57 @@ def create_app() -> Flask:
         lang = request.args.get("lang", "de")
         if lang not in ("de", "en"):
             lang = "de"
-        city = request.args.get("city")
         # `confirmed=pending` / `subscribe_error=mail` are set by the /subscribe
         # redirect so the form can show a "check your inbox" banner or a
         # retryable error instead of silently re-rendering.
         confirmed = request.args.get("confirmed")
         error = request.args.get("subscribe_error")
-        if city is None:
-            # No city chosen: show the picker, not one city's form. Leipzig was
-            # the default for the first 28 launches, which meant every visitor
-            # from the other 28 cities — and every link preview of the bare
-            # domain — was told about Leipzig.
-            all_cities, _ = _tenant_switcher(None, lang)
-            return render_template("cities.html", lang=lang, cities=all_cities,
-                                   confirmed=confirmed, error=error,
-                                   kofi_url=app.config["TERMINE_CONFIG"].kofi_url)
+        # `/?city=x` was the tenant URL until 2026-08-04 and is all over Reddit,
+        # the press article and already-sent emails. Send it to /x for good so
+        # the search engines fold the two together instead of ranking neither.
+        city = request.args.get("city")
+        if city is not None:
+            args = request.args.to_dict(flat=True)
+            args.pop("city")
+            query = f"?{urlencode(args)}" if args else ""
+            return redirect(f"/{city}{query}", code=301)
+        # No city chosen: show the picker, not one city's form. Leipzig was the
+        # default for the first 28 launches, which meant every visitor from the
+        # other 28 cities — and every link preview of the bare domain — was
+        # told about Leipzig.
+        all_cities, _ = _tenant_switcher(None, lang)
+        return render_template("cities.html", lang=lang, cities=all_cities,
+                               confirmed=confirmed, error=error,
+                               kofi_url=app.config["TERMINE_CONFIG"].kofi_url)
+
+    @app.route("/<city>")
+    def city_page(city):
+        """A tenant's sign-up form. Werkzeug ranks static rules above this one,
+        so /impressum and friends keep their own handlers."""
+        lang = request.args.get("lang", "de")
+        if lang not in ("de", "en"):
+            lang = "de"
+        confirmed = request.args.get("confirmed")
+        error = request.args.get("subscribe_error")
         try:
             catalog = load_catalog(city)
         except CatalogError:
-            # Unknown/garbage ?city= — land on the default tenant, not a 500.
-            return redirect("/?lang=en" if lang == "en" else "/")
+            # Not a tenant. 404 rather than redirect to /, so a mistyped or
+            # retired city is not a soft 404 in the index — but render the
+            # picker with it, because the useful next step is choosing a city.
+            all_cities, _ = _tenant_switcher(None, lang)
+            return render_template("cities.html", lang=lang, cities=all_cities,
+                                   unknown_city=city,
+                                   kofi_url=app.config["TERMINE_CONFIG"].kofi_url), 404
         other_cities, sibling_offices = _tenant_switcher(city, lang)
         # A shared city link should preview as that city. The Amt deliberately
         # stays out of it: for a special-category tenant the office name is the
         # sensitive fact, and it would end up on the card of whoever posts it.
         city_name = catalog.display_text("city_name", lang)
-        base = app.config["TERMINE_CONFIG"].public_base_url.rstrip("/")
-        query = f"?{urlencode({'city': city})}" if city != _DEFAULT_CITY else ""
-        og = {"og_url": f"{base}/{query}"}
+        og = {}
         if city_name:
-            og |= {"og_title": _OG_CITY_TITLE[lang].format(city=city_name),
-                   "og_description": _OG_CITY_DESC[lang].format(city=city_name)}
+            og = {"og_title": _OG_CITY_TITLE[lang].format(city=city_name),
+                  "og_description": _OG_CITY_DESC[lang].format(city=city_name)}
         return render_template("form.html",
                                lang=lang,
                                city=city,
@@ -606,10 +678,10 @@ def create_app() -> Flask:
             delivered = False
         # Carry the city and language back, or the banner would land on the
         # picker in German no matter who just signed up for what.
-        args = {"city": city, "confirmed": "pending" if delivered else "queued"}
+        args = {"confirmed": "pending" if delivered else "queued"}
         if lang == "en":
             args["lang"] = lang
-        return redirect(f"/?{urlencode(args)}")
+        return redirect(f"/{city}?{urlencode(args)}")
 
     @app.route("/confirm/<token>")
     def confirm_route(token):

--- a/tests/test_art9_consent.py
+++ b/tests/test_art9_consent.py
@@ -132,12 +132,12 @@ def _days_until(expires_at: str) -> int:
 def test_ordinary_tenant_form_has_no_consent_box(client):
     """The extra box appears only where it is needed — asking every subscriber
     to consent to Art. 9 processing that never happens would be noise."""
-    body = client.get("/?city=leipzig").data.decode()
+    body = client.get("/leipzig").data.decode()
     assert "consent_special" not in body
 
 
 def test_sensitive_tenant_form_asks_for_explicit_consent(client):
-    body = client.get(f"/?city={SENSITIVE_CITY}").data.decode()
+    body = client.get(f"/{SENSITIVE_CITY}").data.decode()
     assert 'name="consent_special"' in body
     assert "Art. 9" in body
     # Explicit consent means opt-in: never pre-ticked.
@@ -148,7 +148,7 @@ def test_sensitive_tenant_form_asks_for_explicit_consent(client):
 
 
 def test_english_form_offers_the_consent_in_english(client):
-    body = client.get(f"/?city={SENSITIVE_CITY}&lang=en").data.decode()
+    body = client.get(f"/{SENSITIVE_CITY}?lang=en").data.decode()
     assert "I explicitly consent" in body
     assert "Art. 9(2)(a) GDPR" in body
 
@@ -364,7 +364,7 @@ def test_go_sub_link_dies_with_the_subscription(client):
 
 # ---------- referrer ----------
 
-@pytest.mark.parametrize("path", ["/", f"/?city={SENSITIVE_CITY}",
+@pytest.mark.parametrize("path", ["/", f"/{SENSITIVE_CITY}",
                                   "/datenschutz", "/impressum"])
 def test_pages_send_no_referrer(client, path):
     """The URL of a sign-up page names the Amt; without this every outbound

--- a/tests/test_link_preview.py
+++ b/tests/test_link_preview.py
@@ -57,30 +57,30 @@ def test_home_has_the_full_preview_set(client):
 
 
 def test_city_page_previews_that_city(client):
-    html = client.get("/?city=bonn").get_data(as_text=True)
+    html = client.get("/bonn").get_data(as_text=True)
     assert "Bonn" in _meta(html, "og:title")
-    assert _meta(html, "og:url") == "https://buergerwecker.de/?city=bonn"
+    assert _meta(html, "og:url") == "https://buergerwecker.de/bonn"
 
 
 def test_title_and_description_name_the_city(client):
-    html = client.get("/?city=nuernberg").get_data(as_text=True)
-    assert _meta(html, "og:title") == "Bürgerwecker – freie Termine in Nürnberg"
+    html = client.get("/nuernberg").get_data(as_text=True)
+    assert _meta(html, "og:title") == "Nürnberg: freie Termine beim Amt – Bürgerwecker"
     assert "Nürnberg" in _meta(html, "og:description")
-    assert "<title>Bürgerwecker – freie Termine in Nürnberg</title>" in html
-    assert _meta(html, "og:url") == "https://buergerwecker.de/?city=nuernberg"
+    assert "<title>Nürnberg: freie Termine beim Amt – Bürgerwecker</title>" in html
+    assert _meta(html, "og:url") == "https://buergerwecker.de/nuernberg"
 
 
 def test_english_pages_preview_in_english(client):
-    html = client.get("/?city=leipzig&lang=en").get_data(as_text=True)
+    html = client.get("/leipzig?lang=en").get_data(as_text=True)
     assert _meta(html, "og:locale") == "en_GB"
-    assert _meta(html, "og:title").startswith("Bürgerwecker – free appointment slots")
+    assert _meta(html, "og:title").startswith("Leipzig: free appointment slots")
 
 
 def test_amt_of_a_special_category_tenant_stays_off_the_card(client):
     # The office name is the sensitive fact for these tenants, and a preview
     # card ends up in whatever chat the link was pasted into.
-    html = client.get("/?city=muenster-standesamt").get_data(as_text=True)
-    assert _meta(html, "og:title") == "Bürgerwecker – freie Termine in Münster"
+    html = client.get("/muenster-standesamt").get_data(as_text=True)
+    assert _meta(html, "og:title") == "Münster: freie Termine beim Amt – Bürgerwecker"
     assert "Standesamt" not in _meta(html, "og:title")
     assert "Standesamt" not in _meta(html, "og:description")
 
@@ -88,6 +88,68 @@ def test_amt_of_a_special_category_tenant_stays_off_the_card(client):
 def test_token_paths_never_put_their_token_in_og_url(client):
     html = client.get("/manage/not-a-real-token").get_data(as_text=True)
     assert _meta(html, "og:url") == "https://buergerwecker.de/"
+
+
+def _link(html: str, rel: str, hreflang: str | None = None) -> str | None:
+    attr = f' hreflang="{hreflang}"' if hreflang else ""
+    m = re.search(rf'<link rel="{rel}"{attr} href="([^"]*)"', html)
+    return m.group(1) if m else None
+
+
+def test_pages_canonicalise_to_themselves_per_language(client):
+    de = client.get("/nuernberg").get_data(as_text=True)
+    assert _link(de, "canonical") == "https://buergerwecker.de/nuernberg"
+    assert _link(de, "alternate", "en") == "https://buergerwecker.de/nuernberg?lang=en"
+    # The English page must NOT canonicalise to the German one, or Google
+    # folds the two and the English version stops being indexed.
+    en = client.get("/nuernberg?lang=en").get_data(as_text=True)
+    assert _link(en, "canonical") == "https://buergerwecker.de/nuernberg?lang=en"
+    assert _link(en, "alternate", "x-default") == "https://buergerwecker.de/nuernberg"
+
+
+def test_token_and_admin_pages_are_noindex(client):
+    for path in ("/manage/not-a-real-token", "/admin?token=" + "a" * 32):
+        html = client.get(path).get_data(as_text=True)
+        assert '<meta name="robots" content="noindex, nofollow">' in html, path
+        assert '<link rel="canonical"' not in html, path
+
+
+def test_public_pages_are_not_noindex(client):
+    for path in ("/", "/leipzig", "/impressum", "/datenschutz"):
+        html = client.get(path).get_data(as_text=True)
+        assert "noindex" not in html, path
+
+
+def test_sitemap_lists_every_tenant_in_both_languages(client):
+    from app.catalog import available_cities
+    r = client.get("/sitemap.xml")
+    assert r.status_code == 200
+    assert r.mimetype == "application/xml"
+    body = r.get_data(as_text=True)
+    assert "<loc>https://buergerwecker.de/</loc>" in body
+    assert "/manage/" not in body and "/admin" not in body
+    for slug in available_cities():
+        assert f"<loc>https://buergerwecker.de/{slug}</loc>" in body, slug
+        assert f"<loc>https://buergerwecker.de/{slug}?lang=en</loc>" in body, slug
+
+
+def test_every_sitemap_url_actually_resolves(client):
+    """A sitemap that lists 404s is worse than no sitemap."""
+    body = client.get("/sitemap.xml").get_data(as_text=True)
+    locs = re.findall(r"<loc>https://buergerwecker\.de(.*?)</loc>", body)
+    assert len(locs) > 50
+    for path in locs:
+        assert client.get(path.replace("&amp;", "&")).status_code == 200, path
+
+
+def test_no_tenant_slug_shadows_a_real_route(client):
+    """A city called 'kontakt' would be unreachable: Werkzeug matches the
+    static rule first, so the tenant would silently never render."""
+    from app.catalog import available_cities
+    reserved = {"admin", "impressum", "datenschutz", "kontakt", "subscribe",
+                "healthz", "sitemap.xml", "og-image.png", "confirm",
+                "unsubscribe", "manage", "renew", "go", "static"}
+    assert reserved.isdisjoint(set(available_cities()))
 
 
 def test_og_image_is_served(client):

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -54,7 +54,8 @@ def test_subscribe_redirect_returns_to_the_city_and_language(client):
         r = client.post("/subscribe", data=form,
                         headers={"X-Forwarded-For": "203.0.113.9"})
     loc = r.headers["Location"]
-    assert "city=bonn" in loc and "lang=en" in loc and "confirmed=pending" in loc
+    assert loc.startswith("/bonn?")
+    assert "lang=en" in loc and "confirmed=pending" in loc
 
 def test_subscribe_quota_deferral_keeps_registration_and_shows_queued(client):
     """When the confirmation email is deferred (daily quota exhausted), the

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -37,7 +37,7 @@ def test_healthz(client):
     assert r.status_code == 200
 
 def test_form_renders(client):
-    r = client.get("/?city=leipzig")
+    r = client.get("/leipzig")
     assert r.status_code == 200
     assert b"E-Mail" in r.data
     assert b"website" in r.data  # honeypot field name
@@ -47,7 +47,7 @@ def test_root_is_the_city_picker_not_one_citys_form(client):
     body = client.get("/").data.decode()
     assert 'name="email"' not in body                 # no sign-up form here
     assert "class=\"city-grid\"" in body
-    assert "city=leipzig" in body and "city=nuernberg" in body
+    assert 'href="/leipzig"' in body and 'href="/nuernberg"' in body
     assert "Wähle deine Stadt" in body
 
 def test_root_picker_speaks_english_too(client):
@@ -56,8 +56,8 @@ def test_root_picker_speaks_english_too(client):
     assert 'name="email"' not in body
 
 def test_form_offers_de_and_en(client):
-    r_de = client.get("/?city=leipzig&lang=de")
-    r_en = client.get("/?city=leipzig&lang=en")
+    r_de = client.get("/leipzig?lang=de")
+    r_en = client.get("/leipzig?lang=en")
     assert r_de.status_code == 200 and r_en.status_code == 200
     assert b"Anmelden" in r_de.data or b"abonnieren" in r_de.data.lower()
 
@@ -97,15 +97,15 @@ def test_pending_banner_shown_after_subscribe(client):
 def test_no_pending_banner_on_bare_form(client):
     """The pending banner must only appear after subscribing, not on the
     bare form."""
-    body = client.get("/?city=leipzig").data.decode().lower()
+    body = client.get("/leipzig").data.decode().lower()
     assert "fast geschafft" not in body
-    body_en = client.get("/?city=leipzig&lang=en").data.decode().lower()
+    body_en = client.get("/leipzig?lang=en").data.decode().lower()
     assert "almost done" not in body_en
 
 def test_form_en_shows_english_service_and_location_labels(client):
     """The English form must render Leipzig's English service/location labels,
     not the German ones (regression: EN page showed a German dropdown)."""
-    body = client.get("/?city=leipzig&lang=en").data.decode()
+    body = client.get("/leipzig?lang=en").data.decode()
     assert "Applying for an identity card" in body          # EN service label
     assert "Resident Services Office Otto-Schill-Straße" in body  # EN location label
     assert "Personalausweis beantragen" not in body         # German label gone
@@ -113,7 +113,7 @@ def test_form_en_shows_english_service_and_location_labels(client):
 
 
 def test_form_de_still_shows_german_labels(client):
-    body = client.get("/?city=leipzig&lang=de").data.decode()
+    body = client.get("/leipzig?lang=de").data.decode()
     assert "Personalausweis beantragen" in body
     assert "Bürgerbüro Otto-Schill-Straße (Zentrum)" in body
     assert "Applying for an identity card" not in body
@@ -151,29 +151,42 @@ def test_subscribe_error_banner_shown(client):
     assert "try again" in r_en.data.decode().lower()
 
 def test_no_error_banner_on_bare_form(client):
-    body = client.get("/?city=leipzig").data.decode().lower()
+    body = client.get("/leipzig").data.decode().lower()
     assert "leider nicht geklappt" not in body
-    body_en = client.get("/?city=leipzig&lang=en").data.decode().lower()
+    body_en = client.get("/leipzig?lang=en").data.decode().lower()
     assert "didn't go through" not in body_en
 
 
 def test_abh_tenant_form_renders_with_own_copy_and_cross_links(client):
-    """/?city=leipzig-abh renders the Ausländerbehörde tenant: its display.json
+    """/leipzig-abh renders the Ausländerbehörde tenant: its display.json
     heading, the Termin-Code note, its service, and a cross-link back to the
     Bürgerbüro tenant (and vice versa)."""
-    abh = client.get("/?city=leipzig-abh").data.decode()
+    abh = client.get("/leipzig-abh").data.decode()
     assert "Abhol-Termine bei der Leipziger Ausländerbehörde" in abh
     assert "Termin-Code" in abh
     assert "Ausgabe  Aufenthaltsdokument" in abh
-    assert 'city=leipzig' in abh                      # link back
+    assert 'href="/leipzig"' in abh                  # link back
     ba = client.get("/").data.decode()
-    assert "city=leipzig-abh" in ba                   # link over
+    assert 'href="/leipzig-abh"' in ba               # link over
 
 
-def test_unknown_city_redirects_to_default(client):
-    r = client.get("/?city=nope-nothing-here")
-    assert r.status_code == 302
-    assert r.headers["Location"].endswith("/")
+def test_unknown_city_is_a_404_with_the_picker(client):
+    """A retired or mistyped city must be a real 404, not a soft one that
+    redirects to a 200 — but still show the list, which is the way out."""
+    r = client.get("/nope-nothing-here")
+    assert r.status_code == 404
+    body = r.data.decode()
+    assert "nope-nothing-here" in body and "Wähle deine Stadt" in body
+
+
+def test_old_query_urls_redirect_permanently(client):
+    """/?city=x is in the press article, on Reddit and in old previews."""
+    r = client.get("/?city=nuernberg")
+    assert r.status_code == 301
+    assert r.headers["Location"] == "/nuernberg"
+    r_en = client.get("/?city=nuernberg&lang=en")
+    assert r_en.status_code == 301
+    assert r_en.headers["Location"] == "/nuernberg?lang=en"
 
 
 def test_city_switcher_groups_a_multi_tenant_city_into_one_cell(client):
@@ -181,7 +194,7 @@ def test_city_switcher_groups_a_multi_tenant_city_into_one_cell(client):
     link, a city with several Ämter becomes one cell listing them by short
     name. The long "Leipzig: …" tenant labels must not reach the grid — they
     are what forced the ellipsis that made the old flat list unreadable."""
-    body = client.get("/?city=dresden").data.decode()
+    body = client.get("/dresden").data.decode()
     assert '<details class="city-switch"' in body
     assert '>Bochum</a>' in body                       # bare name
     assert 'Bochum: ' not in body                      # not the long label
@@ -196,7 +209,7 @@ def test_city_switcher_counts_cities_not_tenants(client):
     not rows. Münster alone contributes seven tenants and one entry."""
     import re
     from app.catalog import available_cities
-    body = client.get("/?city=dresden").data.decode()
+    body = client.get("/dresden").data.decode()
     shown = int(re.search(r"Weitere Städte &amp; Ämter \((\d+)\)", body).group(1))
     assert shown < len(available_cities()) - 1
     assert body.count('<div class="city-cell">') >= 2   # Leipzig and Münster
@@ -205,18 +218,18 @@ def test_city_switcher_counts_cities_not_tenants(client):
 def test_current_city_offices_get_their_own_row(client):
     """Landing on one Amt of a multi-Amt city offers its siblings directly,
     with the current one unlinked — the second step of city → Amt."""
-    body = client.get("/?city=muenster").data.decode()
+    body = client.get("/muenster").data.decode()
     assert 'class="office-switch"' in body
     assert "Ämter in Münster:" in body
     assert '<span class="current" aria-current="page">Bürgeramt</span>' in body
-    assert 'href="/?city=muenster-standesamt"' in body
+    assert 'href="/muenster-standesamt"' in body
     # A city with one tenant has no such row, and never lists itself twice.
-    single = client.get("/?city=dresden").data.decode()
+    single = client.get("/dresden").data.decode()
     assert 'class="office-switch"' not in single
 
 def test_form_has_fairness_faq_in_both_languages(client):
-    de = client.get("/?city=leipzig&lang=de").data.decode()
-    en = client.get("/?city=leipzig&lang=en").data.decode()
+    de = client.get("/leipzig?lang=de").data.decode()
+    en = client.get("/leipzig?lang=en").data.decode()
     assert "Ist das fair?" in de
     assert "Bucht das Tool Termine?" in de
     assert "Is this fair?" in en
@@ -240,7 +253,7 @@ def test_form_embeds_service_locations_map_when_present(client, tmp_path, monkey
     monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", root)
     catalog_mod.load_catalog.cache_clear()
     try:
-        body = client.get("/?city=leipzig").data.decode()
+        body = client.get("/leipzig").data.decode()
     finally:
         catalog_mod.load_catalog.cache_clear()
     assert 'id="service-locations"' in body
@@ -257,7 +270,7 @@ def test_form_omits_filter_script_without_map(client, tmp_path, monkeypatch):
     monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", root)
     catalog_mod.load_catalog.cache_clear()
     try:
-        body = client.get("/?city=leipzig").data.decode()
+        body = client.get("/leipzig").data.decode()
     finally:
         catalog_mod.load_catalog.cache_clear()
     assert 'id="service-locations"' not in body


### PR DESCRIPTION
Follow-up to #44. City pages are `/nuernberg` instead of `/?city=nuernberg`; the old query form 301s, since it's in the L-IZ article, the Reddit posts, and every link preview already cached out there.

The rest is the SEO surface the site never had:

| | before | after |
|---|---|---|
| city URL | `/?city=nuernberg` | `/nuernberg` (old one 301s) |
| canonical | none | per page, per language |
| hreflang | none | de / en / x-default |
| sitemap | none | `/sitemap.xml`, 36 tenants × 2 languages |
| token & admin pages | indexable | `noindex, nofollow` |
| unknown city | 302 → `/` (soft 404) | real 404, with the city list on it |

Two details worth a look:

- **The English page canonicalises to itself** (`/nuernberg?lang=en`), not to the German one. Pointing both at the German URL is the usual mistake and it makes Google drop the English version.
- **The sitemap skips tenants whose catalog doesn't load** — a scaffold directory with only a `scraper_config.json` is a 404, and a sitemap full of 404s teaches a crawler to distrust the rest. There's a test that every URL in the sitemap returns 200, and another that no tenant slug collides with a real route (a city called `kontakt` would be silently unreachable).

Not done, deliberately: no JSON-LD. FAQPage rich results have been limited to government and health sites since 2023, so it would be markup nobody renders.

Needs a manual step after deploy: submit `https://buergerwecker.de/sitemap.xml` in Google Search Console. Cloudflare serves this zone's robots.txt from its managed content, so the sitemap can't be advertised there.