### PR TITLE
fix(web): open redirect via ?city=, introduced in #45

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 import json
+import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
 CATALOG_ROOT = Path(__file__).parent.parent / "catalog"
+
+# The shape of every tenant directory name, and the only thing load_catalog
+# will look up. Notably excludes "/", "\" and "." — see load_catalog.
+_SLUG_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 
 class CatalogError(Exception):
     pass
@@ -122,6 +127,13 @@ class Catalog:
 
 @lru_cache(maxsize=8)
 def load_catalog(city: str) -> Catalog:
+    # A tenant slug arrives straight from a URL, so validate its shape before
+    # it is joined onto a path: "../.." would walk out of the catalog root, and
+    # the lru_cache would then key on whatever was passed. Every tenant
+    # directory is lowercase letters, digits and hyphens (test_catalog asserts
+    # it), so anything else is not a city we have.
+    if not _SLUG_RE.fullmatch(city or ""):
+        raise CatalogError(f"Unknown city: {city}")
     city_dir = CATALOG_ROOT / city
     if not city_dir.is_dir():
         raise CatalogError(f"Unknown city: {city}")

--- a/app/web.py
+++ b/app/web.py
@@ -197,6 +197,15 @@ _RESULT_MESSAGES: dict[str, dict] = {
                "under Art. 9 GDPR. We need your explicit consent for it — "
                "please go back and tick the additional box."),
     },
+    "unknown_city": {
+        "kind": "error",
+        "de": ("Stadt unbekannt", "Diese Stadt gibt es hier nicht",
+               "Die Anmeldung nennt eine Stadt, die wir nicht anbieten. Bitte "
+               "wähle sie auf der Startseite aus."),
+        "en": ("Unknown city", "We don't cover that city",
+               "The sign-up named a city we don't offer. Please pick one from "
+               "the home page."),
+    },
     "missing_type": {
         "kind": "error",
         "de": ("Anliegen fehlt", "Bitte wähle ein Anliegen",
@@ -387,6 +396,22 @@ def _tenant_switcher(city: str | None, lang: str):
     return other_cities, sibling_offices
 
 
+def _is_tenant(city: str | None) -> bool:
+    """True only for a slug we actually serve.
+
+    The gate for every request-supplied city that ends up in a URL or a
+    subscription row. load_catalog validates the slug's shape; this also
+    requires the tenant to exist.
+    """
+    if not city:
+        return False
+    try:
+        load_catalog(city)
+    except CatalogError:
+        return False
+    return True
+
+
 def _offered_sensitive(catalog) -> list[str]:
     """Uuids of this tenant's *offered* special-category services.
 
@@ -537,6 +562,13 @@ def create_app() -> Flask:
         # the search engines fold the two together instead of ranking neither.
         city = request.args.get("city")
         if city is not None:
+            # Only ever redirect to a tenant we actually have. `city` is user
+            # input and lands in a Location header: "/" + "/evil.example.com"
+            # is "//evil.example.com", a protocol-relative URL that browsers
+            # follow off-site. Anything unknown falls through to city_page,
+            # which 404s with the picker.
+            if not _is_tenant(city):
+                return city_page(city)
             args = request.args.to_dict(flat=True)
             args.pop("city")
             query = f"?{urlencode(args)}" if args else ""
@@ -623,6 +655,11 @@ def create_app() -> Flask:
             return _result_page("rate_limited", lang, status=429)
         # 4. parse filter from form
         city = request.form.get("city", _DEFAULT_CITY)
+        # An unknown city used to be stored anyway — a subscription no poller
+        # would ever match — and since the redirect below builds "/{city}", it
+        # also let a posted form choose the Location header.
+        if not _is_tenant(city):
+            return _result_page("unknown_city", lang, status=400)
         atype = request.form.get("appointment_type", "").strip()
         if not atype:
             return _result_page("missing_type", lang, status=400)

--- a/tests/test_open_redirect.py
+++ b/tests/test_open_redirect.py
@@ -1,0 +1,114 @@
+"""A city slug reaches a Location header, so it is untrusted input.
+
+`redirect("/" + city)` with city="/evil.example.com" emits
+`Location: //evil.example.com` — a protocol-relative URL every browser follows
+off-site. On a site whose whole pitch is that it is safe to trust with an Amt
+appointment, an open redirect is a phishing kit.
+"""
+import pytest
+from app.web import create_app
+from app.db import connect, init_schema
+from app.catalog import load_catalog, CatalogError
+
+# "/x" is the one that actually escapes: "/" + "/x" == "//x". The rest cover
+# the usual browser-normalisation tricks around it.
+PAYLOADS = [
+    "/evil.example.com",
+    "//evil.example.com",
+    "/\\evil.example.com",
+    "\\\\evil.example.com",
+    "///evil.example.com",
+    "/%2Fevil.example.com",
+    "https://evil.example.com",
+    "..",
+    "../..",
+    "../../etc",
+]
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "t.db"))
+    monkeypatch.setenv("TOKEN_SECRET_PRIMARY", "x"*32)
+    monkeypatch.setenv("TOKEN_SECRET_PREVIOUS", "")
+    monkeypatch.setenv("SUBSCRIPTION_TTL_DAYS", "90")
+    monkeypatch.setenv("SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR", "50")
+    monkeypatch.setenv("SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY", "50")
+    monkeypatch.setenv("MAILJET_API_KEY", "mj"); monkeypatch.setenv("MAILJET_API_SECRET", "mj")
+    monkeypatch.setenv("MAILJET_FROM_EMAIL", "x@x"); monkeypatch.setenv("MAILJET_FROM_NAME", "x")
+    monkeypatch.setenv("MAILJET_DAILY_QUOTA", "6000")
+    monkeypatch.setenv("RESEND_API_KEY", "re")
+    monkeypatch.setenv("ADMIN_TOKEN", "a"*32)
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://buergerwecker.de")
+    monkeypatch.setenv("DEDUP_WINDOW_HOURS","24");monkeypatch.setenv("RATE_LIMIT_MINUTES","15")
+    monkeypatch.setenv("RENEWAL_REMINDER_DAYS_BEFORE","10");monkeypatch.setenv("MAX_PLANS_PER_CITY","10")
+    monkeypatch.setenv("PARSER_CANARY_THRESHOLD_HOURS","2")
+    monkeypatch.setenv("DEVELOPER_EMAIL","dev@x");monkeypatch.setenv("KOFI_URL","https://k")
+    init_schema(connect(str(tmp_path / "t.db")))
+    app = create_app(); app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _offsite(location: str | None) -> bool:
+    """Would a browser leave buergerwecker.de for this Location?"""
+    if not location:
+        return False
+    normalised = location.replace("\\", "/")
+    return normalised.startswith("//") or "://" in normalised
+
+
+@pytest.mark.parametrize("payload", PAYLOADS)
+def test_legacy_city_query_cannot_redirect_off_site(client, payload):
+    r = client.get("/", query_string={"city": payload})
+    assert not _offsite(r.headers.get("Location")), r.headers.get("Location")
+    assert r.status_code == 404
+
+
+@pytest.mark.parametrize("payload", PAYLOADS)
+def test_subscribe_cannot_redirect_off_site(client, payload):
+    # GLOBAL_IP_LIMITER is a singleton for the whole test session, so each
+    # POST needs an IP nobody else claims — 203.0.113.x is already spoken for
+    # by the rate-limit tests.
+    from unittest.mock import patch
+    form = {
+        "lang": "de", "city": payload, "email": "alice@example.com",
+        "appointment_type": "29cd0a26-fe7a-4d65-88cd-1e05fd749c71",
+        "all_locations": "1", "time_start": "00:00", "time_end": "23:59",
+        "weekdays": ["1"], "website": "",
+    }
+    with patch("app.web._send_confirmation_email", return_value=True):
+        r = client.post("/subscribe", data=form,
+                        headers={"X-Forwarded-For": f"198.51.100.{100 + PAYLOADS.index(payload)}"})
+    assert not _offsite(r.headers.get("Location")), r.headers.get("Location")
+    assert r.status_code == 400
+
+
+def test_unknown_city_is_not_stored_as_a_subscription(client):
+    """It could never be polled, so it is a row nobody will ever notify."""
+    from unittest.mock import patch
+    import os
+    form = {
+        "lang": "de", "city": "not-a-city", "email": "bob@example.com",
+        "appointment_type": "29cd0a26-fe7a-4d65-88cd-1e05fd749c71",
+        "all_locations": "1", "time_start": "00:00", "time_end": "23:59",
+        "weekdays": ["1"], "website": "",
+    }
+    with patch("app.web._send_confirmation_email", return_value=True):
+        client.post("/subscribe", data=form,
+                    headers={"X-Forwarded-For": "198.51.100.150"})
+    conn = connect(os.environ["DB_PATH"])
+    assert conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("slug", ["../catalog", "..", "leipzig/../leipzig",
+                                  "Leipzig", "leipzig ", ""])
+def test_load_catalog_rejects_anything_that_is_not_a_slug(slug):
+    """Path traversal at the source: CATALOG_ROOT / city with an unchecked
+    city walks out of the catalog directory, and lru_cache then keys on it."""
+    with pytest.raises(CatalogError):
+        load_catalog(slug)
+
+
+def test_load_catalog_still_loads_real_tenants():
+    assert load_catalog("leipzig").city == "leipzig"
+    assert load_catalog("muenster-standesamt").city == "muenster-standesamt"


### PR DESCRIPTION
Found by the automated security review on #45, confirmed by hand. My bug, shipped this afternoon.

**The hole**

```
GET /?city=/evil.example.com
→ 301  Location: //evil.example.com
```

`"/" + "/evil.example.com"` is `//evil.example.com`, a protocol-relative URL — browsers read that as `https://evil.example.com` and leave. So a link whose visible prefix is `buergerwecker.de` lands somewhere else. For a service whose whole pitch is that it's safe to trust with an Amt appointment, that's the worst kind of bug to hand out. `/\evil.example.com` works too, browsers normalise the backslash.

`/subscribe` had the same via its `city` form field, and on the way there it stored the bogus city as a subscription row no poller would ever match.

**Three fixes, outermost last**

1. `load_catalog()` only accepts a slug shaped like a real tenant directory (`[a-z0-9][a-z0-9-]*`). It joined the raw value onto a path, so `../..` walked out of the catalog root, and the `lru_cache` then kept an entry keyed on whatever was passed. This one covers the poller and digest paths too, not just the web app.
2. `_is_tenant()` gates every request-supplied city before it becomes a URL. Unknown → the 404 picker.
3. `/subscribe` rejects an unknown city with a 400 and a localized message, instead of storing it.

**Tests** — `tests/test_open_redirect.py`, 10 payloads × both entry points, asserting on whether a browser would go off-site rather than on an exact string. Plus traversal cases against `load_catalog` directly. I checked they fail against the previous commit.

One note for whoever writes the next `/subscribe` test: `GLOBAL_IP_LIMITER` is a session-wide singleton, and `203.0.113.7` is already claimed by `test_ip_ratelimit_ignores_spoofed_cf_header` — my first draft picked the same IP and broke that test from three files away.