### PR TITLE
Datenschutz: add netcup to processor lists

### DIFF
--- a/app/templates/datenschutz.html
+++ b/app/templates/datenschutz.html
@@ -13,7 +13,7 @@
     <h2>Retention period</h2>
     <p>Subscriptions expire automatically 90 days after sign-up — 30 days for the sensitive appointment types described above — unless extended via the renewal link. Deleted records are permanently removed 30 days after deletion.</p>
     <h2>Processors</h2>
-    <p>Cloudflare, Inc. (content delivery & DDoS protection; processes visitors' IP addresses to serve and protect the site — certified under the EU-US Data Privacy Framework). Mailjet (EU servers) and Resend (EU servers, Ireland region) for email delivery. A data processing agreement (DPA) is in place with all providers.</p>
+    <p>Cloudflare, Inc. (content delivery & DDoS protection; processes visitors' IP addresses to serve and protect the site — certified under the EU-US Data Privacy Framework). netcup GmbH, Karlsruhe, Germany (hosting; EU data center). Mailjet (EU servers) and Resend (EU servers, Ireland region) for email delivery. A data processing agreement (DPA) is in place with all providers.</p>
     <h2>Your rights</h2>
     <p>Access (Art. 15), rectification (Art. 16), erasure (Art. 17), restriction (Art. 18), portability (Art. 20), withdrawal of consent (Art. 7(3)). Contact: jakub@jakubwaller.eu.</p>
   {% else %}
@@ -29,7 +29,7 @@
     <h2>Speicherdauer</h2>
     <p>Abonnements laufen 90 Tage nach der Erstanmeldung automatisch ab — bei den oben beschriebenen besonders geschützten Anliegen nach 30 Tagen —, sofern sie nicht über den Erneuerungslink verlängert werden. Gelöschte Datensätze werden 30 Tage nach der Löschung endgültig entfernt.</p>
     <h2>Auftragsverarbeiter</h2>
-    <p>Cloudflare, Inc. (Auslieferung & DDoS-Schutz; verarbeitet die IP-Adressen der Besucher, um die Seite auszuliefern und zu schützen — zertifiziert nach dem EU-US Data Privacy Framework). Mailjet (EU-Server) und Resend (EU-Server, Region Irland) zum Versand der E-Mails. Mit allen Anbietern besteht ein AVV-Vertrag.</p>
+    <p>Cloudflare, Inc. (Auslieferung & DDoS-Schutz; verarbeitet die IP-Adressen der Besucher, um die Seite auszuliefern und zu schützen — zertifiziert nach dem EU-US Data Privacy Framework). netcup GmbH, Karlsruhe (Hosting; EU-Rechenzentrum). Mailjet (EU-Server) und Resend (EU-Server, Region Irland) zum Versand der E-Mails. Mit allen Anbietern besteht ein AVV-Vertrag.</p>
     <h2>Deine Rechte</h2>
     <p>Auskunft (Art. 15), Berichtigung (Art. 16), Löschung (Art. 17), Einschränkung (Art. 18), Datenübertragbarkeit (Art. 20), Widerruf der Einwilligung (Art. 7(3)). Kontakt: jakub@jakubwaller.eu.</p>
   {% endif %}


### PR DESCRIPTION
Adds netcup GmbH, Karlsruhe (hosting, EU data center) to the Processors / Auftragsverarbeiter sections in both languages, ahead of the hosting move to a netcup VPS.

**Do not merge until** (1) the netcup AVV is concluded in the customer panel and (2) the site actually serves from the VPS — the page claims a DPA is in place with all listed providers.