### PR TITLE
feat(bochum): Straßenverkehrsamt, as two tenants on the Bürgerbüro's host

### DIFF
--- a/app/scrapers/__init__.py
+++ b/app/scrapers/__init__.py
@@ -29,6 +29,12 @@ _REGISTRY: dict[str, ModuleType] = {
     "leipzig-abh": smartcjm,
     "dresden": tevis,
     "bochum": smartcjm,
+    # Bochum Straßenverkehrsamt (today the Büro für Kfz-Angelegenheiten),
+    # added 2026-08 on an r/bochum request: two calendars on the same
+    # Smart-CJM host as the Bürgerbüro, Mandant /m/kfz-angelegenheiten/,
+    # no locations step (one office each).
+    "bochum-fuehrerschein": smartcjm,
+    "bochum-kfz": smartcjm,
     "bonn": smartcjm,
     # TEVIS wave 2026-07 (vendor survey Tier 1): per-city config lives in
     # catalog/<slug>/; all share the Dresden scraper.

--- a/catalog/bochum-fuehrerschein/appointment_type.en.json
+++ b/catalog/bochum-fuehrerschein/appointment_type.en.json
@@ -1,0 +1,17 @@
+{
+  "FS - Aushändigung Fahrberechtigung": "3769a016-9356-440f-9d63-7e8c9bbbf0e5",
+  "FS - Ausstellung Fahrerkarte, Ersatz defekte Fahrerkarte": "565137b3-2ba0-46c7-b97d-ea5c6505d4e4",
+  "FS - Ausstellung eines Fahrerqualifizierungsnachweises (Berufskraftfahrerqualifikation)": "591c1fdc-daf6-4614-a4b8-86fde3cf4361",
+  "FS - Beantragung der Erteilung einer Fahrerlaubnis (Führerscheinantrag)": "0e16c179-d4a8-478b-83d2-f78d7d13bd8e",
+  "FS - Beantragung der Erweiterung einer Fahrerlaubnis (Antrag auf weitere Führerscheinklassen)": "fe9a405d-8b97-446c-9179-f1eaf62a4454",
+  "FS - Begleitetes Fahren ab 17 Jahre": "42d1fcc7-1e17-4db8-a15f-cf61dceaa59a",
+  "FS - Ersatzführerschein (Verlust, Diebstahl)": "ac6ff68b-c98d-4267-859e-259798e5d42b",
+  "FS - Erteilung einer vorläufigen Fahrberechtigung nach bestandener Prüfung": "3c2dc4aa-d199-4ede-8c92-0fb495903b1e",
+  "FS - Fahrerlaubnis zur Fahrgastbeförderung": "5dfddf59-3d7f-488d-9702-fef42f548657",
+  "FS - Fahrschulwechsel, Änderungen zum bestehenden Antrag": "0dba09e3-31b0-4a03-95a3-b7187f07f276",
+  "FS - Internationaler Führerschein": "a6302f78-b528-4228-a109-636cf6940a61",
+  "FS - Umstellung Papier-/Kartenführerschein in  den  neuen EU-Kartenführerschein": "013012e9-e960-4549-a984-7c7d31080d83",
+  "FS - Umtausch ausländische Fahrerlaubnis aus Drittstaaten (Nicht EU-Staaten)": "0f392afd-079b-4cb9-aa55-929fe4b67747",
+  "FS - Umtausch ausländische Fahrerlaubnis aus EU-Staaten": "535eb608-48b8-4c2a-8f2d-8645740dbf25",
+  "FS - Verlängerung der Klassen C oder D": "383451f9-bb20-49db-9e78-f39e529b4f2b"
+}

--- a/catalog/bochum-fuehrerschein/appointment_type.json
+++ b/catalog/bochum-fuehrerschein/appointment_type.json
@@ -1,0 +1,17 @@
+{
+  "FS - Aushändigung Fahrberechtigung": "3769a016-9356-440f-9d63-7e8c9bbbf0e5",
+  "FS - Ausstellung Fahrerkarte, Ersatz defekte Fahrerkarte": "565137b3-2ba0-46c7-b97d-ea5c6505d4e4",
+  "FS - Ausstellung eines Fahrerqualifizierungsnachweises (Berufskraftfahrerqualifikation)": "591c1fdc-daf6-4614-a4b8-86fde3cf4361",
+  "FS - Beantragung der Erteilung einer Fahrerlaubnis (Führerscheinantrag)": "0e16c179-d4a8-478b-83d2-f78d7d13bd8e",
+  "FS - Beantragung der Erweiterung einer Fahrerlaubnis (Antrag auf weitere Führerscheinklassen)": "fe9a405d-8b97-446c-9179-f1eaf62a4454",
+  "FS - Begleitetes Fahren ab 17 Jahre": "42d1fcc7-1e17-4db8-a15f-cf61dceaa59a",
+  "FS - Ersatzführerschein (Verlust, Diebstahl)": "ac6ff68b-c98d-4267-859e-259798e5d42b",
+  "FS - Erteilung einer vorläufigen Fahrberechtigung nach bestandener Prüfung": "3c2dc4aa-d199-4ede-8c92-0fb495903b1e",
+  "FS - Fahrerlaubnis zur Fahrgastbeförderung": "5dfddf59-3d7f-488d-9702-fef42f548657",
+  "FS - Fahrschulwechsel, Änderungen zum bestehenden Antrag": "0dba09e3-31b0-4a03-95a3-b7187f07f276",
+  "FS - Internationaler Führerschein": "a6302f78-b528-4228-a109-636cf6940a61",
+  "FS - Umstellung Papier-/Kartenführerschein in  den  neuen EU-Kartenführerschein": "013012e9-e960-4549-a984-7c7d31080d83",
+  "FS - Umtausch ausländische Fahrerlaubnis aus Drittstaaten (Nicht EU-Staaten)": "0f392afd-079b-4cb9-aa55-929fe4b67747",
+  "FS - Umtausch ausländische Fahrerlaubnis aus EU-Staaten": "535eb608-48b8-4c2a-8f2d-8645740dbf25",
+  "FS - Verlängerung der Klassen C oder D": "383451f9-bb20-49db-9e78-f39e529b4f2b"
+}

--- a/catalog/bochum-fuehrerschein/display.json
+++ b/catalog/bochum-fuehrerschein/display.json
@@ -1,0 +1,18 @@
+{
+  "city_name": {
+    "de": "Bochum",
+    "en": "Bochum"
+  },
+  "office": {
+    "de": "Führerscheinstelle",
+    "en": "Driving licence office"
+  },
+  "label": {
+    "de": "Bochum: Führerscheinstelle (Führerscheinantrag, Umtausch u. a.)",
+    "en": "Bochum: driving licence office (applications, exchange, …)"
+  },
+  "heading": {
+    "de": "Nie wieder freie Termine bei der Führerscheinstelle Bochum verpassen",
+    "en": "Never miss a free slot at Bochum's driving licence office"
+  }
+}

--- a/catalog/bochum-fuehrerschein/locations.json
+++ b/catalog/bochum-fuehrerschein/locations.json
@@ -1,0 +1,3 @@
+{
+  "Führerscheinstelle (Bulksmühle 17)": "73cd536b-6222-406b-87e2-6a94bdd8b407"
+}

--- a/catalog/bochum-fuehrerschein/scraper_config.json
+++ b/catalog/bochum-fuehrerschein/scraper_config.json
@@ -1,0 +1,8 @@
+{
+  "vendor": "smartcjm",
+  "base_url": "https://termine.bochum.de/m/kfz-angelegenheiten/extern/calendar",
+  "uid": "7117acdd-f28b-4db4-abf8-b7860edd7d22",
+  "steps": "servicessearch_resultsbookingfinish",
+  "poll_interval_seconds": 300,
+  "max_plans": 24
+}

--- a/catalog/bochum-kfz/appointment_type.en.json
+++ b/catalog/bochum-kfz/appointment_type.en.json
@@ -1,0 +1,13 @@
+{
+  "Kfz - Abmeldung eines in Bochum angemeldeten Fahrzeuges": "bd32e722-3d86-498d-abff-06c00748ac49",
+  "Kfz - Anmeldung bzw. Ummeldung eines Fahrzeuges mit deutschen Fahrzeugpapieren": "0ca5c411-4197-4a43-b35f-d71d5a68f448",
+  "Kfz - Anmeldung eines Fahrzeuges ohne deutsche Fahrzeugpapiere": "f0cbfa98-ebfc-4fad-bb15-0f4784b7ceef",
+  "Kfz - Ausstellung einer Umweltplakette": "ee99ddba-8202-46bf-abfd-4e5e61aff70e",
+  "Kfz - Bewohnerparkausweise": "ac013750-2ad1-4e21-9214-6b0d81145fae",
+  "Kfz - Kurzzeitkennzeichen": "03ae67e1-9222-4c34-bc52-f4037b54878c",
+  "Kfz - Namens- / Adressänderung": "e8771133-fc4c-4db8-b77c-c5418c6ab191",
+  "Kfz - Neuabstempelung eines beschädigten Kennzeichens": "930ede1d-68a3-4023-bc2a-307266035131",
+  "Kfz - Technische Änderungen eintragen": "5e2453e2-42b4-4f6c-94c1-2b455884c84a",
+  "Kfz - Umkennzeichnung / Änderung Saisonkennzeichen": "dfea45d3-284f-448d-baa7-c8d4b3935b49",
+  "Kfz - Verlust von Fahrzeugpapieren": "386f6ad5-602f-4485-84d0-ea75e0790a2f"
+}

--- a/catalog/bochum-kfz/appointment_type.json
+++ b/catalog/bochum-kfz/appointment_type.json
@@ -1,0 +1,13 @@
+{
+  "Kfz - Abmeldung eines in Bochum angemeldeten Fahrzeuges": "bd32e722-3d86-498d-abff-06c00748ac49",
+  "Kfz - Anmeldung bzw. Ummeldung eines Fahrzeuges mit deutschen Fahrzeugpapieren": "0ca5c411-4197-4a43-b35f-d71d5a68f448",
+  "Kfz - Anmeldung eines Fahrzeuges ohne deutsche Fahrzeugpapiere": "f0cbfa98-ebfc-4fad-bb15-0f4784b7ceef",
+  "Kfz - Ausstellung einer Umweltplakette": "ee99ddba-8202-46bf-abfd-4e5e61aff70e",
+  "Kfz - Bewohnerparkausweise": "ac013750-2ad1-4e21-9214-6b0d81145fae",
+  "Kfz - Kurzzeitkennzeichen": "03ae67e1-9222-4c34-bc52-f4037b54878c",
+  "Kfz - Namens- / Adressänderung": "e8771133-fc4c-4db8-b77c-c5418c6ab191",
+  "Kfz - Neuabstempelung eines beschädigten Kennzeichens": "930ede1d-68a3-4023-bc2a-307266035131",
+  "Kfz - Technische Änderungen eintragen": "5e2453e2-42b4-4f6c-94c1-2b455884c84a",
+  "Kfz - Umkennzeichnung / Änderung Saisonkennzeichen": "dfea45d3-284f-448d-baa7-c8d4b3935b49",
+  "Kfz - Verlust von Fahrzeugpapieren": "386f6ad5-602f-4485-84d0-ea75e0790a2f"
+}

--- a/catalog/bochum-kfz/display.json
+++ b/catalog/bochum-kfz/display.json
@@ -1,0 +1,18 @@
+{
+  "city_name": {
+    "de": "Bochum",
+    "en": "Bochum"
+  },
+  "office": {
+    "de": "Kfz-Zulassungsstelle",
+    "en": "Vehicle registration office"
+  },
+  "label": {
+    "de": "Bochum: Kfz-Zulassungsstelle (An-, Um- und Abmeldung u. a.)",
+    "en": "Bochum: vehicle registration (registration, deregistration, …)"
+  },
+  "heading": {
+    "de": "Nie wieder freie Termine bei der Kfz-Zulassungsstelle Bochum verpassen",
+    "en": "Never miss a free slot at Bochum's vehicle registration office"
+  }
+}

--- a/catalog/bochum-kfz/locations.json
+++ b/catalog/bochum-kfz/locations.json
@@ -1,0 +1,3 @@
+{
+  "Büro für Kfz-Angelegenheiten (Bulksmühle 17)": "6f358667-4bfb-472f-91ba-be1857c26ebc"
+}

--- a/catalog/bochum-kfz/scraper_config.json
+++ b/catalog/bochum-kfz/scraper_config.json
@@ -1,0 +1,7 @@
+{
+  "vendor": "smartcjm",
+  "base_url": "https://termine.bochum.de/m/kfz-angelegenheiten/extern/calendar",
+  "uid": "bffa082e-0640-40b4-ad60-4a98355850ff",
+  "steps": "servicessearch_resultsbookingfinish",
+  "poll_interval_seconds": 300
+}

--- a/catalog/bochum/display.json
+++ b/catalog/bochum/display.json
@@ -3,6 +3,10 @@
     "de": "Bochum",
     "en": "Bochum"
   },
+  "office": {
+    "de": "Bürgerbüro",
+    "en": "Citizens' office"
+  },
   "label": {
     "de": "Bochum: Bürgerbüro-Termine (Anmeldung, Ausweise u. a.)",
     "en": "Bochum: citizen office appointments (registration, ID cards, …)"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -207,3 +207,24 @@ def test_only_city_approved_tenants_offer_a_sensitive_service():
         except CatalogError:
             continue
     assert offering == ["muenster-standesamt"]
+
+
+def test_shipped_bochum_kfz_tenants_protect_the_shared_host():
+    """The Straßenverkehrsamt tenants share termine.bochum.de with a
+    Bürgerbüro that already 429s at 180s, so both must poll at the slow
+    cadence; and the Führerscheinstelle's 15 Anliegen at one office sit a
+    single upstream addition away from the global cap of 16, so it carries
+    its own headroom (the per-type "all" collapse frees nothing there)."""
+    from urllib.parse import urlsplit
+    from app.catalog import load_catalog
+    buergerbuero_host = urlsplit(
+        load_catalog("bochum").scraper_config["base_url"]).netloc
+    for slug in ("bochum-kfz", "bochum-fuehrerschein"):
+        cat = load_catalog(slug)
+        scfg = cat.scraper_config
+        assert urlsplit(scfg["base_url"]).netloc == buergerbuero_host
+        assert scfg["poll_interval_seconds"] >= 300
+        assert "locations" not in scfg["steps"]   # single-office flow
+        assert len(cat.locations) == 1
+    fs = load_catalog("bochum-fuehrerschein")
+    assert fs.scraper_config["max_plans"] > len(fs.appointment_types)

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -196,12 +196,17 @@ def test_city_switcher_groups_a_multi_tenant_city_into_one_cell(client):
     are what forced the ellipsis that made the old flat list unreadable."""
     body = client.get("/dresden").data.decode()
     assert '<details class="city-switch"' in body
-    assert '>Bochum</a>' in body                       # bare name
-    assert 'Bochum: ' not in body                      # not the long label
+    assert '>Bonn</a>' in body                         # bare name
+    assert 'Bonn: ' not in body                        # not the long label
     assert '<div class="city-cell">' in body
     assert 'Leipzig: Bürgerbüro-Termine' not in body   # long label stays out
     assert '>Bürgerbüro</a>' in body                   # short office names
     assert '>Ausländerbehörde</a>' in body
+    # Bochum grew from one tenant to three (Straßenverkehrsamt request), so it
+    # is a cell now, not a bare link.
+    assert '>Bochum</a>' not in body
+    assert '>Kfz-Zulassungsstelle</a>' in body
+    assert '>Führerscheinstelle</a>' in body
 
 
 def test_city_switcher_counts_cities_not_tenants(client):


### PR DESCRIPTION
An r/bochum user asked for the Straßenverkehrsamt in the launch thread. It's nowadays the Büro für Kfz-Angelegenheiten and books through the same Smart-CJM instance as the Bürgerbüro — one Mandant (`/m/kfz-angelegenheiten/`), two calendars: Kfz-Zulassung (11 services) and Führerscheinstelle (15), one office each at Bulksmühle 17, no locations step in the flow (the leipzig-abh topology).

Probed live today with the production scraper: 807 free Kfz slots, 649 Führerschein slots, earliest Führerschein slot three months out — so the demand is real.

- 300s cadence for both: the host already 429s the Bürgerbüro at 180s, and a second and third tenant must not make that worse
- `max_plans` 24 for the Führerscheinstelle: 15 Anliegen at one office sit one upstream addition away from the global cap of 16, and the per-type "all" collapse frees nothing at a single-office tenant
- the Bürgerbüro tenant gets its `office` label, so Bochum renders as a city cell in the switcher like Leipzig and Münster