### PR TITLE
Add Mastodon profile verification backlink

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,9 @@
      come from the context processor in web.py; the form page overrides title
      and description with the city it is showing. #}
   <meta name="description" content="{{ og_description }}">
+  {# Mastodon link verification: the profile lists buergerwecker.de, this is
+     the required backlink. #}
+  <link rel="me" href="https://hostux.social/@aloissiola">
   {% if indexable %}
     <link rel="canonical" href="{{ canonical_url }}">
     <link rel="alternate" hreflang="de" href="{{ alternate_de }}">


### PR DESCRIPTION
Adds a rel="me" link to the Mastodon profile so the buergerwecker.de link listed there gets the verified checkmark. Invisible to visitors.