### PR TITLE
docs: add CLAUDE.md, and describe the host we actually deploy to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+Guidance for coding agents working in this repository.
+
+## What this is
+
+Bürgerwecker: you enter an email, pick an appointment type and the offices that work for you, and
+get a mail the moment a matching slot appears on a city's official booking site. You book it
+yourself, there. A Flask web app takes subscriptions, a Python poller checks each city every one to
+three minutes, and a backup container snapshots the SQLite database. One Docker Compose stack behind
+the shared Caddy on the VPS. Cities live as directories under `catalog/`.
+
+## Working in this repo
+
+**Work in a git worktree, not this checkout.** More than one session runs here at once and they
+share the working tree. Run `git status` before you edit anything: modified or untracked files you
+did not create mean someone else is mid-task, and a `git add -A` or `git checkout -- .` will eat
+their work with no warning. Isolate instead:
+
+```bash
+git worktree add -b <branch> ~/gitlab/.worktrees/buergerwecker-<task> main
+```
+
+Stage by naming paths, never `git add -A` / `git commit -a`, in any checkout you share.
+
+## Commands
+
+```bash
+pip install -e ".[dev]"
+pytest -m "not live"     # what CI runs
+pytest                   # adds the live tests — they hit real city endpoints
+ruff check .
+```
+
+Live tests are opt-in behind `LIVE_TESTS=1` and talk to real Leipzig endpoints. Never make them run
+by default, and never add a network call to an ordinary test.
+
+## Things that are easy to get wrong
+
+**This service does not book, and will not.** No automated booking, ever — it is a stated product
+boundary in `README.md`, not a missing feature. Do not add it, do not scaffold toward it, and do not
+"helpfully" implement it because an issue seems to ask for it.
+
+**Client IP resolution is deliberate and subtle** (`app/web.py::_client_ip`). Caddy runs without
+`trusted_proxies`, so it overwrites any client-supplied `X-Forwarded-For` with the real peer — which
+makes XFF trustworthy here. Behind Cloudflare that peer is a shared edge IP, so `CF-Connecting-IP` is
+preferred, **but only when the peer really is Cloudflare**, because otherwise that header is
+spoofable. All three conditions matter; simplifying any of them reintroduces a spoofable rate limit.
+
+**`IPRateLimiter` is per-process.** With N gunicorn workers the effective limit is N×limit. It is a
+soft bot deterrent and explicitly not a security control — never make an authorization decision from
+it.
+
+**Bump `TOKEN_VERSION` in `app/tokens.py`** on any change to the signed payload format, or existing
+links in already-sent mail silently misparse.
+
+**Mail sends are idempotent by key** — `subscription_id | sorted slot hashes | cycle_id`. Changing
+how that key is built means re-notifying people about slots they were already told about.
+
+**Two providers, and the From domain must be verified in both.** `EMAIL_PROVIDER_ORDER` falls back
+between Mailjet and Resend; an unverified sender domain makes the fallback reject the mail at exactly
+the moment it is needed. Quotas are enforced in config — see the DEPLOY runbook.
+
+**One malformed address used to kill a whole batch.** Batch sends must isolate per-recipient
+failures; `tests/test_send_batch.py` guards it.
+
+**`tests/test_no_real_pii.py` fails the build on a real email domain.** Fixtures use `@example.com`.
+When a real address triggers a bug, reproduce its *shape* — the 2026-07-24 case is in
+`tests/test_subscribe.py` as `subscriber@example-com`, a dotless dead domain — never the address.
+
+## Shipping
+
+Branch, PR, squash-merge — never push to `main` directly, even for a one-line docs change.
+
+1. `pytest -m "not live"` and `ruff check .` green before anything else.
+2. Branch off `main`, commit, `gh pr create`, let CI run.
+3. `gh pr merge --squash --delete-branch`.
+4. Deploy and verify per **[`docs/DEPLOY.md`](docs/DEPLOY.md)** — that file is the runbook and the
+   only place deploy commands live. Do not copy them here; a second copy is what rots.
+
+Verify against **https://buergerwecker.de/healthz**. `www.buergerwecker.de` and
+`termine.jakubwaller.eu` only redirect to the apex, so checking them reports a healthy deploy as a
+failure.
+
+If tests or the post-deploy check fail, stop and report rather than merging or leaving the stack
+half-deployed.

--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ pickup slot is free.
 
 ## How it works
 
-A Raspberry Pi in Germany runs a small Docker Compose project: a Caddy
-reverse proxy, a Flask web app for subscriptions, a Python poller that
-checks the cities' booking sites every one to three minutes (depending on
-the city), and a backup
-container that snapshots the SQLite database to an external HDD.
+A small Docker Compose project on a server in Germany: a Caddy reverse
+proxy, a Flask web app for subscriptions, a Python poller that checks the
+cities' booking sites every one to three minutes (depending on the city),
+and a backup container that snapshots the SQLite database daily.
 
 ## Not affiliated with any city
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -2,10 +2,16 @@
 
 ## Prerequisites
 
-- Raspberry Pi running Docker + Docker Compose.
-- Web domain `buergerwecker.de` (or replacement) pointing to the Pi's
-  public IP. Ports 80 and 443 forwarded to the Pi.
-- USB HDD mounted at `/mnt/backup` (auto-mount via `/etc/fstab`).
+- A Linux host running Docker + Docker Compose. The live deployment is a
+  netcup VPS; anything always-on works.
+- Web domain `buergerwecker.de` (or replacement) resolving to that host. The
+  live records are proxied through Cloudflare. On a home server you would also
+  have to forward ports 80 and 443 on the router; on a VPS they are simply open.
+- A backup directory at `/mnt/backup`. **On the VPS this is a plain directory on
+  the root filesystem, so the snapshots sit on the same disk as the live
+  database** — it protects against a bad write or a bad deploy, not against
+  losing the disk. The off-host copy is what covers that; see "Off-host backup"
+  below. (On the Pi this used to be a USB HDD auto-mounted via `/etc/fstab`.)
 - Mailjet and Resend accounts with verified sender domain.
 - SPF / DKIM / DMARC records configured on `buergerwecker.de` and the domain
   validated in **both** Mailjet and Resend before any send — an unverified
@@ -15,14 +21,15 @@
 
 ## First deploy
 
-1. Clone the repo to the Pi.
+1. Clone the repo to the host.
 2. Copy `.env.example` to `.env` and fill in real secrets:
    - 32-byte `TOKEN_SECRET_PRIMARY` and `ADMIN_TOKEN` (e.g., `openssl rand -hex 32`).
    - Mailjet and Resend API keys.
    - Review the email-delivery settings (`EMAIL_PROVIDER_ORDER`,
      `RESEND_DAILY_QUOTA`, `MAILJET_HOURLY_QUOTA`, `MAILJET_DAILY_QUOTA`,
      `QUOTA_ALERT_THRESHOLD_PCT`) — see "Email delivery & quotas" below.
-3. Verify the USB HDD is mounted at `/mnt/backup`.
+3. Verify `/mnt/backup` exists (and, where it is a separate device, that it is
+   mounted) — the compose backup service bind-mounts it.
 4. `docker compose up -d`.
 5. Watch logs: `docker compose logs -f`.
 6. Verify healthz: `curl https://buergerwecker.de/healthz`.
@@ -93,6 +100,11 @@ python scripts/loadtest.py --subs 50000    # single size
 
 ## SMART monitoring (host-side systemd timer)
 
+Only for a host with a real disk to read — this was set up on the Raspberry Pi
+and is **not installed on the VPS**, whose virtual disk exposes nothing useful
+to `smartctl`. Kept here for whenever the project runs on physical hardware
+again.
+
 Install `smartmontools`. Add `/etc/systemd/system/termine-smart.service`:
 
 ```
@@ -120,19 +132,22 @@ WantedBy=timers.target
 
 `systemctl enable --now termine-smart.timer`.
 
-## Off-Pi backup (secondary)
+## Off-host backup (secondary)
 
-From your laptop:
+`/mnt/backup` shares a disk with the live database, so a copy has to leave the
+host. A scheduled pull from a workstation does it — daily, over scp, keeping
+every snapshot it has ever fetched:
 
 ```
-rsync -av jakub@pi:/mnt/backup/ ~/termine-backups/
+scp 'vps:/mnt/backup/app-*.db.gz' <local-snapshot-dir>/
 ```
 
-Cron weekly.
+Never let the puller delete: the point is to survive a deletion on the server,
+which a mirroring sync would faithfully replicate.
 
 ## IP-block runbook
 
-If `terminvereinbarung.leipzig.de` starts returning 403 for the Pi's IP:
+If `terminvereinbarung.leipzig.de` starts returning 403 for the host's IP:
 
 1. Stop the poller: `docker compose stop poller`.
 2. Email the city: `verwaltung@leipzig.de`. Subject: "Anfrage zu

--- a/scripts/smartcheck.sh
+++ b/scripts/smartcheck.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Runs on the Pi host (NOT inside Docker) via a systemd timer.
+# Runs on the host (NOT inside Docker) via a systemd timer, and only where
+# there is a physical disk to read — see docs/DEPLOY.md.
 # Appends SMART output to a file under the bind-mounted backup volume,
 # where the backup container can pick it up and email it.
 set -euo pipefail


### PR DESCRIPTION
Same shape as papa-map#34: **`docs/DEPLOY.md` holds the commands, `CLAUDE.md` holds the guardrails and points at it.** No command in both.

- `docs/deployment.md` → `docs/DEPLOY.md`, and its prerequisites now match the VPS: no router port-forwarding, no USB HDD.
- **Worth a proper read:** on the VPS `/mnt/backup` is a plain directory on the root filesystem, so snapshots share a disk with the live database. The off-host pull is now the only protection against losing that disk. Documented, not silently inherited from the Pi setup.
- SMART monitoring scoped to physical-disk hosts and marked not-installed here.
- New `CLAUDE.md`: the three-part client-IP rule in `_client_ip`, the per-process rate limiter, `TOKEN_VERSION`, the mail idempotency key, two-provider domain verification, the no-booking boundary.

Docs only, no app code touched. 419 passed, 4 live deselected, ruff clean.