### PR TITLE
web: disclose AI use in the Impressum

### DIFF
--- a/app/templates/impressum.html
+++ b/app/templates/impressum.html
@@ -11,6 +11,7 @@
     Contact: jakub@jakubwaller.eu<br>
     Contact form: <a href="/kontakt?projekt=buergerwecker&lang=en">buergerwecker.de/kontakt</a></p>
     <p>This website is not officially affiliated with any of the listed cities or their Bürgerbüros.</p>
+    <p>I do use AI to help me with coding and drafting texts. Everything goes through my human eyes though.</p>
   {% else %}
     <h1>Impressum</h1>
     <p>Angaben gemäß § 5 DDG:</p>
@@ -21,5 +22,6 @@
     Kontakt: jakub@jakubwaller.eu<br>
     Kontaktformular: <a href="/kontakt?projekt=buergerwecker">buergerwecker.de/kontakt</a></p>
     <p>Diese Website ist nicht offiziell mit den aufgeführten Städten oder deren Bürgerbüros verbunden.</p>
+    <p>Beim Programmieren und beim Schreiben der Texte hilft mir KI. Drübergeguckt habe ich trotzdem alles selbst.</p>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Second of the four public sites, after papa-map#35. Both `lang` branches, same statement:

------
Beim Programmieren und beim Schreiben der Texte hilft mir KI. Drübergeguckt habe ich trotzdem alles selbst.
------
------
I do use AI to help me with coding and drafting texts. Everything goes through my human eyes though.
------

Kept out of #51 deliberately — that one is deploy-neutral docs, this changes live site copy.

419 passed, 4 live deselected.