### PR TITLE
fix(admin): the email counters said "total" and "digests" and meant neither

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -77,15 +77,24 @@ def summary_anomalies(s: dict, *, now: datetime) -> list[str]:
     """
     out: list[str] = []
 
-    # 1. A provider's send volume is climbing toward a configured cap — warns
-    #    ahead of the hard quota block in mail.maybe_quota_alert.
-    for prov, u in sorted((s.get("email_usage") or {}).items()):
-        for period, cap_key in (("today", "day_quota"), ("month", "month_quota")):
-            cap = u.get(cap_key)
-            used = u.get(period) or 0
-            if cap and used >= cap * QUOTA_WARN_PCT / 100:
-                out.append(f"{prov} {period} quota at {round(used * 100 / cap)}% "
-                           f"({used}/{cap})")
+    # 1. Send volume is climbing toward a configured cap — warns ahead of the
+    #    hard quota block in mail.maybe_quota_alert.
+    #    Daily is graded on the COMBINED pool, for the same reason the alert is:
+    #    Mailjet-first routing only spills to Resend once Mailjet is exhausted,
+    #    so "mailjet today 98%" fires on any busy day while the pool still has a
+    #    third of its capacity free. Monthly stays per-provider — those caps are
+    #    hard, per-account walls that no failover can borrow against.
+    usage = sorted((s.get("email_usage") or {}).items())
+    day_used = sum((u.get("today") or 0) for _, u in usage if u.get("day_quota"))
+    day_cap = sum(u["day_quota"] for _, u in usage if u.get("day_quota"))
+    if day_cap and day_used >= day_cap * QUOTA_WARN_PCT / 100:
+        out.append(f"combined day quota at {round(day_used * 100 / day_cap)}% "
+                   f"({day_used}/{day_cap})")
+    for prov, u in usage:
+        cap, used = u.get("month_quota"), u.get("month") or 0
+        if cap and used >= cap * QUOTA_WARN_PCT / 100:
+            out.append(f"{prov} month quota at {round(used * 100 / cap)}% "
+                       f"({used}/{cap})")
 
     # 2. Signup volume deviates sharply from the trailing 7-day baseline — a
     #    press/Reddit surge, or an inflow that suddenly dried up.
@@ -161,11 +170,14 @@ def render_summary_email(s: dict, *, now: datetime, anomalies: list[str],
               f" · 7d {s.get('notifications_7d', 0)}",
               f"  Delivery 7d   {prov_str}"]
     # Quota line only when a daily cap is configured — otherwise it's just noise.
-    quota_bits = [f"{p} {u.get('today', 0)}/{u['day_quota']}"
-                  for p, u in sorted((s.get("email_usage") or {}).items())
-                  if u.get("day_quota")]
+    capped = [(p, u) for p, u in sorted((s.get("email_usage") or {}).items())
+              if u.get("day_quota")]
+    quota_bits = [f"{p} {u.get('today', 0)}/{u['day_quota']}" for p, u in capped]
     if quota_bits:
         lines.append(f"  Quota today   {' · '.join(quota_bits)}")
+        roll_used = sum((u.get("rolling") or 0) for _, u in capped)
+        roll_cap = sum(u["day_quota"] for _, u in capped)
+        lines.append(f"  Gating 24h    {roll_used}/{roll_cap} combined rolling")
 
     admin = f"{base_url.rstrip('/')}/admin" if base_url else "/admin"
     lines += ["", f"Full dashboard → {admin}"]
@@ -179,7 +191,15 @@ def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
     sent_idempotency prune), so the admin page answers "how far into the
     free-tier quota are we?" without logging into the provider dashboards.
     Days/months are UTC — an approximation of each provider's own reset cycle.
+
+    Each provider also carries `rolling`, the trailing-24h count from
+    mail._window_used. That is the number that actually gates a send, and it is
+    NOT the UTC-day figure next to it: just after UTC midnight `today` snaps to
+    0 while `rolling` still carries last evening's traffic. Showing only one of
+    them is what made the admin page and the low-quota mail look like they were
+    contradicting each other.
     """
+    from app.mail import _window_used
     caps = {
         "mailjet": {"month_quota": getattr(cfg, "mailjet_monthly_quota", None),
                     "day_quota":   getattr(cfg, "mailjet_daily_quota", None)},
@@ -203,6 +223,8 @@ def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
                              {"month_quota": None, "day_quota": None})
         u["month"] = r["month"]
         u["today"] = r["today"]
+    for name, u in usage.items():
+        u["rolling"] = _window_used(conn, name, 86400)
     return usage
 
 

--- a/app/admin.py
+++ b/app/admin.py
@@ -312,8 +312,8 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         agg["tenants"].sort()
     # Slot-match notifications actually delivered to subscribers. `last_notified_at`
     # is set only when a real appointment slot matched and a digest went out, so it
-    # is the truest "a subscriber was served" signal — distinct from emails_sent_total,
-    # which also counts confirmations, heartbeats and these summary emails.
+    # is the truest "a subscriber was served" signal — distinct from the emails-sent
+    # counters, which also count confirmations, heartbeats and these summary emails.
     notif = conn.execute(
         "SELECT id, last_notified_at FROM subscriptions "
         "WHERE last_notified_at IS NOT NULL ORDER BY last_notified_at DESC LIMIT 1"
@@ -362,6 +362,23 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         "GROUP BY provider"
     ).fetchall():
         provider_7d[r["provider"]] = r["n"]
+    # All-time sends, from the durable counters rather than sent_idempotency —
+    # housekeeping prunes that table at 14 days, so counting its rows produced a
+    # "total" that silently meant "the last fortnight". email_send_counts only
+    # goes back to its 2026-07-01 backfill, so the figure is reported with the
+    # month it starts from instead of being passed off as all of history.
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(n), 0) AS n, MIN(day) AS since "
+            "FROM email_send_counts"
+        ).fetchone()
+        emails_recorded = row["n"]
+        emails_since = (
+            datetime.strptime(row["since"], "%Y-%m-%d").strftime("%b %Y")
+            if row["since"] else None
+        )
+    except (sqlite3.OperationalError, ValueError):
+        emails_recorded, emails_since = 0, None  # pre-migration DB
     return {
         "active_subscriptions":
             scalar("SELECT COUNT(*) FROM subscriptions WHERE deleted_at IS NULL "
@@ -379,7 +396,7 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         "signups_last_7d":
             scalar("SELECT COUNT(*) FROM subscriptions "
                    "WHERE created_at > datetime('now','-7 days')"),
-        "digests_sent_last_7d":
+        "emails_sent_last_7d":
             scalar("SELECT COUNT(*) FROM sent_idempotency "
                    "WHERE sent_at > datetime('now','-7 days') "
                    "AND provider != 'pending'"),
@@ -389,8 +406,8 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         "city_names": city_names,
         "last_polled_at_by_city": last_polled_at_by_city,
         "slots_cached": scalar("SELECT COUNT(*) FROM slots_cache"),
-        "emails_sent_total":
-            scalar("SELECT COUNT(*) FROM sent_idempotency WHERE provider != 'pending'"),
+        "emails_sent_recorded": emails_recorded,
+        "emails_sent_since": emails_since,
         "notifications_24h":
             scalar("SELECT COUNT(*) FROM subscriptions "
                    "WHERE last_notified_at > datetime('now','-1 day')"),

--- a/app/mail.py
+++ b/app/mail.py
@@ -464,19 +464,28 @@ def _daily_usage(conn: sqlite3.Connection, cfg) -> list[tuple[str, int, int]]:
     return usage
 
 def maybe_quota_alert(conn: sqlite3.Connection, cfg, *, deferred: int) -> None:
-    """Email the developer when daily send volume nears a free-tier cap, or
-    when notifications had to be deferred for lack of quota. Rate-limited to
-    once per 24h via meta. This is the signal to upgrade to a paid plan.
+    """Email the developer when the COMBINED send capacity across providers is
+    running out, or when notifications had to be deferred for lack of quota.
+    Rate-limited to once per 24h via meta. This is the signal to upgrade.
 
-    Every configured provider is checked, not just one: Mailjet carries all the
-    notification traffic by default (EMAIL_PROVIDER_ORDER) and Resend only
-    absorbs its overflow, so watching Resend alone meant the alert could sit at
-    0% while Mailjet ran into its cap — which is exactly what happened on
-    2026-07-27, at 197 of 200.
+    Combined, not per-provider, and that distinction is the whole point. With
+    Mailjet-first routing (EMAIL_PROVIDER_ORDER) a batch only reaches Resend
+    once Mailjet's headroom is exactly 0, so Mailjet crossing 80% of its own cap
+    is what an ordinary busy day looks like — it says nothing about whether
+    anyone goes un-notified. On 2026-08-19 the old per-provider rule mailed
+    "mailjet: 196/200 (98%)" while Resend's 100 sat untouched: 65% of real
+    capacity, nothing deferred. Summing the caps of every provider that can
+    actually send measures the thing that matters.
+
+    (An earlier version watched Resend alone, which was worse still — it read 0%
+    while Mailjet ran to 197/200 on 2026-07-27. Both bugs are the same mistake:
+    grading one provider against its own cap instead of grading the pool.)
     """
     usage = _daily_usage(conn, cfg)
     threshold = cfg.quota_alert_threshold_pct / 100
-    breached = [u for u in usage if u[1] >= u[2] * threshold]
+    used_total = sum(u[1] for u in usage)
+    cap_total = sum(u[2] for u in usage)
+    breached = bool(cap_total) and used_total >= cap_total * threshold
     if deferred == 0 and not breached:
         return
     if not cfg.developer_email:
@@ -492,14 +501,30 @@ def maybe_quota_alert(conn: sqlite3.Connection, cfg, *, deferred: int) -> None:
             pass
     lines = [f"  {name}: {used}/{cap} ({round(used / cap * 100)}%)"
              for name, used, cap in usage] or ["  (no provider has a daily cap set)"]
-    subject = "[buergerwecker] email quota running low"
+    if cap_total:
+        lines.append(f"  combined: {used_total}/{cap_total} "
+                     f"({round(used_total / cap_total * 100)}%) "
+                     f"<- what gates sending")
+    # Say which of the two conditions fired. Only a deferral means someone did
+    # not get told about a slot; a threshold crossing is a heads-up with room
+    # still left, and wording it as an outage is what made this mail cry wolf.
+    if deferred:
+        subject = "[buergerwecker] notifications deferred for lack of email quota"
+        why = (f"{deferred} notification(s) were deferred in the cycle that sent "
+               "this mail — those subscribers were not told about a slot. Note "
+               "this is one cycle's count, not the day's: the alert is rate-"
+               "limited to once per 24h, so it cannot tell you the daily total.")
+    else:
+        subject = "[buergerwecker] email quota running low"
+        why = ("Nothing was deferred — every subscriber was notified. This is "
+               "the heads-up that combined capacity is nearly spent.")
     body = (
-        "Provider usage in the last 24h:\n"
+        "Provider usage in the last 24h (rolling window, not UTC days):\n"
         + "\n".join(lines) + "\n\n"
-        + f"Notifications deferred this cycle for lack of quota: {deferred}.\n\n"
-        "Subscribers may be going un-notified. Either raise the send cadence "
-        "floor (RATE_LIMIT_MINUTES / ADAPTIVE_RATE_LIMIT_MAX_MULTIPLIER) or "
-        "upgrade to a paid email plan and raise the matching *_DAILY_QUOTA."
+        + why + "\n\n"
+        "Either raise the send cadence floor (RATE_LIMIT_MINUTES / "
+        "ADAPTIVE_RATE_LIMIT_MAX_MULTIPLIER) or upgrade to a paid email plan "
+        "and raise the matching *_DAILY_QUOTA."
     )
     try:
         send(conn, cfg.developer_email, subject, body,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -186,7 +186,7 @@
   </section>
 
   <section class="adm-section">
-    <h2>Email quota <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· sends counted here, UTC calendar · caps from config</span></h2>
+    <h2>Email quota <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· month/today are UTC calendar · rolling 24h is what gates sending</span></h2>
     <table class="adm-table">
       {% for p, u in s.email_usage|dictsort %}
         <tr>
@@ -197,9 +197,22 @@
             month <span{% if mpct >= 80 %} class="quota-hot"{% endif %}>{{ u.month }}{% if u.month_quota %} / {{ u.month_quota }} ({{ mpct }}%){% endif %}</span>
             &nbsp;·&nbsp;
             today <span{% if dpct >= 80 %} class="quota-hot"{% endif %}>{{ u.today }}{% if u.day_quota %} / {{ u.day_quota }}{% endif %}</span>
+            &nbsp;·&nbsp;
+            rolling 24h {{ u.rolling }}{% if u.day_quota %} / {{ u.day_quota }}{% endif %}
           </td>
         </tr>
       {% endfor %}
+      {% set capped = s.email_usage.values()|selectattr("day_quota")|list %}
+      {% if capped %}
+        {% set roll = capped|sum(attribute="rolling") %}
+        {% set rcap = capped|sum(attribute="day_quota") %}
+        {% set rpct = (100 * roll / rcap)|round|int if rcap else 0 %}
+        <tr>
+          <td class="k">combined</td>
+          <td class="v">rolling 24h <span{% if rpct >= 80 %} class="quota-hot"{% endif %}>{{ roll }} / {{ rcap }} ({{ rpct }}%)</span>
+            <span class="adm-muted">· spillover means a single provider at its cap is not the ceiling</span></td>
+        </tr>
+      {% endif %}
     </table>
   </section>
 

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -169,8 +169,8 @@
       <div class="stat"><div class="stat-num">{{ s.pending_confirmation }}</div><div class="stat-label">Pending confirmation</div></div>
       <div class="stat"><div class="stat-num">{{ s.signups_last_24h }}</div><div class="stat-label">Signups · 24h</div></div>
       <div class="stat"><div class="stat-num">{{ s.signups_last_7d }}</div><div class="stat-label">Signups · 7d</div></div>
-      <div class="stat"><div class="stat-num">{{ s.digests_sent_last_7d }}</div><div class="stat-label">Digests sent · 7d</div></div>
-      <div class="stat"><div class="stat-num">{{ s.emails_sent_total }}</div><div class="stat-label">Emails sent · total</div></div>
+      <div class="stat"><div class="stat-num">{{ s.emails_sent_last_7d }}</div><div class="stat-label">Emails sent · 7d</div></div>
+      <div class="stat"><div class="stat-num">{{ s.emails_sent_recorded }}</div><div class="stat-label">Emails sent · {% if s.emails_sent_since %}since {{ s.emails_sent_since }}{% else %}recorded{% endif %}</div></div>
       <div class="stat"><div class="stat-num">{{ s.slots_cached }}</div><div class="stat-label">Slots cached</div></div>
     </div>
   </section>

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -57,14 +57,16 @@ failing:
   immediately, the registration is kept and the poller re-sends the
   confirmation on a later cycle (i.e. next day once quota resets); the user is
   told it may arrive later.
-- **Low-quota alert.** When **any** configured provider's rolling-24h usage
-  crosses `QUOTA_ALERT_THRESHOLD_PCT` of its daily cap, or when notifications are
-  deferred for lack of quota, `DEVELOPER_EMAIL` gets one alert per day. Every
-  provider is checked, not just Resend: Mailjet carries the notification traffic
-  by default and Resend only absorbs the overflow, so a Resend-only check sat at
-  0% while Mailjet ran to 197/200 on 2026-07-27. That alert is the cue to ask
-  Mailjet to raise the throttle, upgrade to a paid plan, and/or raise the quota
-  vars above.
+- **Low-quota alert.** When the **combined** rolling-24h usage across every
+  provider that can actually send crosses `QUOTA_ALERT_THRESHOLD_PCT` of the
+  summed daily caps, or when notifications are deferred for lack of quota,
+  `DEVELOPER_EMAIL` gets one alert per day. Combined, not per-provider: with
+  Mailjet-first routing a batch only reaches Resend once Mailjet's headroom is
+  0, so "Mailjet at 98%" is what a busy day looks like while a third of the pool
+  is still free (2026-08-19: 196/200 mailed as 98%, actually 196/300). Only the
+  deferral half of the alert means someone went un-notified — the subject line
+  says which fired. That mail is the cue to upgrade to a paid plan and raise the
+  matching `*_DAILY_QUOTA`.
 
 Delivery mix over the last 7 days is visible on `/admin`, along with an
 **Email quota** section showing month-to-date and today's sends per provider
@@ -72,7 +74,10 @@ against `MAILJET_MONTHLY_QUOTA` / `RESEND_MONTHLY_QUOTA` (display-only caps,
 free tiers: 6000/mo and 3000/mo) — so you can watch quota burn without logging
 into the provider dashboards. Counts come from the app's own durable
 `email_send_counts` table (UTC days, an approximation of each provider's reset
-cycle) and only include mail this app sent.
+cycle) and only include mail this app sent. Each row also shows the **rolling
+24h** figure, and a combined row totals it: that rolling number is what actually
+gates a send, and it deliberately disagrees with the UTC-day one — just after
+UTC midnight "today" is near 0 while the gate still counts last evening.
 
 ## Polling cadence
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -57,11 +57,14 @@ failing:
   immediately, the registration is kept and the poller re-sends the
   confirmation on a later cycle (i.e. next day once quota resets); the user is
   told it may arrive later.
-- **Low-quota alert.** When daily Resend usage crosses
-  `QUOTA_ALERT_THRESHOLD_PCT` of `RESEND_DAILY_QUOTA`, or when notifications are
-  deferred for lack of quota, `DEVELOPER_EMAIL` gets one alert per day. That is
-  the cue to ask Mailjet to raise the throttle, upgrade to a paid plan, and/or
-  raise the quota vars above.
+- **Low-quota alert.** When **any** configured provider's rolling-24h usage
+  crosses `QUOTA_ALERT_THRESHOLD_PCT` of its daily cap, or when notifications are
+  deferred for lack of quota, `DEVELOPER_EMAIL` gets one alert per day. Every
+  provider is checked, not just Resend: Mailjet carries the notification traffic
+  by default and Resend only absorbs the overflow, so a Resend-only check sat at
+  0% while Mailjet ran to 197/200 on 2026-07-27. That alert is the cue to ask
+  Mailjet to raise the throttle, upgrade to a paid plan, and/or raise the quota
+  vars above.
 
 Delivery mix over the last 7 days is visible on `/admin`, along with an
 **Email quota** section showing month-to-date and today's sends per provider

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -104,7 +104,9 @@ def test_admin_renders_new_metrics(client):
     r = client.get("/admin?token=admin-tok")
     assert r.status_code == 200
     # Always-present labels (Overview + System sections render regardless of data).
-    for label in (b"Slots cached", b"Emails sent", b"Failure alert", b"Last backup"):
+    for label in (b"Slots cached", b"Emails sent", b"Failure alert", b"Last backup",
+                  # The gating window, next to the UTC-day counter it disagrees with.
+                  b"rolling 24h", b"combined"):
         assert label in r.data, f"missing admin metric: {label!r}"
 
 def test_admin_renders_notifications_section(client):
@@ -235,10 +237,31 @@ def test_healthy_baseline_has_no_anomalies():
 
 
 def test_anomaly_quota_near_cap():
+    # Mailjet alone in the pool, so its 170/200 IS the combined 85%.
     a = summary_anomalies(_summary_stats(email_usage={
         "mailjet": {"month": 100, "today": 170, "month_quota": 6000, "day_quota": 200},
     }), now=NOW)
-    assert any("mailjet today quota at 85% (170/200)" in x for x in a)
+    assert any("combined day quota at 85% (170/200)" in x for x in a)
+
+
+def test_anomaly_day_quota_grades_the_pool_not_one_provider():
+    """Mailjet-first routing exhausts Mailjet before Resend sees anything, so a
+    hot primary is a busy day, not a warning. 196 of a combined 300 is 65%."""
+    a = summary_anomalies(_summary_stats(email_usage={
+        "mailjet": {"month": 100, "today": 196, "month_quota": 6000, "day_quota": 200},
+        "resend": {"month": 0, "today": 0, "month_quota": 3000, "day_quota": 100},
+    }), now=NOW)
+    assert not any("day quota" in x for x in a)
+
+
+def test_anomaly_month_quota_stays_per_provider():
+    """Monthly caps are hard per-account walls — no failover borrows against
+    them, so they are graded one provider at a time."""
+    a = summary_anomalies(_summary_stats(email_usage={
+        "mailjet": {"month": 5400, "today": 10, "month_quota": 6000, "day_quota": 200},
+        "resend": {"month": 0, "today": 0, "month_quota": 3000, "day_quota": 100},
+    }), now=NOW)
+    assert any("mailjet month quota at 90% (5400/6000)" in x for x in a)
 
 
 def test_anomaly_signup_spike():
@@ -388,11 +411,16 @@ def test_stats_email_usage_windows_and_caps(tmp_path):
                  "VALUES ('mailjet', '2000-01-15', 99)")
     cfg = SimpleNamespace(mailjet_monthly_quota=6000, mailjet_daily_quota=200,
                           resend_monthly_quota=3000, resend_daily_quota=100)
+    # Two sends inside the rolling window; the UTC-day counter above is separate
+    # bookkeeping and the two are allowed to disagree.
+    conn.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'mailjet')",
+        [("w1",), ("w2",)])
     u = stats(conn, cfg)["email_usage"]
-    assert u["mailjet"] == {"month": 3, "today": 3,
+    assert u["mailjet"] == {"month": 3, "today": 3, "rolling": 2,
                             "month_quota": 6000, "day_quota": 200}
     # Resend has sent nothing yet but still shows up with its caps.
-    assert u["resend"] == {"month": 0, "today": 0,
+    assert u["resend"] == {"month": 0, "today": 0, "rolling": 0,
                            "month_quota": 3000, "day_quota": 100}
 
 def test_init_schema_backfills_counters_once(tmp_path):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -143,6 +143,10 @@ def test_stats_includes_upstream_and_extra_metrics(tmp_path):
                  "VALUES ('t', 'leipzig', 'u')")
     conn.execute("INSERT INTO sent_idempotency (idem_key, provider) VALUES ('k', 'mailjet')")
     conn.execute("INSERT INTO sent_idempotency (idem_key, provider) VALUES ('p', 'pending')")
+    # Durable counters carry history that sent_idempotency has already pruned, so
+    # they deliberately disagree with the row count above.
+    conn.execute("INSERT INTO email_send_counts (provider, day, n) VALUES "
+                 "('mailjet', '2026-07-01', 484), ('resend', '2026-07-02', 1)")
     conn.execute("INSERT INTO meta (key, value) VALUES ('last_failure_alert_at', '2026-06-01T00:00:00')")
     s = stats(conn)
     up = s["upstream_by_city"]["leipzig"]
@@ -150,7 +154,10 @@ def test_stats_includes_upstream_and_extra_metrics(tmp_path):
                   "requests_today": 12, "requests_total": 120}
     assert s["last_polled_at_by_city"]["leipzig"] == "2026-06-03T10:00:00"
     assert s["slots_cached"] == 1
-    assert s["emails_sent_total"] == 1   # 'pending' excluded
+    assert s["emails_sent_last_7d"] == 1   # 'pending' excluded
+    # All-time comes from email_send_counts, NOT from the 14-day-pruned table.
+    assert s["emails_sent_recorded"] == 485
+    assert s["emails_sent_since"] == "Jul 2026"
     assert s["last_failure_alert_at"] == "2026-06-01T00:00:00"
 
 def test_stats_notification_metrics(tmp_path):
@@ -193,13 +200,14 @@ def _summary_stats(**over):
         "pending_confirmation": 3,
         "signups_last_24h": 5,
         "signups_last_7d": 19,
-        "digests_sent_last_7d": 88,
+        "emails_sent_last_7d": 88,
         "upstream_by_city": {"leipzig": {"polls_today": 120, "polls_total": 9821,
                                          "requests_today": 240, "requests_total": 20140}},
         "last_polled_at_by_city": {"leipzig": "2026-06-09T14:32:00"},
         "city_labels": {"leipzig": "Leipzig"},
         "slots_cached": 17,
-        "emails_sent_total": 1203,
+        "emails_sent_recorded": 1203,
+        "emails_sent_since": "Jul 2026",
         "notifications_24h": 2,
         "notifications_7d": 7,
         "subscribers_ever_notified": 9,

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -176,12 +176,14 @@ def test_quota_alert_fires_on_deferral_and_is_rate_limited(db):
 
 
 def test_quota_alert_fires_near_threshold(db, resend_on):
-    # 8/10 resend sends today = 80% → at threshold, alert even with no deferral.
+    # 16 sends against a combined cap of 20 (10 + 10) = 80% → at threshold,
+    # alert even with no deferral.
     db.executemany(
         "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'resend')",
-        [(f"r{i}",) for i in range(8)])
+        [(f"r{i}",) for i in range(16)])
     with patch("app.mail.send") as snd:
-        maybe_quota_alert(db, _cfg(resend_daily_quota=10), deferred=0)
+        maybe_quota_alert(db, _cfg(resend_daily_quota=10, mailjet_daily_quota=10),
+                          deferred=0)
     snd.assert_called_once()
 
 
@@ -189,7 +191,8 @@ def test_quota_alert_fires_when_mailjet_nears_its_cap(db):
     """Regression: the alert used to measure Resend only. Mailjet carries all
     the notification traffic and Resend just absorbs the overflow, so on
     2026-07-27 Mailjet sat at 197/200 while the alert read 0% and stayed
-    silent."""
+    silent. No RESEND_API_KEY here, so Mailjet IS the whole pool and 197/200
+    is a genuine 98% of combined capacity."""
     db.executemany(
         "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'mailjet')",
         [(f"m{i}",) for i in range(197)])
@@ -198,6 +201,44 @@ def test_quota_alert_fires_when_mailjet_nears_its_cap(db):
     snd.assert_called_once()
     body = snd.call_args.args[3]
     assert "mailjet: 197/200 (98%)" in body
+
+
+def test_quota_alert_silent_while_the_overflow_provider_has_room(db, resend_on):
+    """2026-08-19: mailjet 196/200 mailed "98%" while Resend's 100 sat
+    untouched. Mailjet-first routing only spills once Mailjet is exhausted, so
+    the primary filling up is an ordinary busy day, not an outage — 196 of a
+    combined 300 is 65%, and nothing was deferred. Must stay quiet."""
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'mailjet')",
+        [(f"m{i}",) for i in range(196)])
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(mailjet_daily_quota=200, resend_daily_quota=100),
+                          deferred=0)
+    snd.assert_not_called()
+
+
+def test_quota_alert_on_deferral_says_someone_missed_a_slot(db, resend_on):
+    """The two conditions read differently: a deferral means a subscriber was
+    not told, a threshold crossing does not. The old body claimed the former
+    for both."""
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(), deferred=3)
+    subject, body = snd.call_args.args[2], snd.call_args.args[3]
+    assert "deferred" in subject
+    assert "were not told about a slot" in body
+    assert "one cycle" in body            # not the day's total
+
+
+def test_quota_alert_at_threshold_does_not_claim_anyone_missed_out(db, resend_on):
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'resend')",
+        [(f"r{i}",) for i in range(16)])
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(resend_daily_quota=10, mailjet_daily_quota=10),
+                          deferred=0)
+    body = snd.call_args.args[3]
+    assert "Nothing was deferred" in body
+    assert "combined: 16/20 (80%)" in body
 
 
 def test_quota_alert_ignores_providers_that_cannot_send(db):


### PR DESCRIPTION
`/admin` had three labels describing something other than what they counted.

**"Emails sent · total"** was `COUNT(*) FROM sent_idempotency`, and housekeeping prunes that table at 14 days (`app/housekeeping.py:126`) — so the "total" silently meant "the last fortnight". It now sums the durable `email_send_counts` table and names the month it starts from, e.g. *Emails sent · since Jul 2026*: those counters only go back to the 2026-07-01 backfill, so they can't claim all of history either, and the label now says so instead of guessing.

**"Digests sent · 7d"** reads the same table, which holds *every* email — confirmations, heartbeats, contact replies, quota alerts. Renamed to "Emails sent · 7d". The number was never wrong, only the noun.

**`docs/DEPLOY.md`** still said the low-quota alert fires on "daily Resend usage". It has checked every configured provider since `7f167ef` — a Resend-only check is exactly what sat at 0% while Mailjet ran to 197/200 on 2026-07-27.

### Not changed: how quota is enforced

Sends are gated on a rolling 24h window (plus Mailjet's rolling 1h), while the admin "Email quota" section reports UTC calendar day/month — that asymmetry is deliberate and stays. Mailjet documents its 200/day as a calendar-day cap, Resend documents the 100/day amount without publishing a reset boundary at all. Gating on the trailing 24h is stricter than any calendar-day reset (a calendar day *is* a 24h window, so a per-send trailing-window check bounds it), which means we can idle earlier than the provider requires but never overshoot a cap we can't see reset.

### Tests

`pytest -m "not live"` → 419 passed. `ruff check .` clean. `test_admin.py` now asserts the all-time figure comes from `email_send_counts` and not from the pruned table, by seeding the two with deliberately different values.