### PR TITLE
fix(digest): rotate the deferred tail, and stop losing digests silently

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -96,6 +96,13 @@ def summary_anomalies(s: dict, *, now: datetime) -> list[str]:
             out.append(f"{prov} month quota at {round(used * 100 / cap)}% "
                        f"({used}/{cap})")
 
+    #    A deferral is not a "nearing the cap" warning — it is the cap already
+    #    having cost someone a notification, so it is reported whatever the
+    #    percentages say.
+    deferred = s.get("deferrals_today") or 0
+    if deferred:
+        out.append(f"{deferred} notification(s) deferred today for lack of quota")
+
     # 2. Signup volume deviates sharply from the trailing 7-day baseline — a
     #    press/Reddit surge, or an inflow that suddenly dried up.
     d24 = s.get("signups_last_24h") or 0
@@ -178,6 +185,9 @@ def render_summary_email(s: dict, *, now: datetime, anomalies: list[str],
         roll_used = sum((u.get("rolling") or 0) for _, u in capped)
         roll_cap = sum(u["day_quota"] for _, u in capped)
         lines.append(f"  Gating 24h    {roll_used}/{roll_cap} combined rolling")
+    if s.get("deferrals_today") or s.get("deferrals_7d"):
+        lines.append(f"  Deferred      today {s.get('deferrals_today', 0)}"
+                     f" · 7d {s.get('deferrals_7d', 0)}")
 
     admin = f"{base_url.rstrip('/')}/admin" if base_url else "/admin"
     lines += ["", f"Full dashboard → {admin}"]
@@ -445,6 +455,11 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         "last_notification": last_notification,
         "emails_by_provider_7d": provider_7d,
         "email_usage": _email_usage(conn, cfg),
+        "deferrals_today":
+            scalar("SELECT n FROM email_deferral_counts WHERE day = date('now')"),
+        "deferrals_7d":
+            scalar("SELECT COALESCE(SUM(n), 0) FROM email_deferral_counts "
+                   "WHERE day >= date('now','-7 days')"),
         "last_failure_alert_at": meta_val("last_failure_alert_at"),
         "last_housekeeping_at": meta_val("last_housekeeping_at"),
         "last_backup_at":       meta_val("last_backup_at"),

--- a/app/db.py
+++ b/app/db.py
@@ -3,7 +3,7 @@ import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS subscriptions (
@@ -49,6 +49,16 @@ CREATE TABLE IF NOT EXISTS email_send_counts (
   day      TEXT NOT NULL,
   n        INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (provider, day)
+);
+
+-- Notifications a cycle could not send because the combined provider quota was
+-- spent. Durable and per-UTC-day because the alert mail is rate-limited to once
+-- per 24h: a per-cycle count in that mail cannot tell you whether the day lost
+-- one digest or four hundred. This is the only record that someone was not told
+-- about a slot, so it outlives sent_idempotency's 14-day prune.
+CREATE TABLE IF NOT EXISTS email_deferral_counts (
+  day TEXT PRIMARY KEY,
+  n   INTEGER NOT NULL DEFAULT 0
 );
 
 -- Per-address delivery failures. A provider that parses our request and still

--- a/app/digest.py
+++ b/app/digest.py
@@ -237,11 +237,22 @@ def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
 def flush_digests(conn: sqlite3.Connection, sink: list, cfg) -> None:
     """Deliver every staged digest in `sink` via quota-aware batches, then
     record seen_slots + last_notified for the ones that were actually sent.
-    Deferred digests are left unrecorded so the next cycle re-sends them."""
+    Deferred digests are left unrecorded so the next cycle re-sends them.
+
+    Longest-waiting subscriber first. `send_batch` fills provider batches in
+    list order and defers the tail, so whatever order the cycle happened to
+    stage in decides who loses a digest under saturation — and that order is
+    stable (city, then subscription id), which would put the same people at the
+    back every cycle. Sorting on last_notified_at rotates it: a deferred digest
+    never stamps last_notified_at, so anyone passed over keeps their old (or
+    absent) timestamp and leads the next cycle. Never-notified subscribers sort
+    first, which is also the right answer on the merits.
+    """
     if not sink:
         return
     from app.db import transaction
     from app.repo import record_seen_slot, set_last_notified
+    sink = sorted(sink, key=lambda q: str(q.subscription.last_notified_at or ""))
     result = send_batch(conn, [q.item for q in sink], cfg)
     for q in sink:
         if q.item.idem_key not in result.delivered:

--- a/app/mail.py
+++ b/app/mail.py
@@ -447,8 +447,29 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
         with transaction(conn):
             conn.executemany("DELETE FROM sent_idempotency WHERE idem_key=?",
                              [(c.idem_key,) for c in remaining])
+            _record_deferrals(conn, len(remaining))
         result.deferred = len(remaining)
     return result
+
+def _record_deferrals(conn: sqlite3.Connection, n: int) -> None:
+    """Bump the durable per-UTC-day deferral counter. Deferral is the only event
+    that means a subscriber was not told about a slot, and nothing else records
+    it: the idempotency claim is deleted on the way out and the digest itself is
+    never written anywhere."""
+    conn.execute(
+        "INSERT INTO email_deferral_counts (day, n) VALUES (date('now'), ?) "
+        "ON CONFLICT (day) DO UPDATE SET n = n + excluded.n",
+        (n,),
+    )
+
+def deferrals_today(conn: sqlite3.Connection) -> int:
+    try:
+        row = conn.execute(
+            "SELECT n FROM email_deferral_counts WHERE day = date('now')"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0  # pre-migration DB
+    return row["n"] if row else 0
 
 def _daily_usage(conn: sqlite3.Connection, cfg) -> list[tuple[str, int, int]]:
     """(provider, sends in the last 24h, daily cap) for every provider that is
@@ -511,9 +532,10 @@ def maybe_quota_alert(conn: sqlite3.Connection, cfg, *, deferred: int) -> None:
     if deferred:
         subject = "[buergerwecker] notifications deferred for lack of email quota"
         why = (f"{deferred} notification(s) were deferred in the cycle that sent "
-               "this mail — those subscribers were not told about a slot. Note "
-               "this is one cycle's count, not the day's: the alert is rate-"
-               "limited to once per 24h, so it cannot tell you the daily total.")
+               f"this mail, {deferrals_today(conn)} so far today (UTC) — those "
+               "subscribers were not told about a slot. They are re-sent next "
+               "cycle, longest-waiting first, but a slot taken in the meantime "
+               "is simply gone.")
     else:
         subject = "[buergerwecker] email quota running low"
         why = ("Nothing was deferred — every subscriber was notified. This is "

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -213,6 +213,11 @@
             <span class="adm-muted">· spillover means a single provider at its cap is not the ceiling</span></td>
         </tr>
       {% endif %}
+      <tr>
+        <td class="k">deferred</td>
+        <td class="v"><span{% if s.deferrals_today %} class="quota-hot"{% endif %}>today {{ s.deferrals_today }}</span> · 7d {{ s.deferrals_7d }}
+          <span class="adm-muted">· notifications the quota could not send — re-tried next cycle, longest wait first</span></td>
+      </tr>
     </table>
   </section>
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -53,6 +53,19 @@ failing:
   Mailjet lifts the throttle, raise these caps — not the provider order** (e.g.
   bump `MAILJET_HOURLY_QUOTA`); the daily cap then binds. Raise all of them
   after upgrading to a paid plan.
+- **When the whole pool is spent, digests are deferred, not dropped.** The
+  leftovers have their idempotency claims released and their slots left
+  unrecorded, so the next cycle re-sends them with a fresh `cycle_id`. Two
+  consequences worth knowing: a slot taken in the meantime is simply gone (the
+  digest never goes out, correctly), and the deferred count is written to
+  `email_deferral_counts` per UTC day — visible on `/admin`, in the ops summary,
+  and in the alert mail. That counter is the **only** record that a subscriber
+  was not told about a slot; nothing else persists it.
+- **The deferred tail rotates.** Batches are filled in list order, so without
+  care the same subscribers land at the back of every saturated cycle.
+  `flush_digests` sorts by `last_notified_at` (never-notified first), and a
+  deferred digest never stamps that column — so whoever was passed over leads
+  the next cycle.
 - **Sign-ups are never lost to quota.** If the confirmation email can't go out
   immediately, the registration is kept and the poller re-sends the
   confirmation on a later cycle (i.e. next day once quota resets); the user is

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -454,3 +454,28 @@ def test_summary_email_quota_line_lists_each_provider():
     }), now=NOW, anomalies=[])
     q = _line(text, "Quota today")
     assert "mailjet 12/200" in q and "resend 0/100" in q
+
+
+def test_stats_and_anomaly_report_deferrals(tmp_path):
+    from types import SimpleNamespace
+    conn = connect(str(tmp_path / "d.db")); init_schema(conn)
+    conn.executemany(
+        "INSERT INTO email_deferral_counts (day, n) VALUES (?, ?)",
+        [(datetime.utcnow().date().isoformat(), 12), ("2000-01-15", 99)])
+    cfg = SimpleNamespace(mailjet_monthly_quota=6000, mailjet_daily_quota=200,
+                          resend_monthly_quota=3000, resend_daily_quota=100)
+    s = stats(conn, cfg)
+    assert s["deferrals_today"] == 12
+    assert s["deferrals_7d"] == 12          # the 2000 row is outside the window
+    a = summary_anomalies(_summary_stats(deferrals_today=12), now=NOW)
+    assert any("12 notification(s) deferred today" in x for x in a)
+
+
+def test_anomaly_deferral_reported_even_below_quota_thresholds():
+    """A deferral is not a "nearing the cap" warning — it is the cap having
+    already cost a subscriber a slot, so percentages don't gate it."""
+    a = summary_anomalies(_summary_stats(deferrals_today=1, email_usage={
+        "mailjet": {"month": 10, "today": 5, "month_quota": 6000, "day_quota": 200},
+    }), now=NOW)
+    assert any("deferred today" in x for x in a)
+    assert not any("quota at" in x for x in a)

--- a/tests/test_digest_fairness.py
+++ b/tests/test_digest_fairness.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.db import connect, init_schema
+from app.digest import QueuedDigest, flush_digests
+from app.mail import BatchResult, Outgoing
+
+
+@pytest.fixture
+def db(tmp_path):
+    conn = connect(str(tmp_path / "d.db"))
+    init_schema(conn)
+    return conn
+
+
+def _q(sub_id, last_notified_at):
+    return QueuedDigest(
+        item=Outgoing(to=f"u{sub_id}@example.com", subject="s", body="b",
+                      idem_key=f"k{sub_id}"),
+        subscription=SimpleNamespace(id=sub_id, last_notified_at=last_notified_at),
+        slots=[],
+        match_count=1,
+    )
+
+
+def _flush_order(db, sink):
+    with patch("app.digest.send_batch") as sb, \
+         patch("app.digest.maybe_quota_alert"):
+        sb.return_value = BatchResult()
+        flush_digests(db, sink, SimpleNamespace())
+    return [i.idem_key for i in sb.call_args.args[1]]
+
+
+def test_flush_sends_longest_waiting_first(db):
+    """send_batch fills provider batches in list order and defers the tail, so
+    list order decides who loses a digest when quota runs out. Longest wait
+    leads; never-notified subscribers lead outright."""
+    order = _flush_order(db, [_q(1, "2026-08-19T10:00:00"),
+                              _q(2, None),
+                              _q(3, "2026-08-19T08:00:00")])
+    assert order == ["k2", "k3", "k1"]
+
+
+def test_flush_order_does_not_depend_on_staging_order(db):
+    """The cycle stages in a stable order (city, then subscription id). Without
+    the sort that put the same subscribers at the back of every saturated cycle
+    — the point of the fix is that staging order stops mattering."""
+    stamps = {1: "2026-08-19T10:00:00", 2: None, 3: "2026-08-19T08:00:00"}
+    forward = _flush_order(db, [_q(i, stamps[i]) for i in (1, 2, 3)])
+    backward = _flush_order(db, [_q(i, stamps[i]) for i in (3, 2, 1)])
+    assert forward == backward == ["k2", "k3", "k1"]
+
+
+def test_flush_tolerates_all_subscribers_never_notified(db):
+    """All-NULL timestamps must not blow up the sort (a naive tuple key
+    comparing None to None raises TypeError)."""
+    assert _flush_order(db, [_q(1, None), _q(2, None)]) == ["k1", "k2"]

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -226,7 +226,9 @@ def test_quota_alert_on_deferral_says_someone_missed_a_slot(db, resend_on):
     subject, body = snd.call_args.args[2], snd.call_args.args[3]
     assert "deferred" in subject
     assert "were not told about a slot" in body
-    assert "one cycle" in body            # not the day's total
+    # The cycle count alone can't tell you what the day cost — the alert only
+    # fires once per 24h — so the mail carries the UTC-day total beside it.
+    assert "so far today" in body
 
 
 def test_quota_alert_at_threshold_does_not_claim_anyone_missed_out(db, resend_on):
@@ -469,3 +471,27 @@ def test_graded_batch_where_everything_failed_is_not_a_provider_outage(db, resen
         res = send_batch(db, _items(2), _cfg())
     assert len(res.delivered) == 2 and res.undeliverable == set()
     assert res.sent_by_provider == {"resend": 2}
+
+
+def test_deferral_is_recorded_per_utc_day(db, resend_on):
+    """Deferral is the only trace that a subscriber was not told about a slot:
+    the idempotency claim is deleted on the way out and the digest is never
+    persisted. Without this counter the loss is invisible."""
+    with patch("app.mail._call_mailjet_batch", return_value=200), \
+         patch("app.mail._call_resend_batch", return_value=200):
+        res = send_batch(db, _items(9), _cfg(mailjet_daily_quota=2,
+                                             mailjet_hourly_quota=2,
+                                             resend_daily_quota=3))
+    assert res.deferred == 4                      # 9 staged, 2 + 3 sent
+    from app.mail import deferrals_today
+    assert deferrals_today(db) == 4
+
+
+def test_deferral_counter_accumulates_across_cycles(db, resend_on):
+    cfg = _cfg(mailjet_daily_quota=1, mailjet_hourly_quota=1, resend_daily_quota=0)
+    with patch("app.mail._call_mailjet_batch", return_value=200), \
+         patch("app.mail._call_resend_batch", return_value=200):
+        send_batch(db, _items(3, "a"), cfg)       # 1 sent, 2 deferred
+        send_batch(db, _items(3, "b"), cfg)       # quota spent, 3 deferred
+    from app.mail import deferrals_today
+    assert deferrals_today(db) == 5


### PR DESCRIPTION
Follow-up to #53, for what happens once the combined quota is genuinely spent.

### The same people were always at the back

`send_batch` fills provider batches in list order and defers the leftovers, so list order decides who loses a digest under saturation. The cycle stages in a stable order (city, then subscription id), so that was the same subscribers every time.

`flush_digests` now sorts by `last_notified_at`, never-notified first. The rotation needs no bookkeeping of its own: a deferred digest never stamps `last_notified_at`, so anyone passed over keeps their old timestamp and leads the next cycle.

### A deferral left no trace

The idempotency claim is deleted on the way out and the digest is never persisted, so the one event that means *a subscriber was not told about a slot* was invisible after the fact. Now counted per UTC day in `email_deferral_counts` (schema v7) and surfaced three ways:

- `/admin`, in the Email quota section
- the ops summary, as an anomaly with no percentage gating it — the cap has already cost someone a notification, which is not a "nearing the limit" warning
- the alert mail, beside the per-cycle count, which alone could never say what the day cost

### Deliberately not fixed

A slot taken before the retry means the digest never goes out. That is correct — there is nothing left to tell anyone about.

### Tests

431 passed, ruff clean. New: ordering is independent of staging order, an all-NULL sort doesn't raise (a naive tuple key comparing `None` to `None` would), the counter accumulates across cycles, and the anomaly fires below every quota threshold.