### PR TITLE
fix(privacy): let the bounce counter die with its subscription

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -65,7 +65,9 @@ CREATE TABLE IF NOT EXISTS email_deferral_counts (
 -- rejects it (HTTP 400/422) is refusing the recipient, not failing itself; once
 -- an address collects MAX_SEND_FAILURES_PER_ADDRESS of those we stop attempting
 -- it, so one typo'd sign-up isn't retried every cycle forever. Cleared on any
--- successful delivery to that address.
+-- successful delivery to that address, and by housekeeping once no subscription
+-- carries the address any more — the row is a bare e-mail address, so it may not
+-- outlive the subscription that justified storing it.
 CREATE TABLE IF NOT EXISTS email_failures (
   email          TEXT PRIMARY KEY,
   failures       INTEGER NOT NULL DEFAULT 0,

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -21,6 +21,7 @@ def run_once(conn: sqlite3.Connection) -> None:
     _send_heartbeats(conn, cfg, milestone_days=60, milestone_col="heartbeat_60d_at")
     _prune_seen_slots(conn)
     _prune_idempotency(conn)
+    _prune_email_failures(conn)
     _prune_slots_cache(conn)
     _prune_availability(conn)
     _check_parser_canary(conn, cfg)
@@ -124,6 +125,20 @@ def _prune_seen_slots(conn):
 
 def _prune_idempotency(conn):
     conn.execute("DELETE FROM sent_idempotency WHERE sent_at < datetime('now','-14 days')")
+
+def _prune_email_failures(conn):
+    """The bounce counter is keyed by the address itself, so it has to age out
+    on the same clock the address does. `_purge_hard` above deletes a
+    subscription 30 days after it was deleted; without this, its row here
+    outlived it forever — a bare e-mail address with nothing left to be
+    attached to, still dumped into every nightly backup, against a privacy
+    policy that promises final removal 30 days after deletion.
+
+    Depends on `_purge_hard` having run first in `run_once`. NOT EXISTS rather
+    than NOT IN: the latter deletes nothing at all if any subscription e-mail
+    is ever NULL."""
+    conn.execute("DELETE FROM email_failures WHERE NOT EXISTS ("
+                 "SELECT 1 FROM subscriptions s WHERE s.email = email_failures.email)")
 
 def _prune_slots_cache(conn):
     # Slots are short-lived in the upstream system; 14 days is generous.

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -100,6 +100,37 @@ def test_old_deleted_rows_hard_purged(db):
     row = db.execute("SELECT id FROM subscriptions WHERE id=?", (sid,)).fetchone()
     assert row is None
 
+def test_bounce_counter_dies_with_its_subscription(db):
+    """The hard purge takes the subscription; the bounce row keyed on the same
+    address must go with it, or a bare e-mail address outlives the 30-day
+    promise in datenschutz.html and keeps landing in every nightly dump."""
+    sid = insert_pending(db, email="bounced@example.com", city="leipzig",
+                         language="de", filter_=_f(), ttl_days=90)
+    db.execute("INSERT INTO email_failures (email, failures, last_failed_at) "
+               "VALUES ('bounced@example.com', 3, CURRENT_TIMESTAMP)")
+    db.execute("UPDATE subscriptions SET deleted_at=datetime('now','-31 days') WHERE id=?",
+               (sid,))
+    with patch("app.mail.send"):
+        run_once(db)
+    assert db.execute("SELECT 1 FROM email_failures "
+                      "WHERE email='bounced@example.com'").fetchone() is None
+
+
+def test_bounce_counter_survives_while_someone_still_subscribes(db):
+    """Suppression must not be reset just because housekeeping ran: the address
+    is still on a live subscription, so we still owe it the cap."""
+    sid = insert_pending(db, email="typo@example.com", city="leipzig",
+                         language="de", filter_=_f(), ttl_days=90)
+    confirm(db, sid)
+    db.execute("INSERT INTO email_failures (email, failures, last_failed_at) "
+               "VALUES ('typo@example.com', 3, datetime('now','-200 days'))")
+    with patch("app.mail.send"):
+        run_once(db)
+    row = db.execute("SELECT failures FROM email_failures "
+                     "WHERE email='typo@example.com'").fetchone()
+    assert row is not None and row["failures"] == 3
+
+
 def test_renewal_reminder_sent_in_window(db):
     sid = insert_pending(db, email="a@x.com", city="leipzig", language="de",
                          filter_=_f(), ttl_days=90)


### PR DESCRIPTION
`email_failures` keys on the bare e-mail address and is only ever cleared by a later *successful* delivery to it (`app/mail.py::_clear_send_failures`). A hard-bounced address therefore had no exit path: the subscription that justified storing it is soft-deleted, hard-purged 30 days later by `_purge_hard`, and the row here stays behind indefinitely, landing in every nightly dump.

That contradicts `Gelöschte Datensätze werden 30 Tage nach der Löschung endgültig entfernt`, and no backup retention window fixes it, because the row is in the live database.

Housekeeping now deletes any row whose address no longer appears in `subscriptions`. Placed after `_purge_hard` in `run_once`, so it ages out on exactly the same 30-day clock, and suppression is untouched while anyone still subscribes with that address. `NOT EXISTS` rather than `NOT IN` so a NULL e-mail could never silently disable the whole delete.

Two tests, both verified to fail with the call commented out (the second is the guard against fixing this by simply wiping the table): the counter dies with a hard-purged subscription, and a 200-day-old counter survives while its subscriber is live. Full suite 433 passed, ruff clean.

Scale today: 1 row against 108 subscriptions, so this is a correctness-of-promise fix rather than a volume one.