### PR TITLE
feat(mail): add Brevo and Sweego email providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,36 +10,49 @@ REPLY_TO_EMAIL=termine@jakubwaller.eu
 # hourly throttle binds; once Mailjet lifts it, this daily cap takes over. Set
 # high after upgrading to a paid Mailjet plan.
 MAILJET_DAILY_QUOTA=200
-# Optional fallback provider. Leave blank to disable — Mailjet failures
-# will then surface as MailFailed instead of falling back silently.
+# Optional fallback providers. Leave a key blank to disable that provider —
+# with no fallback configured, Mailjet failures surface as MailFailed instead
+# of falling back silently. Brevo and Sweego are EU providers; Resend (US) is
+# transitional and being phased out.
+BREVO_API_KEY=
+SWEEGO_API_KEY=
 RESEND_API_KEY=
 # Quota-aware delivery caps. Notification digests are sent in batches (Resend
-# up to 100/call, Mailjet up to 50/call) and never past these rolling-window
-# limits — the overflow is deferred to a later cycle. Defaults match the free
-# tiers (Resend 100/day; Mailjet 10/hour warm-up throttle + 200/day above).
-# Raise these to match your plan after upgrading.
+# up to 100/call, Mailjet up to 50/call; Brevo and Sweego one message per call)
+# and never past these rolling-window limits — the overflow is deferred to a
+# later cycle. Defaults match the free tiers (Brevo 300/day; Sweego 100/day;
+# Resend 100/day; Mailjet 10/hour warm-up throttle + 200/day above). Raise
+# these to match your plan after upgrading.
+BREVO_DAILY_QUOTA=300
+SWEEGO_DAILY_QUOTA=100
 RESEND_DAILY_QUOTA=100
 MAILJET_HOURLY_QUOTA=10
 # Monthly caps, display-only: the /admin "Email quota" section shows
-# month-to-date sends against these (free tiers: Mailjet 6000/mo, Resend
-# 3000/mo). They do NOT gate delivery — the rolling-window caps above do.
+# month-to-date sends against these (free tiers: Mailjet 6000/mo, Brevo
+# 9000/mo, Sweego 3000/mo, Resend 3000/mo). They do NOT gate delivery — the
+# rolling-window caps above do.
 MAILJET_MONTHLY_QUOTA=6000
+BREVO_MONTHLY_QUOTA=9000
+SWEEGO_MONTHLY_QUOTA=3000
 RESEND_MONTHLY_QUOTA=3000
 # Order digests try providers. Mailjet-first routes notification volume through
 # Mailjet so its account sees traffic (needed to get the new-sender throttle
-# lifted); Resend takes the overflow. Flip to "resend,mailjet" once Mailjet's
-# limit is raised, with no redeploy.
+# lifted); the rest take the overflow, in order. Recommended once Brevo and
+# Sweego keys are in place: "mailjet,brevo,sweego,resend" (EU providers before
+# the outgoing Resend). Runtime-configurable, no redeploy.
 EMAIL_PROVIDER_ORDER=mailjet,resend
-# Email DEVELOPER_EMAIL once/day when daily Resend usage crosses this percent
-# of RESEND_DAILY_QUOTA, or whenever notifications get deferred for lack of
-# quota — the cue to switch to a paid plan.
+# Email DEVELOPER_EMAIL once/day when the COMBINED rolling-24h usage across
+# every provider that can send crosses this percent of the summed daily caps,
+# or whenever notifications get deferred for lack of quota — the cue to switch
+# to a paid plan.
 QUOTA_ALERT_THRESHOLD_PCT=80
 TOKEN_SECRET_PRIMARY=
 TOKEN_SECRET_PREVIOUS=
 ADMIN_TOKEN=
 # Public site URL — all links in emails (confirm / manage / unsubscribe) are
-# built from this. The From domain above must stay verified with BOTH
-# providers (Mailjet and Resend), or fallback sends get rejected.
+# built from this. The From domain above must stay verified with EVERY
+# configured provider (Mailjet, Brevo, Sweego, Resend), or fallback sends get
+# rejected.
 PUBLIC_BASE_URL=https://buergerwecker.de
 DEDUP_WINDOW_HOURS=24
 RATE_LIMIT_MINUTES=15

--- a/.env.example
+++ b/.env.example
@@ -10,10 +10,13 @@ REPLY_TO_EMAIL=termine@jakubwaller.eu
 # hourly throttle binds; once Mailjet lifts it, this daily cap takes over. Set
 # high after upgrading to a paid Mailjet plan.
 MAILJET_DAILY_QUOTA=200
-# Optional fallback providers. Leave a key blank to disable that provider —
-# with no fallback configured, Mailjet failures surface as MailFailed instead
-# of falling back silently. Brevo and Sweego are EU providers; Resend (US) is
-# transitional and being phased out.
+# Optional fallback providers. A provider sends only when its key is set AND
+# it is named in EMAIL_PROVIDER_ORDER below — a key alone is inert, so one can
+# be configured ahead of a smoke test without routing live mail through it.
+# Leave a key blank to disable that provider outright; with no fallback in the
+# order, Mailjet failures surface as MailFailed instead of falling back
+# silently. Brevo and Sweego are EU providers; Resend (US) is transitional and
+# being phased out.
 BREVO_API_KEY=
 SWEEGO_API_KEY=
 RESEND_API_KEY=
@@ -35,11 +38,12 @@ MAILJET_MONTHLY_QUOTA=6000
 BREVO_MONTHLY_QUOTA=9000
 SWEEGO_MONTHLY_QUOTA=3000
 RESEND_MONTHLY_QUOTA=3000
-# Order digests try providers. Mailjet-first routes notification volume through
+# Order providers are tried — for notification digests and the transactional
+# fallback chain alike. Mailjet-first routes notification volume through
 # Mailjet so its account sees traffic (needed to get the new-sender throttle
 # lifted); the rest take the overflow, in order. Recommended once Brevo and
-# Sweego keys are in place: "mailjet,brevo,sweego,resend" (EU providers before
-# the outgoing Resend). Runtime-configurable, no redeploy.
+# Sweego are proven (see docs/DEPLOY.md): "mailjet,brevo,sweego,resend" (EU
+# providers before the outgoing Resend). Runtime-configurable, no redeploy.
 EMAIL_PROVIDER_ORDER=mailjet,resend
 # Email DEVELOPER_EMAIL once/day when the COMBINED rolling-24h usage across
 # every provider that can send crosses this percent of the summed daily caps,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,10 @@ links in already-sent mail silently misparse.
 **Mail sends are idempotent by key** — `subscription_id | sorted slot hashes | cycle_id`. Changing
 how that key is built means re-notifying people about slots they were already told about.
 
-**Two providers, and the From domain must be verified in both.** `EMAIL_PROVIDER_ORDER` falls back
-between Mailjet and Resend; an unverified sender domain makes the fallback reject the mail at exactly
-the moment it is needed. Quotas are enforced in config — see the DEPLOY runbook.
+**Several providers, and the From domain must be verified in every one of them.**
+`EMAIL_PROVIDER_ORDER` falls back along the configured chain (Mailjet, Brevo, Sweego, Resend); an
+unverified sender domain makes a fallback provider reject the mail at exactly the moment it is
+needed. Quotas are enforced in config — see the DEPLOY runbook.
 
 **One malformed address used to kill a whole batch.** Batch sends must isolate per-recipient
 failures; `tests/test_send_batch.py` guards it.

--- a/app/admin.py
+++ b/app/admin.py
@@ -216,6 +216,16 @@ def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
         "resend":  {"month_quota": getattr(cfg, "resend_monthly_quota", None),
                     "day_quota":   getattr(cfg, "resend_daily_quota", None)},
     }
+    # Brevo/Sweego join the table only once their API key is configured: a
+    # provider that cannot send must not add its cap to the combined-pool
+    # grading in summary_anomalies (the same principle mail._daily_usage
+    # applies via _providers).
+    if getattr(cfg, "brevo_api_key", ""):
+        caps["brevo"] = {"month_quota": getattr(cfg, "brevo_monthly_quota", None),
+                         "day_quota":   getattr(cfg, "brevo_daily_quota", None)}
+    if getattr(cfg, "sweego_api_key", ""):
+        caps["sweego"] = {"month_quota": getattr(cfg, "sweego_monthly_quota", None),
+                          "day_quota":   getattr(cfg, "sweego_daily_quota", None)}
     usage = {p: {"month": 0, "today": 0, **caps[p]} for p in caps}
     try:
         rows = conn.execute(

--- a/app/admin.py
+++ b/app/admin.py
@@ -216,14 +216,19 @@ def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
         "resend":  {"month_quota": getattr(cfg, "resend_monthly_quota", None),
                     "day_quota":   getattr(cfg, "resend_daily_quota", None)},
     }
-    # Brevo/Sweego join the table only once their API key is configured: a
-    # provider that cannot send must not add its cap to the combined-pool
-    # grading in summary_anomalies (the same principle mail._daily_usage
-    # applies via _providers).
-    if getattr(cfg, "brevo_api_key", ""):
+    # Brevo/Sweego join the table only once they can actually send: API key
+    # configured AND named in EMAIL_PROVIDER_ORDER — the same gate
+    # mail._daily_usage applies via _providers. A provider that cannot send
+    # (say, a key configured ahead of a smoke test while the order still
+    # excludes it) must not add its cap to the combined-pool grading in
+    # summary_anomalies. The unconditional mailjet/resend rows above are
+    # transition-scoped on purpose: Mailjet is required config, and Resend
+    # keeps its row until the phase-out completes.
+    order = getattr(cfg, "email_provider_order", ("mailjet", "resend"))
+    if getattr(cfg, "brevo_api_key", "") and "brevo" in order:
         caps["brevo"] = {"month_quota": getattr(cfg, "brevo_monthly_quota", None),
                          "day_quota":   getattr(cfg, "brevo_daily_quota", None)}
-    if getattr(cfg, "sweego_api_key", ""):
+    if getattr(cfg, "sweego_api_key", "") and "sweego" in order:
         caps["sweego"] = {"month_quota": getattr(cfg, "sweego_monthly_quota", None),
                           "day_quota":   getattr(cfg, "sweego_daily_quota", None)}
     usage = {p: {"month": 0, "today": 0, **caps[p]} for p in caps}

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,12 @@ class Config:
     resend_api_key: str
     resend_daily_quota: int
     resend_monthly_quota: int
+    brevo_api_key: str
+    brevo_daily_quota: int
+    brevo_monthly_quota: int
+    sweego_api_key: str
+    sweego_daily_quota: int
+    sweego_monthly_quota: int
     mailjet_hourly_quota: int
     quota_alert_threshold_pct: int
     max_send_failures_per_address: int
@@ -58,14 +64,21 @@ def load_config() -> Config:
         mailjet_from_name=_req("MAILJET_FROM_NAME"),
         mailjet_daily_quota=_req_int("MAILJET_DAILY_QUOTA"),
         resend_api_key=os.environ.get("RESEND_API_KEY", ""),
+        brevo_api_key=os.environ.get("BREVO_API_KEY", ""),
+        sweego_api_key=os.environ.get("SWEEGO_API_KEY", ""),
         # Free-tier send caps used for quota-aware delivery + alerting. Defaults
-        # match Resend's free tier (100/day) and the current Mailjet allowance
-        # (10/hour). Raise these after upgrading to a paid plan.
+        # match the free tiers — Resend 100/day, Brevo 300/day, Sweego 100/day —
+        # and the current Mailjet allowance (10/hour). Raise these after
+        # upgrading to a paid plan.
         resend_daily_quota=int(os.environ.get("RESEND_DAILY_QUOTA", "100")),
+        brevo_daily_quota=int(os.environ.get("BREVO_DAILY_QUOTA", "300")),
+        sweego_daily_quota=int(os.environ.get("SWEEGO_DAILY_QUOTA", "100")),
         # Monthly caps are display-only (admin quota view): free tiers allow
-        # Mailjet 6000/mo and Resend 3000/mo.
+        # Mailjet 6000/mo, Resend 3000/mo, Brevo 9000/mo, Sweego 3000/mo.
         mailjet_monthly_quota=int(os.environ.get("MAILJET_MONTHLY_QUOTA", "6000")),
         resend_monthly_quota=int(os.environ.get("RESEND_MONTHLY_QUOTA", "3000")),
+        brevo_monthly_quota=int(os.environ.get("BREVO_MONTHLY_QUOTA", "9000")),
+        sweego_monthly_quota=int(os.environ.get("SWEEGO_MONTHLY_QUOTA", "3000")),
         mailjet_hourly_quota=int(os.environ.get("MAILJET_HOURLY_QUOTA", "10")),
         quota_alert_threshold_pct=int(os.environ.get("QUOTA_ALERT_THRESHOLD_PCT", "80")),
         # How many provider content-rejections an address may collect before we

--- a/app/mail.py
+++ b/app/mail.py
@@ -161,19 +161,33 @@ def _record_send_count(conn: sqlite3.Connection, provider: str, n: int = 1) -> N
         (provider, n),
     )
 
+# Providers whose API key is optional; a missing key disables the provider.
+_PROVIDER_API_KEYS = {"brevo": "BREVO_API_KEY", "sweego": "SWEEGO_API_KEY",
+                      "resend": "RESEND_API_KEY"}
+
 def _single_send_chain() -> list[tuple[str, Any]]:
-    """Failover chain for transactional `send()`: Mailjet first (it is required
-    config), then every optional provider whose API key is present — the EU
-    providers before Resend, matching the recommended EMAIL_PROVIDER_ORDER
-    transition (Resend is being phased out)."""
-    chain: list[tuple[str, Any]] = [("mailjet", _call_mailjet)]
-    if os.environ.get("BREVO_API_KEY"):
-        chain.append(("brevo", _call_brevo))
-    if os.environ.get("SWEEGO_API_KEY"):
-        chain.append(("sweego", _call_sweego))
-    if os.environ.get("RESEND_API_KEY"):
-        chain.append(("resend", _call_resend))
-    return chain
+    """Failover chain for transactional `send()`, gated by EMAIL_PROVIDER_ORDER
+    exactly like the digest path (`_providers`): a provider sends only when it
+    is named in the order AND its API key is present. A key configured ahead of
+    a smoke test is therefore inert until the order says otherwise, and
+    dropping a provider from the order removes it from BOTH send paths. If the
+    order names nothing usable, Mailjet (required config) is the last resort —
+    transactional mail must always have a provider."""
+    available = {"mailjet": _call_mailjet, "brevo": _call_brevo,
+                 "sweego": _call_sweego, "resend": _call_resend}
+    order = [p.strip() for p in
+             os.environ.get("EMAIL_PROVIDER_ORDER", "mailjet,resend").split(",")
+             if p.strip()]
+    chain: list[tuple[str, Any]] = []
+    for name in order:
+        call = available.get(name)
+        if call is None:
+            continue
+        env_key = _PROVIDER_API_KEYS.get(name)
+        if env_key and not os.environ.get(env_key):
+            continue
+        chain.append((name, call))
+    return chain or [("mailjet", _call_mailjet)]
 
 def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
          *, idem_key: str, unsub_url: str | None = None,
@@ -199,7 +213,7 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
         # Fail over on ANY provider error (4xx incl. 401/403 account blocks,
         # and 5xx/429), not just transient ones — a blocked account returns
         # 401, and that's exactly when the fallback must engage.
-        for provider, call in _single_send_chain():  # never empty: mailjet leads
+        for provider, call in _single_send_chain():  # never empty: mailjet is the last resort
             resp = call(to, subject, body, unsub_url, reply_to)
             if resp.status_code < 400:
                 break
@@ -363,15 +377,13 @@ def _providers(cfg) -> list[tuple]:
         "resend": ("resend", _call_resend_batch, 100,
                    [(cfg.resend_daily_quota, 86400)]),
     }
-    api_keys = {"brevo": "BREVO_API_KEY", "sweego": "SWEEGO_API_KEY",
-                "resend": "RESEND_API_KEY"}
     order = getattr(cfg, "email_provider_order", ("mailjet", "resend"))
     specs: list[tuple] = []
     for name in order:
         spec = available.get(name)
         if spec is None:
             continue
-        env_key = api_keys.get(name)
+        env_key = _PROVIDER_API_KEYS.get(name)
         if env_key and not os.environ.get(env_key):
             continue
         specs.append(spec)
@@ -384,6 +396,16 @@ def _content_rejected(status: int | None) -> bool:
     """400/422: the provider parsed the request and rejected what was in it.
     For a batch send that points at a recipient, not at the provider."""
     return status in (400, 422)
+
+# When one provider rejects at least this many messages in a cycle while
+# delivering none, its 400/422s stop being believed as per-recipient verdicts
+# (see the guard in send_batch). One or two rejections is the everyday case
+# the failure counter exists for — a typo'd address. A whole cycle of them
+# with zero successes looks like the provider rejecting the sender's side
+# (bad payload shape, unverified From domain — every call 4xxes), and blaming
+# the recipients would silently retire every routed address within
+# max_send_failures_per_address cycles.
+_SYSTEMIC_REJECTION_MIN = 3
 
 def _deliver(send_fn, chunk: list[Outgoing]) -> tuple[list, list, bool]:
     """Send `chunk`. Returns (delivered, undeliverable, provider_unusable).
@@ -530,6 +552,13 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
                 # provider can take it. If every provider fails, the trailing
                 # deferral block releases them.
                 break
+        if (len(refused) >= _SYSTEMIC_REJECTION_MIN
+                and not result.sent_by_provider.get(name)):
+            # An unbroken rejection streak with nothing delivered: treat it as
+            # the provider being unusable, not as a verdict on the recipients.
+            # Hand the mail on to the next provider (or the deferral path at
+            # the bottom) with no failure strikes recorded.
+            remaining, refused = remaining + refused, []
 
     if refused:
         # Refused by every provider that could try it. Release the claim so a

--- a/app/mail.py
+++ b/app/mail.py
@@ -66,6 +66,49 @@ def _resend_email(to: str, subject: str, body: str,
         payload["reply_to"] = reply_to
     return payload
 
+def _brevo_email(to: str, subject: str, body: str,
+                 unsub_url: str | None = None,
+                 reply_to: str | None = None) -> dict:
+    """One Brevo `/v3/smtp/email` payload. The From identity is the same
+    verified sending address the other providers use."""
+    payload = {
+        "sender": {"email": os.environ["MAILJET_FROM_EMAIL"],
+                   "name":  os.environ["MAILJET_FROM_NAME"]},
+        "to": [{"email": to}],
+        "subject": subject,
+        "textContent": body,
+    }
+    headers = _unsub_headers(unsub_url)
+    if headers:
+        payload["headers"] = headers
+    reply_to = reply_to or os.environ.get("REPLY_TO_EMAIL")
+    if reply_to:
+        payload["replyTo"] = {"email": reply_to}
+    return payload
+
+def _sweego_email(to: str, subject: str, body: str,
+                  unsub_url: str | None = None,
+                  reply_to: str | None = None) -> dict:
+    """One Sweego `/send` payload. Field names are hyphenated JSON keys, and
+    `channel`/`provider` are required literals."""
+    payload = {
+        "channel": "email",
+        "provider": "sweego",
+        "campaign-type": "transac",
+        "from": {"email": os.environ["MAILJET_FROM_EMAIL"],
+                 "name":  os.environ["MAILJET_FROM_NAME"]},
+        "recipients": [{"email": to}],
+        "subject": subject,
+        "message-txt": body,
+    }
+    headers = _unsub_headers(unsub_url)
+    if headers:
+        payload["headers"] = headers
+    reply_to = reply_to or os.environ.get("REPLY_TO_EMAIL")
+    if reply_to:
+        payload["reply-to"] = {"email": reply_to}
+    return payload
+
 def _call_mailjet(to: str, subject: str, body: str,
                   unsub_url: str | None = None,
                   reply_to: str | None = None) -> Any:
@@ -87,6 +130,26 @@ def _call_resend(to: str, subject: str, body: str,
         timeout=30,
     )
 
+def _call_brevo(to: str, subject: str, body: str,
+                unsub_url: str | None = None,
+                reply_to: str | None = None) -> Any:
+    return requests.post(
+        "https://api.brevo.com/v3/smtp/email",
+        headers={"api-key": os.environ["BREVO_API_KEY"]},
+        json=_brevo_email(to, subject, body, unsub_url, reply_to),
+        timeout=30,
+    )
+
+def _call_sweego(to: str, subject: str, body: str,
+                 unsub_url: str | None = None,
+                 reply_to: str | None = None) -> Any:
+    return requests.post(
+        "https://api.sweego.io/send",
+        headers={"Api-Key": os.environ["SWEEGO_API_KEY"]},
+        json=_sweego_email(to, subject, body, unsub_url, reply_to),
+        timeout=30,
+    )
+
 def _record_send_count(conn: sqlite3.Connection, provider: str, n: int = 1) -> None:
     """Bump the durable per-day counter behind the admin quota view. Days are
     UTC (matching sent_at's CURRENT_TIMESTAMP), an approximation of the
@@ -98,6 +161,20 @@ def _record_send_count(conn: sqlite3.Connection, provider: str, n: int = 1) -> N
         (provider, n),
     )
 
+def _single_send_chain() -> list[tuple[str, Any]]:
+    """Failover chain for transactional `send()`: Mailjet first (it is required
+    config), then every optional provider whose API key is present — the EU
+    providers before Resend, matching the recommended EMAIL_PROVIDER_ORDER
+    transition (Resend is being phased out)."""
+    chain: list[tuple[str, Any]] = [("mailjet", _call_mailjet)]
+    if os.environ.get("BREVO_API_KEY"):
+        chain.append(("brevo", _call_brevo))
+    if os.environ.get("SWEEGO_API_KEY"):
+        chain.append(("sweego", _call_sweego))
+    if os.environ.get("RESEND_API_KEY"):
+        chain.append(("resend", _call_resend))
+    return chain
+
 def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
          *, idem_key: str, unsub_url: str | None = None,
          reply_to: str | None = None) -> None:
@@ -106,8 +183,8 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
     `reply_to` overrides the REPLY_TO_EMAIL default for this one message.
 
     Order: claim the idempotency row FIRST (atomic INSERT OR IGNORE), then
-    attempt sends. If both providers fail the claim is rolled back so a
-    retry can proceed. If the process dies between claim and successful
+    attempt sends. If every configured provider fails the claim is rolled back
+    so a retry can proceed. If the process dies between claim and successful
     send, the row remains with provider='pending' and the next call
     short-circuits — preventing a double-send on crash recovery.
     """
@@ -119,14 +196,13 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
     if cur.rowcount == 0:
         return  # already claimed by an earlier call
     try:
-        resp = _call_mailjet(to, subject, body, unsub_url, reply_to)
-        provider = "mailjet"
-        # Fail over to Resend on ANY Mailjet error (4xx incl. 401/403 account
-        # blocks, and 5xx/429), not just transient ones — a blocked Mailjet
-        # account returns 401, and that's exactly when the fallback must engage.
-        if resp.status_code >= 400 and os.environ.get("RESEND_API_KEY"):
-            resp = _call_resend(to, subject, body, unsub_url, reply_to)
-            provider = "resend"
+        # Fail over on ANY provider error (4xx incl. 401/403 account blocks,
+        # and 5xx/429), not just transient ones — a blocked account returns
+        # 401, and that's exactly when the fallback must engage.
+        for provider, call in _single_send_chain():  # never empty: mailjet leads
+            resp = call(to, subject, body, unsub_url, reply_to)
+            if resp.status_code < 400:
+                break
         if resp.status_code >= 400:
             raise MailFailed(f"provider failed; last status {resp.status_code}")
     except Exception:
@@ -142,12 +218,12 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
 # --------------------------------------------------------------------------
 # Batched, quota-aware delivery (notification digests).
 #
-# Free-tier providers cap total sends (Resend ~100/day, Mailjet ~10/hour), so
-# a notification burst must (a) be sent in as few HTTP calls as possible and
-# (b) stop before a provider's cap to avoid account blocks. `send_batch` packs
-# recipients into provider batch calls, sends only within each provider's
-# remaining rolling-window quota, and DEFERS the rest (releasing their
-# idempotency claims so a later cycle retries them).
+# Free-tier providers cap total sends (Mailjet ~10/hour, Brevo ~300/day,
+# Sweego and Resend ~100/day), so a notification burst must (a) be sent in as
+# few HTTP calls as possible and (b) stop before a provider's cap to avoid
+# account blocks. `send_batch` packs recipients into provider batch calls,
+# sends only within each provider's remaining rolling-window quota, and DEFERS
+# the rest (releasing their idempotency claims so a later cycle retries them).
 # --------------------------------------------------------------------------
 
 @dataclass(frozen=True)
@@ -233,6 +309,23 @@ def _call_resend_batch(items: list[Outgoing]) -> ProviderResult:
     )
     return ProviderResult(resp.status_code)
 
+# Brevo and Sweego send ONE message per API call, on purpose. Neither API
+# documents whether a multi-message request is all-or-nothing, and our retry
+# logic is only safe under one of two regimes: per-message verdicts (Mailjet)
+# or a provably atomic batch (Resend). One recipient per call sidesteps the
+# ambiguity — a 4xx is attributable to exactly that recipient, and nothing was
+# partially delivered. Both are registered with batch_size=1 to enforce it.
+
+def _call_brevo_batch(items: list[Outgoing]) -> ProviderResult:
+    [item] = items  # batch_size=1 — see the atomicity note above
+    resp = _call_brevo(item.to, item.subject, item.body, item.unsub_url)
+    return ProviderResult(resp.status_code)
+
+def _call_sweego_batch(items: list[Outgoing]) -> ProviderResult:
+    [item] = items  # batch_size=1 — see the atomicity note above
+    resp = _call_sweego(item.to, item.subject, item.body, item.unsub_url)
+    return ProviderResult(resp.status_code)
+
 def _window_used(conn: sqlite3.Connection, provider: str, window_seconds: int) -> int:
     """Count emails a provider actually sent within the last `window_seconds`.
     Reads sent_idempotency (14-day retention covers our day/hour windows)."""
@@ -248,28 +341,38 @@ def _providers(cfg) -> list[tuple]:
 
     Order follows cfg.email_provider_order (default Mailjet-first, so Mailjet's
     account sees the notification traffic — the prerequisite for getting its
-    new-sender throttle lifted; Resend absorbs whatever exceeds Mailjet's
-    hourly allowance). Resend is skipped when no API key is configured. Each
-    provider's window usage already includes transactional emails sent via
-    `send()`, since those are recorded under the same provider name.
+    new-sender throttle lifted; the rest of the order absorbs whatever exceeds
+    Mailjet's hourly allowance). Optional providers (Brevo, Sweego, Resend) are
+    skipped when their API key is not configured. Each provider's window usage
+    already includes transactional emails sent via `send()`, since those are
+    recorded under the same provider name.
     """
     # Mailjet is bounded by BOTH its hourly cap (the new-sender warm-up
     # throttle) and its daily cap (free tier = 200/day); _headroom takes the
-    # tighter of the two. Resend's free tier is a flat daily cap.
+    # tighter of the two. Brevo (free tier 300/day), Sweego (100/day) and
+    # Resend (100/day) are flat daily caps. Brevo and Sweego run at
+    # batch_size=1 — see the atomicity note above their batch callers.
     available = {
         "mailjet": ("mailjet", _call_mailjet_batch, 50,
                     [(cfg.mailjet_hourly_quota, 3600),
                      (cfg.mailjet_daily_quota, 86400)]),
+        "brevo": ("brevo", _call_brevo_batch, 1,
+                  [(getattr(cfg, "brevo_daily_quota", 300), 86400)]),
+        "sweego": ("sweego", _call_sweego_batch, 1,
+                   [(getattr(cfg, "sweego_daily_quota", 100), 86400)]),
         "resend": ("resend", _call_resend_batch, 100,
                    [(cfg.resend_daily_quota, 86400)]),
     }
+    api_keys = {"brevo": "BREVO_API_KEY", "sweego": "SWEEGO_API_KEY",
+                "resend": "RESEND_API_KEY"}
     order = getattr(cfg, "email_provider_order", ("mailjet", "resend"))
     specs: list[tuple] = []
     for name in order:
         spec = available.get(name)
         if spec is None:
             continue
-        if name == "resend" and not os.environ.get("RESEND_API_KEY"):
+        env_key = api_keys.get(name)
+        if env_key and not os.environ.get(env_key):
             continue
         specs.append(spec)
     return specs
@@ -476,6 +579,8 @@ def _daily_usage(conn: sqlite3.Connection, cfg) -> list[tuple[str, int, int]]:
     actually configured to send. Providers without a cap are skipped — there is
     nothing to be near the limit of."""
     caps = {"mailjet": getattr(cfg, "mailjet_daily_quota", 0),
+            "brevo": getattr(cfg, "brevo_daily_quota", 0),
+            "sweego": getattr(cfg, "sweego_daily_quota", 0),
             "resend": getattr(cfg, "resend_daily_quota", 0)}
     usage = []
     for name, _send_fn, _batch_size, _limits in _providers(cfg):

--- a/app/templates/datenschutz.html
+++ b/app/templates/datenschutz.html
@@ -13,7 +13,7 @@
     <h2>Retention period</h2>
     <p>Subscriptions expire automatically 90 days after sign-up — 30 days for the sensitive appointment types described above — unless extended via the renewal link. Deleted records are permanently removed 30 days after deletion.</p>
     <h2>Processors</h2>
-    <p>Cloudflare, Inc. (content delivery & DDoS protection; processes visitors' IP addresses to serve and protect the site — certified under the EU-US Data Privacy Framework). netcup GmbH, Karlsruhe, Germany (hosting; EU data center). Mailjet (EU servers), Brevo (EU servers) and Sweego (EU servers, France) for email delivery. During a transition period we still use Resend, a US provider that dispatches our emails via EU servers (Ireland) but stores account data in the USA; it is being phased out. A data processing agreement (DPA) is in place with all providers.</p>
+    <p>Cloudflare, Inc. (content delivery & DDoS protection; processes visitors' IP addresses to serve and protect the site — certified under the EU-US Data Privacy Framework). netcup GmbH, Karlsruhe, Germany (hosting; EU data center). Mailjet (EU servers), Brevo (EU servers) and Sweego (EU servers, France) for email delivery. During a transition period we still use Resend, a US provider that dispatches our emails via EU servers (Ireland) but stores account data, logs and email metadata (including recipient addresses) in the USA; it is being phased out. A data processing agreement (DPA) is in place with all providers.</p>
     <h2>Your rights</h2>
     <p>Access (Art. 15), rectification (Art. 16), erasure (Art. 17), restriction (Art. 18), portability (Art. 20), withdrawal of consent (Art. 7(3)). Contact: jakub@jakubwaller.eu.</p>
   {% else %}
@@ -29,7 +29,7 @@
     <h2>Speicherdauer</h2>
     <p>Abonnements laufen 90 Tage nach der Erstanmeldung automatisch ab — bei den oben beschriebenen besonders geschützten Anliegen nach 30 Tagen —, sofern sie nicht über den Erneuerungslink verlängert werden. Gelöschte Datensätze werden 30 Tage nach der Löschung endgültig entfernt.</p>
     <h2>Auftragsverarbeiter</h2>
-    <p>Cloudflare, Inc. (Auslieferung & DDoS-Schutz; verarbeitet die IP-Adressen der Besucher, um die Seite auszuliefern und zu schützen — zertifiziert nach dem EU-US Data Privacy Framework). netcup GmbH, Karlsruhe (Hosting; EU-Rechenzentrum). Mailjet (EU-Server), Brevo (EU-Server) und Sweego (EU-Server, Frankreich) zum Versand der E-Mails. Übergangsweise setzen wir noch Resend ein, einen US-Anbieter, der unsere E-Mails über EU-Server (Irland) versendet, Kontodaten jedoch in den USA speichert; er wird schrittweise abgelöst. Mit allen Anbietern besteht ein AVV-Vertrag.</p>
+    <p>Cloudflare, Inc. (Auslieferung & DDoS-Schutz; verarbeitet die IP-Adressen der Besucher, um die Seite auszuliefern und zu schützen — zertifiziert nach dem EU-US Data Privacy Framework). netcup GmbH, Karlsruhe (Hosting; EU-Rechenzentrum). Mailjet (EU-Server), Brevo (EU-Server) und Sweego (EU-Server, Frankreich) zum Versand der E-Mails. Übergangsweise setzen wir noch Resend ein, einen US-Anbieter, der unsere E-Mails über EU-Server (Irland) versendet, Kontodaten, Protokolle und E-Mail-Metadaten (einschließlich Empfängeradressen) jedoch in den USA speichert; er wird schrittweise abgelöst. Mit allen Anbietern besteht ein AVV-Vertrag.</p>
     <h2>Deine Rechte</h2>
     <p>Auskunft (Art. 15), Berichtigung (Art. 16), Löschung (Art. 17), Einschränkung (Art. 18), Datenübertragbarkeit (Art. 20), Widerruf der Einwilligung (Art. 7(3)). Kontakt: jakub@jakubwaller.eu.</p>
   {% endif %}

--- a/app/templates/datenschutz.html
+++ b/app/templates/datenschutz.html
@@ -13,7 +13,7 @@
     <h2>Retention period</h2>
     <p>Subscriptions expire automatically 90 days after sign-up — 30 days for the sensitive appointment types described above — unless extended via the renewal link. Deleted records are permanently removed 30 days after deletion.</p>
     <h2>Processors</h2>
-    <p>Cloudflare, Inc. (content delivery & DDoS protection; processes visitors' IP addresses to serve and protect the site — certified under the EU-US Data Privacy Framework). netcup GmbH, Karlsruhe, Germany (hosting; EU data center). Mailjet (EU servers) and Resend (EU servers, Ireland region) for email delivery. A data processing agreement (DPA) is in place with all providers.</p>
+    <p>Cloudflare, Inc. (content delivery & DDoS protection; processes visitors' IP addresses to serve and protect the site — certified under the EU-US Data Privacy Framework). netcup GmbH, Karlsruhe, Germany (hosting; EU data center). Mailjet (EU servers), Brevo (EU servers) and Sweego (EU servers, France) for email delivery. During a transition period we still use Resend, a US provider that dispatches our emails via EU servers (Ireland) but stores account data in the USA; it is being phased out. A data processing agreement (DPA) is in place with all providers.</p>
     <h2>Your rights</h2>
     <p>Access (Art. 15), rectification (Art. 16), erasure (Art. 17), restriction (Art. 18), portability (Art. 20), withdrawal of consent (Art. 7(3)). Contact: jakub@jakubwaller.eu.</p>
   {% else %}
@@ -29,7 +29,7 @@
     <h2>Speicherdauer</h2>
     <p>Abonnements laufen 90 Tage nach der Erstanmeldung automatisch ab — bei den oben beschriebenen besonders geschützten Anliegen nach 30 Tagen —, sofern sie nicht über den Erneuerungslink verlängert werden. Gelöschte Datensätze werden 30 Tage nach der Löschung endgültig entfernt.</p>
     <h2>Auftragsverarbeiter</h2>
-    <p>Cloudflare, Inc. (Auslieferung & DDoS-Schutz; verarbeitet die IP-Adressen der Besucher, um die Seite auszuliefern und zu schützen — zertifiziert nach dem EU-US Data Privacy Framework). netcup GmbH, Karlsruhe (Hosting; EU-Rechenzentrum). Mailjet (EU-Server) und Resend (EU-Server, Region Irland) zum Versand der E-Mails. Mit allen Anbietern besteht ein AVV-Vertrag.</p>
+    <p>Cloudflare, Inc. (Auslieferung & DDoS-Schutz; verarbeitet die IP-Adressen der Besucher, um die Seite auszuliefern und zu schützen — zertifiziert nach dem EU-US Data Privacy Framework). netcup GmbH, Karlsruhe (Hosting; EU-Rechenzentrum). Mailjet (EU-Server), Brevo (EU-Server) und Sweego (EU-Server, Frankreich) zum Versand der E-Mails. Übergangsweise setzen wir noch Resend ein, einen US-Anbieter, der unsere E-Mails über EU-Server (Irland) versendet, Kontodaten jedoch in den USA speichert; er wird schrittweise abgelöst. Mit allen Anbietern besteht ein AVV-Vertrag.</p>
     <h2>Deine Rechte</h2>
     <p>Auskunft (Art. 15), Berichtigung (Art. 16), Löschung (Art. 17), Einschränkung (Art. 18), Datenübertragbarkeit (Art. 20), Widerruf der Einwilligung (Art. 7(3)). Kontakt: jakub@jakubwaller.eu.</p>
   {% endif %}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -12,21 +12,26 @@
   database** — it protects against a bad write or a bad deploy, not against
   losing the disk. The off-host copy is what covers that; see "Off-host backup"
   below. (On the Pi this used to be a USB HDD auto-mounted via `/etc/fstab`.)
-- Mailjet and Resend accounts with verified sender domain.
+- Email provider accounts with verified sender domain: Mailjet, Brevo and
+  Sweego (plus Resend while it is still in the chain — it is transitional and
+  on its way out).
 - SPF / DKIM / DMARC records configured on `buergerwecker.de` and the domain
-  validated in **both** Mailjet and Resend before any send — an unverified
-  From domain makes the fallback provider reject mail. `REPLY_TO_EMAIL`
-  points at a real mailbox on `jakubwaller.eu`; the From address itself
-  doesn't receive mail.
+  validated in **every** configured provider (Mailjet, Brevo, Sweego, Resend)
+  before any send — an unverified From domain makes a fallback provider reject
+  mail. Mind the DMARC record when adding a provider: the domain must keep
+  exactly one, so extend the existing record rather than letting a provider's
+  automatic flow replace it. `REPLY_TO_EMAIL` points at a real mailbox on
+  `jakubwaller.eu`; the From address itself doesn't receive mail.
 
 ## First deploy
 
 1. Clone the repo to the host.
 2. Copy `.env.example` to `.env` and fill in real secrets:
    - 32-byte `TOKEN_SECRET_PRIMARY` and `ADMIN_TOKEN` (e.g., `openssl rand -hex 32`).
-   - Mailjet and Resend API keys.
+   - Mailjet, Brevo, Sweego and Resend API keys.
    - Review the email-delivery settings (`EMAIL_PROVIDER_ORDER`,
-     `RESEND_DAILY_QUOTA`, `MAILJET_HOURLY_QUOTA`, `MAILJET_DAILY_QUOTA`,
+     `BREVO_DAILY_QUOTA`, `SWEEGO_DAILY_QUOTA`, `RESEND_DAILY_QUOTA`,
+     `MAILJET_HOURLY_QUOTA`, `MAILJET_DAILY_QUOTA`,
      `QUOTA_ALERT_THRESHOLD_PCT`) — see "Email delivery & quotas" below.
 3. Verify `/mnt/backup` exists (and, where it is a separate device, that it is
    mounted) — the compose backup service bind-mounts it.
@@ -37,22 +42,32 @@
 ## Email delivery & quotas
 
 Notification digests and confirmation emails are sent in quota-aware batches
-across two providers, so a traffic spike degrades gracefully instead of
+across several providers, so a traffic spike degrades gracefully instead of
 failing:
 
 - **Provider order** (`EMAIL_PROVIDER_ORDER`, default `mailjet,resend`).
-  Digests try the first provider up to its remaining quota, then spill to the
-  next. Mailjet-first routes volume through Mailjet so its account accrues the
-  traffic needed to lift a new-sender throttle. Normally you leave this as-is;
-  it's runtime-configurable (a `docker compose restart web poller`, no rebuild)
-  only if you ever want a different primary.
-- **Per-provider caps** (`RESEND_DAILY_QUOTA`, `MAILJET_HOURLY_QUOTA`,
-  `MAILJET_DAILY_QUOTA`). Sends beyond the tighter of a provider's rolling
-  windows are **deferred** to a later cycle, not dropped. Defaults match the
-  free tiers (Resend 100/day; Mailjet 10/hour warm-up + 200/day). **When
-  Mailjet lifts the throttle, raise these caps — not the provider order** (e.g.
-  bump `MAILJET_HOURLY_QUOTA`); the daily cap then binds. Raise all of them
-  after upgrading to a paid plan.
+  Digests try the first provider up to its remaining quota, then spill along
+  the chain. Mailjet-first routes volume through Mailjet so its account accrues
+  the traffic needed to lift a new-sender throttle. A provider named in the
+  order without its API key configured is skipped. **Recommended transition
+  order once the Brevo and Sweego accounts are set up:
+  `mailjet,brevo,sweego,resend`** — the EU providers absorb the overflow and
+  Resend (US, being phased out) only sees traffic when everything else is
+  spent; drop `resend` from the order once the new providers are proven. It's
+  runtime-configurable (a `docker compose restart web poller`, no rebuild).
+- **Per-provider caps** (`BREVO_DAILY_QUOTA`, `SWEEGO_DAILY_QUOTA`,
+  `RESEND_DAILY_QUOTA`, `MAILJET_HOURLY_QUOTA`, `MAILJET_DAILY_QUOTA`). Sends
+  beyond the tighter of a provider's rolling windows are **deferred** to a
+  later cycle, not dropped. Defaults match the free tiers (Brevo 300/day —
+  shared with any marketing sends on the account, and free-tier mail carries a
+  Brevo footer logo; Sweego 100/day; Resend 100/day; Mailjet 10/hour warm-up +
+  200/day). **When Mailjet lifts the throttle, raise these caps — not the
+  provider order** (e.g. bump `MAILJET_HOURLY_QUOTA`); the daily cap then
+  binds. Raise all of them after upgrading to a paid plan.
+- **Brevo and Sweego send one message per API call** — neither documents batch
+  atomicity, and the retry logic is only safe with per-message verdicts or a
+  provably all-or-nothing batch. A few hundred mails a day fit comfortably in
+  single calls.
 - **When the whole pool is spent, digests are deferred, not dropped.** The
   leftovers have their idempotency claims released and their slots left
   unrecorded, so the next cycle re-sends them with a fresh `cycle_id`. Two
@@ -74,18 +89,21 @@ failing:
   provider that can actually send crosses `QUOTA_ALERT_THRESHOLD_PCT` of the
   summed daily caps, or when notifications are deferred for lack of quota,
   `DEVELOPER_EMAIL` gets one alert per day. Combined, not per-provider: with
-  Mailjet-first routing a batch only reaches Resend once Mailjet's headroom is
-  0, so "Mailjet at 98%" is what a busy day looks like while a third of the pool
-  is still free (2026-08-19: 196/200 mailed as 98%, actually 196/300). Only the
+  Mailjet-first routing a batch only reaches the next provider in the chain
+  once Mailjet's headroom is 0, so "Mailjet at 98%" is what a busy day looks
+  like while a third of the pool is still free (2026-08-19, back when the pool
+  was Mailjet + Resend: 196/200 mailed as 98%, actually 196/300). Only the
   deferral half of the alert means someone went un-notified — the subject line
   says which fired. That mail is the cue to upgrade to a paid plan and raise the
   matching `*_DAILY_QUOTA`.
 
 Delivery mix over the last 7 days is visible on `/admin`, along with an
 **Email quota** section showing month-to-date and today's sends per provider
-against `MAILJET_MONTHLY_QUOTA` / `RESEND_MONTHLY_QUOTA` (display-only caps,
-free tiers: 6000/mo and 3000/mo) — so you can watch quota burn without logging
-into the provider dashboards. Counts come from the app's own durable
+against `MAILJET_MONTHLY_QUOTA` / `BREVO_MONTHLY_QUOTA` /
+`SWEEGO_MONTHLY_QUOTA` / `RESEND_MONTHLY_QUOTA` (display-only caps, free
+tiers: 6000, 9000, 3000 and 3000/mo; Brevo and Sweego appear once their API
+key is configured) — so you can watch quota burn without logging into the
+provider dashboards. Counts come from the app's own durable
 `email_send_counts` table (UTC days, an approximation of each provider's reset
 cycle) and only include mail this app sent. Each row also shows the **rolling
 24h** figure, and a combined row totals it: that rolling number is what actually

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -22,13 +22,22 @@
   exactly one, so extend the existing record rather than letting a provider's
   automatic flow replace it. `REPLY_TO_EMAIL` points at a real mailbox on
   `jakubwaller.eu`; the From address itself doesn't receive mail.
+- A signed data-processing agreement (DPA / AVV) with every processor the
+  privacy page names — Mailjet, Brevo, Sweego and (while it remains) Resend,
+  besides Cloudflare and netcup. The Datenschutz page states unconditionally
+  that a DPA is in place with all listed providers, so concluding a new
+  provider's DPA comes **before** deploying a version that lists it, not
+  after.
 
 ## First deploy
 
 1. Clone the repo to the host.
 2. Copy `.env.example` to `.env` and fill in real secrets:
    - 32-byte `TOKEN_SECRET_PRIMARY` and `ADMIN_TOKEN` (e.g., `openssl rand -hex 32`).
-   - Mailjet, Brevo, Sweego and Resend API keys.
+   - The Mailjet API key + secret (required — Mailjet is the primary sender).
+     `BREVO_API_KEY`, `SWEEGO_API_KEY` and `RESEND_API_KEY` are optional:
+     leave a key blank to disable that provider. A fresh deploy has no reason
+     to create a Resend account — it is transitional and being phased out.
    - Review the email-delivery settings (`EMAIL_PROVIDER_ORDER`,
      `BREVO_DAILY_QUOTA`, `SWEEGO_DAILY_QUOTA`, `RESEND_DAILY_QUOTA`,
      `MAILJET_HOURLY_QUOTA`, `MAILJET_DAILY_QUOTA`,
@@ -49,12 +58,24 @@ failing:
   Digests try the first provider up to its remaining quota, then spill along
   the chain. Mailjet-first routes volume through Mailjet so its account accrues
   the traffic needed to lift a new-sender throttle. A provider named in the
-  order without its API key configured is skipped. **Recommended transition
-  order once the Brevo and Sweego accounts are set up:
+  order without its API key configured is skipped. The order gates **every**
+  send path — notification digests and the transactional fallback chain alike —
+  so a configured key alone is inert until its provider is named here.
+- **Prove a new provider before adding it to the order.** Verify the From
+  domain in its dashboard, then send yourself one real mail through its API
+  with the same payload the app builds (`app/mail.py`) and check it arrives
+  with the `List-Unsubscribe`/`List-Unsubscribe-Post` headers intact (Brevo
+  takes them as a plain `headers` passthrough — confirm on a real mailbox).
+  For Sweego, whose API reference renders client-side and cannot be
+  desk-checked, validate the payload shape with a `dry-run: true` send first,
+  then one real send. Only then add the provider to the order.
+  **Recommended transition order once Brevo and Sweego are proven:
   `mailjet,brevo,sweego,resend`** — the EU providers absorb the overflow and
   Resend (US, being phased out) only sees traffic when everything else is
-  spent; drop `resend` from the order once the new providers are proven. It's
-  runtime-configurable (a `docker compose restart web poller`, no rebuild).
+  spent. To finish the phase-out, drop `resend` from the order (that removes
+  it from both send paths), then delete `RESEND_API_KEY` and trim Resend from
+  the Datenschutz page. The order is runtime-configurable (a
+  `docker compose restart web poller`, no rebuild).
 - **Per-provider caps** (`BREVO_DAILY_QUOTA`, `SWEEGO_DAILY_QUOTA`,
   `RESEND_DAILY_QUOTA`, `MAILJET_HOURLY_QUOTA`, `MAILJET_DAILY_QUOTA`). Sends
   beyond the tighter of a provider's rolling windows are **deferred** to a
@@ -102,7 +123,8 @@ Delivery mix over the last 7 days is visible on `/admin`, along with an
 against `MAILJET_MONTHLY_QUOTA` / `BREVO_MONTHLY_QUOTA` /
 `SWEEGO_MONTHLY_QUOTA` / `RESEND_MONTHLY_QUOTA` (display-only caps, free
 tiers: 6000, 9000, 3000 and 3000/mo; Brevo and Sweego appear once their API
-key is configured) — so you can watch quota burn without logging into the
+key is configured and they are named in `EMAIL_PROVIDER_ORDER`) — so you can
+watch quota burn without logging into the
 provider dashboards. Counts come from the app's own durable
 `email_send_counts` table (UTC days, an approximation of each provider's reset
 cycle) and only include mail this app sent. Each row also shows the **rolling

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -423,6 +423,22 @@ def test_stats_email_usage_windows_and_caps(tmp_path):
     assert u["resend"] == {"month": 0, "today": 0, "rolling": 0,
                            "month_quota": 3000, "day_quota": 100}
 
+def test_stats_email_usage_lists_new_providers_only_when_configured(tmp_path):
+    """Brevo/Sweego join the quota table (and thus the ops-summary combined
+    pool) only once their API key is configured — a provider that cannot send
+    must not add its cap to the pool math."""
+    from types import SimpleNamespace
+    conn = connect(str(tmp_path / "v.db")); init_schema(conn)
+    cfg = SimpleNamespace(mailjet_monthly_quota=6000, mailjet_daily_quota=200,
+                          resend_monthly_quota=3000, resend_daily_quota=100,
+                          brevo_api_key="xkeysib-x", brevo_monthly_quota=9000,
+                          brevo_daily_quota=300, sweego_api_key="",
+                          sweego_monthly_quota=3000, sweego_daily_quota=100)
+    u = stats(conn, cfg)["email_usage"]
+    assert u["brevo"] == {"month": 0, "today": 0, "rolling": 0,
+                          "month_quota": 9000, "day_quota": 300}
+    assert "sweego" not in u
+
 def test_init_schema_backfills_counters_once(tmp_path):
     conn = connect(str(tmp_path / "b.db")); init_schema(conn)
     for k, p in (("k1", "mailjet"), ("k2", "mailjet"), ("k3", "resend"),

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -425,19 +425,26 @@ def test_stats_email_usage_windows_and_caps(tmp_path):
 
 def test_stats_email_usage_lists_new_providers_only_when_configured(tmp_path):
     """Brevo/Sweego join the quota table (and thus the ops-summary combined
-    pool) only once their API key is configured — a provider that cannot send
-    must not add its cap to the pool math."""
+    pool) only once they can actually send: API key configured AND named in
+    EMAIL_PROVIDER_ORDER — the same gate mail._daily_usage applies. A provider
+    that cannot send must not add its cap to the pool math."""
     from types import SimpleNamespace
     conn = connect(str(tmp_path / "v.db")); init_schema(conn)
-    cfg = SimpleNamespace(mailjet_monthly_quota=6000, mailjet_daily_quota=200,
-                          resend_monthly_quota=3000, resend_daily_quota=100,
-                          brevo_api_key="xkeysib-x", brevo_monthly_quota=9000,
-                          brevo_daily_quota=300, sweego_api_key="",
-                          sweego_monthly_quota=3000, sweego_daily_quota=100)
+    base = dict(mailjet_monthly_quota=6000, mailjet_daily_quota=200,
+                resend_monthly_quota=3000, resend_daily_quota=100,
+                brevo_api_key="xkeysib-x", brevo_monthly_quota=9000,
+                brevo_daily_quota=300, sweego_api_key="",
+                sweego_monthly_quota=3000, sweego_daily_quota=100)
+    cfg = SimpleNamespace(**base, email_provider_order=(
+        "mailjet", "brevo", "sweego", "resend"))
     u = stats(conn, cfg)["email_usage"]
     assert u["brevo"] == {"month": 0, "today": 0, "rolling": 0,
                           "month_quota": 9000, "day_quota": 300}
-    assert "sweego" not in u
+    assert "sweego" not in u                    # in the order, but keyless
+    # Keyed but NOT in the order — the smoke-test transition state: the cap
+    # must stay out of the pool, exactly as the digest path skips the provider.
+    cfg = SimpleNamespace(**base, email_provider_order=("mailjet", "resend"))
+    assert "brevo" not in stats(conn, cfg)["email_usage"]
 
 def test_init_schema_backfills_counters_once(tmp_path):
     conn = connect(str(tmp_path / "b.db")); init_schema(conn)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,29 @@ def test_resend_api_key_is_optional(monkeypatch):
     cfg = load_config()
     assert cfg.resend_api_key == ""
 
+def test_brevo_and_sweego_api_keys_are_optional(monkeypatch):
+    """The new providers are opt-in, like Resend; the quota defaults match
+    their free tiers."""
+    for k, v in {
+        "MAILJET_API_KEY":"x","MAILJET_API_SECRET":"x","MAILJET_FROM_EMAIL":"x@x",
+        "MAILJET_FROM_NAME":"x","MAILJET_DAILY_QUOTA":"6000",
+        "TOKEN_SECRET_PRIMARY":"a"*32,"TOKEN_SECRET_PREVIOUS":"",
+        "ADMIN_TOKEN":"b"*32,"PUBLIC_BASE_URL":"https://x",
+        "DEDUP_WINDOW_HOURS":"24","RATE_LIMIT_MINUTES":"15",
+        "SUBSCRIPTION_TTL_DAYS":"90","RENEWAL_REMINDER_DAYS_BEFORE":"10",
+        "MAX_PLANS_PER_CITY":"10","PARSER_CANARY_THRESHOLD_HOURS":"2",
+        "SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR":"5",
+        "SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY":"1",
+        "DEVELOPER_EMAIL":"d@x","KOFI_URL":"https://k",
+    }.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.delenv("BREVO_API_KEY", raising=False)
+    monkeypatch.delenv("SWEEGO_API_KEY", raising=False)
+    cfg = load_config()
+    assert cfg.brevo_api_key == "" and cfg.sweego_api_key == ""
+    assert cfg.brevo_daily_quota == 300 and cfg.sweego_daily_quota == 100
+    assert cfg.brevo_monthly_quota == 9000 and cfg.sweego_monthly_quota == 3000
+
 def test_load_config_missing_required(monkeypatch):
     # Establish a complete valid environment, then remove ONE required var,
     # so the test fails for the right reason regardless of the shell's state.

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -23,6 +23,12 @@ def brevo_configured(monkeypatch):
 def sweego_configured(monkeypatch):
     monkeypatch.setenv("SWEEGO_API_KEY", "sw_test")
 
+@pytest.fixture
+def full_chain_order(monkeypatch):
+    """The recommended transition order. The chain honors EMAIL_PROVIDER_ORDER,
+    so tests expecting Brevo/Sweego in the transactional chain must name them."""
+    monkeypatch.setenv("EMAIL_PROVIDER_ORDER", "mailjet,brevo,sweego,resend")
+
 def _ok():
     r = MagicMock()
     r.status_code = 200
@@ -163,7 +169,8 @@ def test_explicit_reply_to_overrides_the_env_default(monkeypatch, mailjet_env):
 
 # ---------- Brevo & Sweego in the transactional failover chain ----------
 
-def test_failover_prefers_brevo_over_resend(db, resend_configured, brevo_configured):
+def test_failover_prefers_brevo_over_resend(db, resend_configured, brevo_configured,
+                                            full_chain_order):
     """With Brevo configured, a Mailjet failure goes to the EU provider first;
     Resend (being phased out) is only the last resort in the chain."""
     with patch("app.mail._call_mailjet", return_value=_resp(503)), \
@@ -176,7 +183,7 @@ def test_failover_prefers_brevo_over_resend(db, resend_configured, brevo_configu
     assert row["provider"] == "brevo"
 
 def test_failover_walks_the_whole_chain(db, resend_configured, brevo_configured,
-                                        sweego_configured):
+                                        sweego_configured, full_chain_order):
     with patch("app.mail._call_mailjet", return_value=_resp(500)), \
          patch("app.mail._call_brevo", return_value=_resp(402)), \
          patch("app.mail._call_sweego", return_value=_resp(500)), \
@@ -187,7 +194,7 @@ def test_failover_walks_the_whole_chain(db, resend_configured, brevo_configured,
     assert row["provider"] == "resend"
 
 def test_raises_when_the_whole_chain_fails(db, brevo_configured, sweego_configured,
-                                           monkeypatch):
+                                           full_chain_order, monkeypatch):
     monkeypatch.delenv("RESEND_API_KEY", raising=False)
     with patch("app.mail._call_mailjet", return_value=_resp(503)), \
          patch("app.mail._call_brevo", return_value=_resp(500)), \
@@ -197,7 +204,8 @@ def test_raises_when_the_whole_chain_fails(db, brevo_configured, sweego_configur
     # Claim rolled back on full failure → retry possible.
     assert db.execute("SELECT * FROM sent_idempotency WHERE idem_key='kd1'").fetchone() is None
 
-def test_brevo_and_sweego_not_in_the_chain_without_keys(db, monkeypatch):
+def test_brevo_and_sweego_not_in_the_chain_without_keys(db, full_chain_order,
+                                                        monkeypatch):
     monkeypatch.delenv("BREVO_API_KEY", raising=False)
     monkeypatch.delenv("SWEEGO_API_KEY", raising=False)
     monkeypatch.delenv("RESEND_API_KEY", raising=False)
@@ -208,6 +216,44 @@ def test_brevo_and_sweego_not_in_the_chain_without_keys(db, monkeypatch):
             send(db, "alice@example.com", "subj", "body", idem_key="ke1")
     bv.assert_not_called()
     sw.assert_not_called()
+
+def test_a_key_outside_the_provider_order_is_not_a_live_fallback(db, monkeypatch,
+                                                                 brevo_configured):
+    """The smoke-test transition state: BREVO_API_KEY configured for a manual
+    test while EMAIL_PROVIDER_ORDER still reads mailjet,resend. The order gates
+    the transactional chain too — an unproven provider must not quietly become
+    a live fallback for confirmations."""
+    monkeypatch.setenv("EMAIL_PROVIDER_ORDER", "mailjet,resend")
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with patch("app.mail._call_mailjet", return_value=_resp(503)), \
+         patch("app.mail._call_brevo") as bv:
+        with pytest.raises(MailFailed):
+            send(db, "alice@example.com", "subj", "body", idem_key="ko1")
+    bv.assert_not_called()
+
+def test_dropping_resend_from_the_order_removes_it_from_the_chain(db, monkeypatch,
+                                                                  resend_configured,
+                                                                  brevo_configured):
+    """Completing the phase-out by dropping `resend` from the order must stop
+    transactional fallbacks too, not just digests — otherwise Resend keeps
+    seeing occasional mail until its key is deleted."""
+    monkeypatch.setenv("EMAIL_PROVIDER_ORDER", "mailjet,brevo")
+    with patch("app.mail._call_mailjet", return_value=_resp(503)), \
+         patch("app.mail._call_brevo", return_value=_ok()), \
+         patch("app.mail._call_resend") as re_:
+        send(db, "alice@example.com", "subj", "body", idem_key="ko2")
+    re_.assert_not_called()
+    row = db.execute("SELECT provider FROM sent_idempotency WHERE idem_key='ko2'").fetchone()
+    assert row["provider"] == "brevo"
+
+def test_order_without_a_usable_provider_falls_back_to_mailjet(db, monkeypatch):
+    """A bad order must not leave transactional mail with no provider at all —
+    Mailjet is required config, so it is the last resort."""
+    monkeypatch.setenv("EMAIL_PROVIDER_ORDER", "resend")
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with patch("app.mail._call_mailjet", return_value=_ok()) as mj:
+        send(db, "alice@example.com", "subj", "body", idem_key="ko3")
+    mj.assert_called_once()
 
 def test_pending_row_blocks_second_call_after_crash(db):
     """If the process died mid-send leaving provider='pending', the next call must skip."""
@@ -324,7 +370,8 @@ def test_send_counter_follows_failover_provider(db, resend_configured):
     assert _day_count(db, "resend") == 1
     assert _day_count(db, "mailjet") == 0
 
-def test_send_counter_follows_the_chain_provider(db, brevo_configured):
+def test_send_counter_follows_the_chain_provider(db, brevo_configured,
+                                                 full_chain_order):
     with patch("app.mail._call_mailjet", return_value=_resp(503)), \
          patch("app.mail._call_brevo", return_value=_ok()):
         send(db, "a@x.com", "s", "b", idem_key="cnt5")

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -2,7 +2,8 @@ import sqlite3
 from unittest.mock import patch, MagicMock
 import pytest
 from app.db import connect, init_schema
-from app.mail import send, MailFailed, _idem_key, _call_mailjet, _call_resend
+from app.mail import (send, MailFailed, _idem_key, _call_mailjet, _call_resend,
+                      _call_brevo, _call_sweego)
 
 @pytest.fixture
 def db(tmp_path):
@@ -13,6 +14,14 @@ def db(tmp_path):
 @pytest.fixture
 def resend_configured(monkeypatch):
     monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+
+@pytest.fixture
+def brevo_configured(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+
+@pytest.fixture
+def sweego_configured(monkeypatch):
+    monkeypatch.setenv("SWEEGO_API_KEY", "sw_test")
 
 def _ok():
     r = MagicMock()
@@ -106,9 +115,12 @@ def mailjet_env(monkeypatch):
     monkeypatch.setenv("MAILJET_FROM_NAME", "Bürgerwecker")
 
 def _capture():
-    """Patch-ready post that records the json= payload and returns 200."""
+    """Patch-ready post that records the url, headers and json= payload and
+    returns 200."""
     seen = {}
     def fake_post(url, **kwargs):
+        seen["url"] = url
+        seen["headers"] = kwargs.get("headers")
         seen["json"] = kwargs.get("json")
         return _ok()
     return seen, fake_post
@@ -149,6 +161,54 @@ def test_explicit_reply_to_overrides_the_env_default(monkeypatch, mailjet_env):
     assert seen["json"]["reply_to"] == "gast@example.org"
 
 
+# ---------- Brevo & Sweego in the transactional failover chain ----------
+
+def test_failover_prefers_brevo_over_resend(db, resend_configured, brevo_configured):
+    """With Brevo configured, a Mailjet failure goes to the EU provider first;
+    Resend (being phased out) is only the last resort in the chain."""
+    with patch("app.mail._call_mailjet", return_value=_resp(503)), \
+         patch("app.mail._call_brevo", return_value=_ok()) as bv, \
+         patch("app.mail._call_resend") as re_:
+        send(db, "alice@example.com", "subj", "body", idem_key="kb1")
+    bv.assert_called_once()
+    re_.assert_not_called()
+    row = db.execute("SELECT provider FROM sent_idempotency WHERE idem_key='kb1'").fetchone()
+    assert row["provider"] == "brevo"
+
+def test_failover_walks_the_whole_chain(db, resend_configured, brevo_configured,
+                                        sweego_configured):
+    with patch("app.mail._call_mailjet", return_value=_resp(500)), \
+         patch("app.mail._call_brevo", return_value=_resp(402)), \
+         patch("app.mail._call_sweego", return_value=_resp(500)), \
+         patch("app.mail._call_resend", return_value=_ok()) as re_:
+        send(db, "alice@example.com", "subj", "body", idem_key="kc1")
+    re_.assert_called_once()
+    row = db.execute("SELECT provider FROM sent_idempotency WHERE idem_key='kc1'").fetchone()
+    assert row["provider"] == "resend"
+
+def test_raises_when_the_whole_chain_fails(db, brevo_configured, sweego_configured,
+                                           monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with patch("app.mail._call_mailjet", return_value=_resp(503)), \
+         patch("app.mail._call_brevo", return_value=_resp(500)), \
+         patch("app.mail._call_sweego", return_value=_resp(500)):
+        with pytest.raises(MailFailed):
+            send(db, "alice@example.com", "subj", "body", idem_key="kd1")
+    # Claim rolled back on full failure → retry possible.
+    assert db.execute("SELECT * FROM sent_idempotency WHERE idem_key='kd1'").fetchone() is None
+
+def test_brevo_and_sweego_not_in_the_chain_without_keys(db, monkeypatch):
+    monkeypatch.delenv("BREVO_API_KEY", raising=False)
+    monkeypatch.delenv("SWEEGO_API_KEY", raising=False)
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with patch("app.mail._call_mailjet", return_value=_resp(503)), \
+         patch("app.mail._call_brevo") as bv, \
+         patch("app.mail._call_sweego") as sw:
+        with pytest.raises(MailFailed):
+            send(db, "alice@example.com", "subj", "body", idem_key="ke1")
+    bv.assert_not_called()
+    sw.assert_not_called()
+
 def test_pending_row_blocks_second_call_after_crash(db):
     """If the process died mid-send leaving provider='pending', the next call must skip."""
     db.execute(
@@ -174,6 +234,74 @@ def test_unsub_headers_only_with_real_url(monkeypatch, mailjet_env):
         _call_mailjet("a@x.com", "s", "b")   # no unsub semantics (e.g. confirmation)
     assert "Headers" not in seen["json"]["Messages"][0]
 
+# ---------- Brevo & Sweego payload shapes ----------
+
+def test_brevo_payload_shape(monkeypatch, mailjet_env, brevo_configured):
+    monkeypatch.setenv("REPLY_TO_EMAIL", "termine@jakubwaller.eu")
+    seen, fake = _capture()
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_brevo("alice@example.com", "subj", "body",
+                    "https://x/unsubscribe/tok123")
+    assert seen["url"] == "https://api.brevo.com/v3/smtp/email"
+    assert seen["headers"]["api-key"] == "xkeysib-test"
+    p = seen["json"]
+    assert p["sender"] == {"email": "hallo@buergerwecker.de",
+                           "name": "Bürgerwecker"}
+    assert p["to"] == [{"email": "alice@example.com"}]
+    assert p["subject"] == "subj" and p["textContent"] == "body"
+    assert p["replyTo"] == {"email": "termine@jakubwaller.eu"}
+    assert p["headers"]["List-Unsubscribe"] == "<https://x/unsubscribe/tok123>"
+    assert p["headers"]["List-Unsubscribe-Post"] == "List-Unsubscribe=One-Click"
+
+def test_brevo_omits_reply_to_and_headers_when_unset(monkeypatch, mailjet_env,
+                                                     brevo_configured):
+    monkeypatch.delenv("REPLY_TO_EMAIL", raising=False)
+    seen, fake = _capture()
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_brevo("alice@example.com", "subj", "body")
+    assert "replyTo" not in seen["json"]
+    assert "headers" not in seen["json"]
+
+def test_sweego_payload_shape(monkeypatch, mailjet_env, sweego_configured):
+    monkeypatch.setenv("REPLY_TO_EMAIL", "termine@jakubwaller.eu")
+    seen, fake = _capture()
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_sweego("alice@example.com", "subj", "body",
+                     "https://x/unsubscribe/tok123")
+    assert seen["url"] == "https://api.sweego.io/send"
+    assert seen["headers"]["Api-Key"] == "sw_test"
+    p = seen["json"]
+    assert p["channel"] == "email" and p["provider"] == "sweego"
+    assert p["campaign-type"] == "transac"
+    assert p["from"] == {"email": "hallo@buergerwecker.de",
+                         "name": "Bürgerwecker"}
+    assert p["recipients"] == [{"email": "alice@example.com"}]
+    assert p["subject"] == "subj" and p["message-txt"] == "body"
+    assert p["reply-to"] == {"email": "termine@jakubwaller.eu"}
+    assert p["headers"]["List-Unsubscribe"] == "<https://x/unsubscribe/tok123>"
+    assert p["headers"]["List-Unsubscribe-Post"] == "List-Unsubscribe=One-Click"
+
+def test_sweego_omits_reply_to_and_headers_when_unset(monkeypatch, mailjet_env,
+                                                      sweego_configured):
+    monkeypatch.delenv("REPLY_TO_EMAIL", raising=False)
+    seen, fake = _capture()
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_sweego("alice@example.com", "subj", "body")
+    assert "reply-to" not in seen["json"]
+    assert "headers" not in seen["json"]
+
+def test_explicit_reply_to_overrides_env_for_new_providers(monkeypatch, mailjet_env,
+                                                           brevo_configured,
+                                                           sweego_configured):
+    monkeypatch.setenv("REPLY_TO_EMAIL", "buergerwecker@jakubwaller.eu")
+    seen, fake = _capture()
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_brevo("alice@example.com", "s", "b", None, "gast@example.org")
+    assert seen["json"]["replyTo"] == {"email": "gast@example.org"}
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_sweego("alice@example.com", "s", "b", None, "gast@example.org")
+    assert seen["json"]["reply-to"] == {"email": "gast@example.org"}
+
 # ---------- durable per-day send counters (admin quota view) ----------
 
 def _day_count(db, provider):
@@ -194,6 +322,13 @@ def test_send_counter_follows_failover_provider(db, resend_configured):
          patch("app.mail._call_resend", return_value=_ok()):
         send(db, "a@x.com", "s", "b", idem_key="cnt3")
     assert _day_count(db, "resend") == 1
+    assert _day_count(db, "mailjet") == 0
+
+def test_send_counter_follows_the_chain_provider(db, brevo_configured):
+    with patch("app.mail._call_mailjet", return_value=_resp(503)), \
+         patch("app.mail._call_brevo", return_value=_ok()):
+        send(db, "a@x.com", "s", "b", idem_key="cnt5")
+    assert _day_count(db, "brevo") == 1
     assert _day_count(db, "mailjet") == 0
 
 def test_failed_send_does_not_bump_counter(db, monkeypatch):

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -21,9 +21,19 @@ def resend_on(monkeypatch):
         monkeypatch.setenv(k, v)
 
 
+@pytest.fixture
+def brevo_sweego_on(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("SWEEGO_API_KEY", "sw_test")
+    for k, v in {"MAILJET_API_KEY": "m", "MAILJET_API_SECRET": "s",
+                 "MAILJET_FROM_EMAIL": "x@x", "MAILJET_FROM_NAME": "x"}.items():
+        monkeypatch.setenv(k, v)
+
+
 def _cfg(order=("mailjet", "resend"), **over):
     base = dict(resend_daily_quota=100, mailjet_hourly_quota=10,
                 mailjet_daily_quota=100_000,  # effectively unbounded unless set
+                brevo_daily_quota=300, sweego_daily_quota=100,
                 quota_alert_threshold_pct=80, developer_email="dev@x",
                 email_provider_order=order)
     base.update(over)
@@ -495,3 +505,156 @@ def test_deferral_counter_accumulates_across_cycles(db, resend_on):
         send_batch(db, _items(3, "b"), cfg)       # quota spent, 3 deferred
     from app.mail import deferrals_today
     assert deferrals_today(db) == 5
+
+
+# --- Brevo & Sweego: one message per call, same failover discipline ----------
+# Neither API documents batch atomicity, so both are registered with
+# batch_size=1 — a 4xx is attributable to exactly one recipient, and there is
+# never a partially-delivered batch to mis-retry.
+
+def test_order_routes_to_brevo_one_message_per_call(db, brevo_sweego_on):
+    with patch("app.mail._call_brevo_batch", return_value=201) as bb, \
+         patch("app.mail._call_sweego_batch") as sb, \
+         patch("app.mail._call_mailjet_batch") as mb:
+        res = send_batch(db, _items(3), _cfg(order=("brevo", "sweego")))
+    assert len(res.delivered) == 3 and res.deferred == 0
+    assert bb.call_count == 3                 # batch_size=1, never a real batch
+    assert all(len(c.args[0]) == 1 for c in bb.call_args_list)
+    sb.assert_not_called()
+    mb.assert_not_called()
+    assert _sent(db, "brevo") == 3
+
+
+def test_brevo_and_sweego_skipped_without_api_keys(db, resend_on, monkeypatch):
+    monkeypatch.delenv("BREVO_API_KEY", raising=False)
+    monkeypatch.delenv("SWEEGO_API_KEY", raising=False)
+    with patch("app.mail._call_brevo_batch") as bb, \
+         patch("app.mail._call_sweego_batch") as sb, \
+         patch("app.mail._call_mailjet_batch", return_value=200) as mb:
+        res = send_batch(db, _items(2),
+                         _cfg(order=("brevo", "sweego", "mailjet")))
+    assert len(res.delivered) == 2
+    bb.assert_not_called()
+    sb.assert_not_called()
+    mb.assert_called_once()
+
+
+def test_brevo_overflow_spills_to_sweego(db, brevo_sweego_on):
+    with patch("app.mail._call_brevo_batch", return_value=201), \
+         patch("app.mail._call_sweego_batch", return_value=200):
+        res = send_batch(db, _items(5), _cfg(order=("brevo", "sweego"),
+                                             brevo_daily_quota=2))
+    assert len(res.delivered) == 5 and res.deferred == 0
+    assert _sent(db, "brevo") == 2 and _sent(db, "sweego") == 3
+
+
+def test_existing_brevo_usage_counts_against_its_quota(db, brevo_sweego_on):
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'brevo')",
+        [(f"old{i}",) for i in range(4)])
+    with patch("app.mail._call_brevo_batch", return_value=201):
+        res = send_batch(db, _items(3), _cfg(order=("brevo",),
+                                             brevo_daily_quota=5))
+    assert len(res.delivered) == 1 and res.deferred == 2
+
+
+def test_brevo_402_is_an_outage_not_a_bad_recipient(db, brevo_sweego_on):
+    """Brevo answers 402 when the account is out of credits. That is a provider
+    problem — fall through to the next provider, condemn nobody."""
+    with patch("app.mail._call_brevo_batch", return_value=402) as bb, \
+         patch("app.mail._call_sweego_batch", return_value=200):
+        res = send_batch(db, _items(3), _cfg(order=("brevo", "sweego")))
+    assert len(res.delivered) == 3 and res.undeliverable == set()
+    assert bb.call_count == 1                 # first 402 abandons the provider
+    assert db.execute("SELECT COUNT(*) AS n FROM email_failures").fetchone()["n"] == 0
+
+
+def test_sweego_rejection_feeds_the_failure_accounting(db, brevo_sweego_on):
+    items = _items(3)
+    items[1] = Outgoing(to="subscriber@example-com", subject="s", body="b",
+                        idem_key="poison")
+    with patch("app.mail._call_sweego_batch",
+               _poisoned(["subscriber@example-com"])):
+        res = send_batch(db, items, _cfg(order=("sweego",)))
+    assert len(res.delivered) == 2
+    assert res.undeliverable == {"poison"}
+    assert db.execute(
+        "SELECT failures FROM email_failures WHERE email='subscriber@example-com'"
+    ).fetchone()["failures"] == 1
+
+
+def test_sweego_422_is_attributed_to_the_single_recipient(db, brevo_sweego_on):
+    """Sweego's documented validation error is 422; with one message per call
+    it points at exactly one address."""
+    with patch("app.mail._call_sweego_batch", return_value=422):
+        res = send_batch(db, _items(1), _cfg(order=("sweego",)))
+    assert res.undeliverable == {"k0"} and res.delivered == set()
+    assert db.execute(
+        "SELECT failures FROM email_failures WHERE email='u0@x.com'"
+    ).fetchone()["failures"] == 1
+
+
+def test_a_rejection_at_brevo_still_tries_sweego(db, brevo_sweego_on):
+    items = _items(3)
+    items[1] = Outgoing(to="odd@x.com", subject="s", body="b", idem_key="odd")
+    with patch("app.mail._call_brevo_batch", _poisoned(["odd@x.com"])), \
+         patch("app.mail._call_sweego_batch", return_value=200):
+        res = send_batch(db, items, _cfg(order=("brevo", "sweego")))
+    assert len(res.delivered) == 3 and res.undeliverable == set()
+    assert res.sent_by_provider == {"brevo": 2, "sweego": 1}
+    assert db.execute("SELECT COUNT(*) AS n FROM email_failures").fetchone()["n"] == 0
+
+
+def test_brevo_and_sweego_both_down_defers_rather_than_condemns(db, brevo_sweego_on):
+    with patch("app.mail._call_brevo_batch", return_value=500), \
+         patch("app.mail._call_sweego_batch", side_effect=OSError("timeout")):
+        res = send_batch(db, _items(3), _cfg(order=("brevo", "sweego")))
+    assert res.deferred == 3 and res.undeliverable == set()
+    assert db.execute("SELECT COUNT(*) AS n FROM email_failures").fetchone()["n"] == 0
+    assert db.execute("SELECT COUNT(*) AS n FROM sent_idempotency").fetchone()["n"] == 0
+
+
+def test_batch_bumps_daily_counters_for_new_providers(db, brevo_sweego_on):
+    with patch("app.mail._call_brevo_batch", return_value=201), \
+         patch("app.mail._call_sweego_batch", return_value=200):
+        send_batch(db, _items(4), _cfg(order=("brevo", "sweego"),
+                                       brevo_daily_quota=3))
+    def day_count(p):
+        row = db.execute(
+            "SELECT n FROM email_send_counts WHERE provider=? AND day=date('now')",
+            (p,)).fetchone()
+        return row["n"] if row else 0
+    assert day_count("brevo") == 3
+    assert day_count("sweego") == 1
+
+
+def test_quota_alert_pool_includes_new_providers_when_configured(db, brevo_sweego_on):
+    # 16 sends against a combined cap of 20 (mailjet 5 + brevo 10 + sweego 5)
+    # = 80% → the alert fires even with no deferral. Guards the _daily_usage
+    # caps dict: a provider missing from it silently drops out of the pool.
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'brevo')",
+        [(f"b{i}",) for i in range(16)])
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(order=("mailjet", "brevo", "sweego"),
+                                   mailjet_daily_quota=5, brevo_daily_quota=10,
+                                   sweego_daily_quota=5),
+                          deferred=0)
+    snd.assert_called_once()
+    body = snd.call_args.args[3]
+    assert "brevo: 16/10" in body
+
+
+def test_quota_alert_ignores_new_providers_without_keys(db, monkeypatch):
+    """No BREVO/SWEEGO API keys → they are not in the send path, so their
+    (unused) caps must not join the pool or raise an alarm on their own."""
+    monkeypatch.delenv("BREVO_API_KEY", raising=False)
+    monkeypatch.delenv("SWEEGO_API_KEY", raising=False)
+    db.executemany(
+        "INSERT INTO sent_idempotency (idem_key, provider) VALUES (?, 'brevo')",
+        [(f"b{i}",) for i in range(99)])
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(order=("mailjet", "brevo", "sweego"),
+                                   brevo_daily_quota=100, sweego_daily_quota=100),
+                          deferred=0)
+    snd.assert_not_called()

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -594,6 +594,55 @@ def test_sweego_422_is_attributed_to_the_single_recipient(db, brevo_sweego_on):
     ).fetchone()["failures"] == 1
 
 
+def test_systemic_rejection_streak_defers_rather_than_retires(db, brevo_sweego_on):
+    """A misconfigured provider (bad payload shape, unverified sender) answers
+    400/422 to EVERY call — at batch_size=1 indistinguishable per-call from a
+    bad recipient. A provider that rejects a whole cycle while delivering
+    nothing is treated as unusable: the mail defers to the next cycle instead
+    of striking every address, which at the failure cap would silently retire
+    them all within three cycles."""
+    with patch("app.mail._call_sweego_batch", return_value=422):
+        res = send_batch(db, _items(4), _cfg(order=("sweego",)))
+    assert res.deferred == 4 and res.undeliverable == set()
+    assert db.execute("SELECT COUNT(*) AS n FROM email_failures").fetchone()["n"] == 0
+    # Claims released so the next cycle (or a fixed provider) can retry.
+    assert db.execute("SELECT COUNT(*) AS n FROM sent_idempotency").fetchone()["n"] == 0
+
+
+def test_batch_adapters_reach_the_wire_with_the_single_send_payload(db,
+                                                                    brevo_sweego_on):
+    """Route send_batch through the REAL _call_brevo_batch/_call_sweego_batch
+    bodies — only requests.post is faked. Guards the adapter glue (the
+    batch_size=1 unpack, the positional unsub_url pass-through, the
+    ProviderResult wrap) that every other batch test mocks away."""
+    posted = []
+    def fake_post(url, **kwargs):
+        posted.append((url, kwargs.get("json")))
+        r = MagicMock()
+        r.status_code = 201
+        return r
+    item = Outgoing(to="u0@x.com", subject="s", body="b", idem_key="w0",
+                    unsub_url="https://x/unsubscribe/tok")
+    with patch("app.mail.requests.post", side_effect=fake_post):
+        res = send_batch(db, [item], _cfg(order=("brevo",)))
+    assert res.delivered == {"w0"} and _sent(db, "brevo") == 1
+    url, payload = posted[0]
+    assert url == "https://api.brevo.com/v3/smtp/email"
+    assert payload["to"] == [{"email": "u0@x.com"}]
+    assert payload["headers"]["List-Unsubscribe"] == "<https://x/unsubscribe/tok>"
+    posted.clear()
+    item = Outgoing(to="u1@x.com", subject="s", body="b", idem_key="w1",
+                    unsub_url="https://x/unsubscribe/tok")
+    with patch("app.mail.requests.post", side_effect=fake_post):
+        res = send_batch(db, [item], _cfg(order=("sweego",)))
+    assert res.delivered == {"w1"} and _sent(db, "sweego") == 1
+    url, payload = posted[0]
+    assert url == "https://api.sweego.io/send"
+    assert payload["recipients"] == [{"email": "u1@x.com"}]
+    assert payload["message-txt"] == "b"
+    assert payload["headers"]["List-Unsubscribe"] == "<https://x/unsubscribe/tok>"
+
+
 def test_a_rejection_at_brevo_still_tries_sweego(db, brevo_sweego_on):
     items = _items(3)
     items[1] = Outgoing(to="odd@x.com", subject="s", body="b", idem_key="odd")


### PR DESCRIPTION
Adds two EU email providers to the failover pool, raising the combined ceiling from ~300/day (Mailjet 200 + Resend 100) to 600/day (Mailjet 200 + Brevo 300 + Sweego 100) and preparing the Resend phase-out for EU data residency.

## What changed

- **app/mail.py** — payload builders, single-send and batch callers for both providers. Batch callers send exactly one message per API call (`batch_size=1`): neither provider documents atomic batch semantics, so a 4xx stays attributable to one recipient without bisection double-sends. Transactional `send()` now walks `_single_send_chain()`, gated on `EMAIL_PROVIDER_ORDER` membership AND a configured key — same rule as the digest path, so a key staged in `.env` is inert until the order names the provider, and dropping a provider from the order removes it from both send paths.
- **Systemic-rejection guard** — ≥3 rejections in a cycle with zero deliveries from that provider is treated as the provider being unusable, not a verdict on the recipients: mail passes to the next provider (or defers, raising the deferral alert) with no failure strikes. Single/double rejections still condemn as before, so typo'd-address retirement keeps working.
- **app/config.py / .env.example** — `BREVO_API_KEY`/`SWEEGO_API_KEY` (optional, blank disables), daily quotas 300/100, monthly display caps 9000/3000.
- **app/admin.py** — quota table rows for the new providers, gated on key AND order membership so an unusable provider's cap never dilutes the combined-pool grading.
- **datenschutz.html** — processor list now names Mailjet, Brevo, Sweego (EU servers); the Resend sentence states accurately that it is a US provider dispatching via EU servers (Ireland) while storing account data, logs and email metadata (including recipient addresses) in the USA, and that it is being phased out. EN/DE parity kept.
- **docs/DEPLOY.md** — prove-a-provider-first runbook step (domain verification, one real Brevo send checking List-Unsubscribe passthrough, Sweego `dry-run:true` payload validation), recommended transition order `mailjet,brevo,sweego,resend`, phase-out ends by dropping resend from the order and then deleting `RESEND_API_KEY`, and a signed-DPA prerequisite before deploying a page that lists a processor.

## Not changed

- Idempotency key construction, `TOKEN_VERSION`, default `EMAIL_PROVIDER_ORDER` (still `mailjet,resend` — enabling the new providers is a deploy-time config change).
- Transactional `send()` still aborts on a network exception rather than failing over (pre-existing, deliberate: avoids duplicate sends on timeout-after-delivery).

## Tests

`pytest -m "not live"`: 462 passed. `ruff check .` clean. New coverage: payload shapes and auth headers for both providers, chain gating by order and key, quota spill/deferral, Brevo 402-as-outage, Sweego 400/422 rejections feeding `email_failures`, the systemic-rejection guard, and a wire-level batch-adapter test with only `requests.post` faked.