### PR TITLE
fix(mail): send Sweego the List-Unsubscribe form it accepts

### DIFF
--- a/app/mail.py
+++ b/app/mail.py
@@ -101,10 +101,18 @@ def _sweego_email(to: str, subject: str, body: str,
         "subject": subject,
         "message-txt": body,
     }
-    headers = _unsub_headers(unsub_url)
-    if headers:
-        payload["headers"] = headers
     reply_to = reply_to or os.environ.get("REPLY_TO_EMAIL")
+    headers = _unsub_headers(unsub_url)
+    if headers and reply_to:
+        # Sweego validates List-Unsubscribe and 422s on the RFC 8058 URL-only
+        # form every other provider accepts: it requires <mailto:...>,<url>
+        # paired with the one-click Post header (verified against the live
+        # API, 2026-08-21). The reply-to mailbox is the monitored address, so
+        # unsubscribe-by-mail lands somewhere real; without one there is no
+        # valid mailto and the headers must be dropped, not sent malformed.
+        headers["List-Unsubscribe"] = (
+            f"<mailto:{reply_to}?subject=abmelden>,<{unsub_url}>")
+        payload["headers"] = headers
     if reply_to:
         payload["reply-to"] = {"email": reply_to}
     return payload

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -68,7 +68,11 @@ failing:
   takes them as a plain `headers` passthrough — confirm on a real mailbox).
   For Sweego, whose API reference renders client-side and cannot be
   desk-checked, validate the payload shape with a `dry-run: true` send first,
-  then one real send. Only then add the provider to the order.
+  then one real send. (That dry-run is not optional ceremony: it is how we
+  found, 2026-08-21, that Sweego rejects the RFC 8058 URL-only
+  `List-Unsubscribe` header and requires the `<mailto:…>,<url>` form — which
+  `app/mail.py` now builds for Sweego alone.) Only then add the provider to
+  the order.
   **Recommended transition order once Brevo and Sweego are proven:
   `mailjet,brevo,sweego,resend`** — the EU providers absorb the overflow and
   Resend (US, being phased out) only sees traffic when everything else is

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -324,7 +324,11 @@ def test_sweego_payload_shape(monkeypatch, mailjet_env, sweego_configured):
     assert p["recipients"] == [{"email": "alice@example.com"}]
     assert p["subject"] == "subj" and p["message-txt"] == "body"
     assert p["reply-to"] == {"email": "termine@jakubwaller.eu"}
-    assert p["headers"]["List-Unsubscribe"] == "<https://x/unsubscribe/tok123>"
+    # Sweego refuses the URL-only form the other providers send: it demands
+    # <mailto:...>,<url> with the one-click Post header.
+    assert p["headers"]["List-Unsubscribe"] == (
+        "<mailto:termine@jakubwaller.eu?subject=abmelden>,"
+        "<https://x/unsubscribe/tok123>")
     assert p["headers"]["List-Unsubscribe-Post"] == "List-Unsubscribe=One-Click"
 
 def test_sweego_omits_reply_to_and_headers_when_unset(monkeypatch, mailjet_env,
@@ -334,6 +338,17 @@ def test_sweego_omits_reply_to_and_headers_when_unset(monkeypatch, mailjet_env,
     with patch("app.mail.requests.post", side_effect=fake):
         _call_sweego("alice@example.com", "subj", "body")
     assert "reply-to" not in seen["json"]
+    assert "headers" not in seen["json"]
+
+def test_sweego_drops_unsub_headers_without_a_reply_to_mailbox(
+        monkeypatch, mailjet_env, sweego_configured):
+    # An unsub URL but no monitored mailbox: Sweego would 422 the URL-only
+    # header, so none are sent at all.
+    monkeypatch.delenv("REPLY_TO_EMAIL", raising=False)
+    seen, fake = _capture()
+    with patch("app.mail.requests.post", side_effect=fake):
+        _call_sweego("alice@example.com", "subj", "body",
+                     "https://x/unsubscribe/tok123")
     assert "headers" not in seen["json"]
 
 def test_explicit_reply_to_overrides_env_for_new_providers(monkeypatch, mailjet_env,

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -609,8 +609,8 @@ def test_systemic_rejection_streak_defers_rather_than_retires(db, brevo_sweego_o
     assert db.execute("SELECT COUNT(*) AS n FROM sent_idempotency").fetchone()["n"] == 0
 
 
-def test_batch_adapters_reach_the_wire_with_the_single_send_payload(db,
-                                                                    brevo_sweego_on):
+def test_batch_adapters_reach_the_wire_with_the_single_send_payload(
+        db, brevo_sweego_on, monkeypatch):
     """Route send_batch through the REAL _call_brevo_batch/_call_sweego_batch
     bodies — only requests.post is faked. Guards the adapter glue (the
     batch_size=1 unpack, the positional unsub_url pass-through, the
@@ -631,6 +631,7 @@ def test_batch_adapters_reach_the_wire_with_the_single_send_payload(db,
     assert payload["to"] == [{"email": "u0@x.com"}]
     assert payload["headers"]["List-Unsubscribe"] == "<https://x/unsubscribe/tok>"
     posted.clear()
+    monkeypatch.setenv("REPLY_TO_EMAIL", "termine@jakubwaller.eu")
     item = Outgoing(to="u1@x.com", subject="s", body="b", idem_key="w1",
                     unsub_url="https://x/unsubscribe/tok")
     with patch("app.mail.requests.post", side_effect=fake_post):
@@ -640,7 +641,10 @@ def test_batch_adapters_reach_the_wire_with_the_single_send_payload(db,
     assert url == "https://api.sweego.io/send"
     assert payload["recipients"] == [{"email": "u1@x.com"}]
     assert payload["message-txt"] == "b"
-    assert payload["headers"]["List-Unsubscribe"] == "<https://x/unsubscribe/tok>"
+    # Sweego's mailto+url form — the URL-only header the others send is 422'd.
+    assert payload["headers"]["List-Unsubscribe"] == (
+        "<mailto:termine@jakubwaller.eu?subject=abmelden>,"
+        "<https://x/unsubscribe/tok>")
 
 
 def test_a_rejection_at_brevo_still_tries_sweego(db, brevo_sweego_on):


### PR DESCRIPTION
The prescribed Sweego dry-run smoke test (docs/DEPLOY.md, "prove a new provider") caught this before any real traffic: Sweego's API rejects the RFC 8058 URL-only `List-Unsubscribe` header that Mailjet, Brevo and Resend all accept — every send with an unsubscribe URL came back 422 ("Wrong one-click format"). Verified against the live API: Sweego requires `<mailto:…>,<url>` paired with the `List-Unsubscribe-Post: List-Unsubscribe=One-Click` header; the mailto may carry a `?subject=` parameter.

Without this fix, enabling Sweego in `EMAIL_PROVIDER_ORDER` would have made every digest routed to it bounce as a content rejection (the systemic-rejection guard would have handed the mail on, but Sweego would never carry traffic).

- `_sweego_email` now builds `<mailto:REPLY_TO?subject=abmelden>,<unsub_url>` for Sweego alone — the reply-to mailbox is the monitored address, so unsubscribe-by-mail lands somewhere real. Without a reply-to there is no valid mailto, and the headers are dropped rather than sent malformed (Sweego 422s the URL-only form in every combination tried).
- Tests updated to pin the new shape, plus a new test for the no-reply-to case; the wire-level batch-adapter test now sets `REPLY_TO_EMAIL` and asserts the mailto+url form.
- DEPLOY.md's prove-a-provider bullet now records why the dry-run step is not optional ceremony.

Smoke status: dry-run with this exact header shape returns 200, and one real send each through Brevo (201) and Sweego (200) went out today.

`pytest -m "not live"`: 463 passed. `ruff check .` clean.