### PR TITLE
feat(admin): count people, and order the quota table like the chain

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -176,8 +176,9 @@ def render_summary_email(s: dict, *, now: datetime, anomalies: list[str],
               f"  Notified      24h {s.get('notifications_24h', 0)}"
               f" · 7d {s.get('notifications_7d', 0)}",
               f"  Delivery 7d   {prov_str}"]
-    # Quota line only when a daily cap is configured — otherwise it's just noise.
-    capped = [(p, u) for p, u in sorted((s.get("email_usage") or {}).items())
+    # Quota line only when a daily cap is configured — otherwise it's just
+    # noise. email_usage arrives in EMAIL_PROVIDER_ORDER; keep that order.
+    capped = [(p, u) for p, u in (s.get("email_usage") or {}).items()
               if u.get("day_quota")]
     quota_bits = [f"{p} {u.get('today', 0)}/{u['day_quota']}" for p, u in capped]
     if quota_bits:
@@ -232,6 +233,15 @@ def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
         caps["sweego"] = {"month_quota": getattr(cfg, "sweego_monthly_quota", None),
                           "day_quota":   getattr(cfg, "sweego_daily_quota", None)}
     usage = {p: {"month": 0, "today": 0, **caps[p]} for p in caps}
+
+    def chain_order(u: dict) -> dict:
+        # The admin page and ops mail render this dict in iteration order;
+        # make that EMAIL_PROVIDER_ORDER (the actual fallback chain), with
+        # providers that only exist in the counters — retired ones — after.
+        out = {p: u[p] for p in order if p in u}
+        out.update(sorted((p, v) for p, v in u.items() if p not in out))
+        return out
+
     try:
         rows = conn.execute(
             "SELECT provider, "
@@ -242,7 +252,7 @@ def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
             "GROUP BY provider"
         ).fetchall()
     except sqlite3.OperationalError:
-        return usage  # pre-migration DB; counters not available yet
+        return chain_order(usage)  # pre-migration DB; counters not available yet
     for r in rows:
         u = usage.setdefault(r["provider"],
                              {"month_quota": None, "day_quota": None})
@@ -250,7 +260,7 @@ def _email_usage(conn: sqlite3.Connection, cfg) -> dict:
         u["today"] = r["today"]
     for name, u in usage.items():
         u["rolling"] = _window_used(conn, name, 86400)
-    return usage
+    return chain_order(usage)
 
 
 def stats(conn: sqlite3.Connection, cfg=None) -> dict:
@@ -430,6 +440,12 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         "active_subscriptions":
             scalar("SELECT COUNT(*) FROM subscriptions WHERE deleted_at IS NULL "
                    "AND confirmed_at IS NOT NULL AND expires_at > CURRENT_TIMESTAMP"),
+        # People, not rows: one address may hold several subscriptions. lower()
+        # folds rows that predate the subscribe form's lowercasing.
+        "active_subscribers":
+            scalar("SELECT COUNT(DISTINCT lower(email)) FROM subscriptions "
+                   "WHERE deleted_at IS NULL AND confirmed_at IS NOT NULL "
+                   "AND expires_at > CURRENT_TIMESTAMP"),
         "active_subscriptions_by_city": by_city_subs,
         "cities": cities,
         "current_plan_count_by_city": by_city_plans,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -166,6 +166,7 @@
   <section class="adm-section">
     <div class="stat-grid">
       <div class="stat"><div class="stat-num">{{ s.active_subscriptions }}</div><div class="stat-label">Active subscriptions</div></div>
+      <div class="stat"><div class="stat-num">{{ s.active_subscribers }}</div><div class="stat-label">Distinct subscribers</div></div>
       <div class="stat"><div class="stat-num">{{ s.pending_confirmation }}</div><div class="stat-label">Pending confirmation</div></div>
       <div class="stat"><div class="stat-num">{{ s.signups_last_24h }}</div><div class="stat-label">Signups · 24h</div></div>
       <div class="stat"><div class="stat-num">{{ s.signups_last_7d }}</div><div class="stat-label">Signups · 7d</div></div>
@@ -188,20 +189,6 @@
   <section class="adm-section">
     <h2>Email quota <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· month/today are UTC calendar · rolling 24h is what gates sending</span></h2>
     <table class="adm-table">
-      {% for p, u in s.email_usage|dictsort %}
-        <tr>
-          <td class="k">{{ p }}</td>
-          <td class="v">
-            {% set mpct = (100 * u.month / u.month_quota)|round|int if u.month_quota else 0 %}
-            {% set dpct = (100 * u.today / u.day_quota)|round|int if u.day_quota else 0 %}
-            month <span{% if mpct >= 80 %} class="quota-hot"{% endif %}>{{ u.month }}{% if u.month_quota %} / {{ u.month_quota }} ({{ mpct }}%){% endif %}</span>
-            &nbsp;·&nbsp;
-            today <span{% if dpct >= 80 %} class="quota-hot"{% endif %}>{{ u.today }}{% if u.day_quota %} / {{ u.day_quota }}{% endif %}</span>
-            &nbsp;·&nbsp;
-            rolling 24h {{ u.rolling }}{% if u.day_quota %} / {{ u.day_quota }}{% endif %}
-          </td>
-        </tr>
-      {% endfor %}
       {% set capped = s.email_usage.values()|selectattr("day_quota")|list %}
       {% if capped %}
         {% set roll = capped|sum(attribute="rolling") %}
@@ -218,6 +205,21 @@
         <td class="v"><span{% if s.deferrals_today %} class="quota-hot"{% endif %}>today {{ s.deferrals_today }}</span> · 7d {{ s.deferrals_7d }}
           <span class="adm-muted">· notifications the quota could not send — re-tried next cycle, longest wait first</span></td>
       </tr>
+      {# per-provider rows follow in EMAIL_PROVIDER_ORDER — the fallback chain #}
+      {% for p, u in s.email_usage.items() %}
+        <tr>
+          <td class="k">{{ p }}</td>
+          <td class="v">
+            {% set mpct = (100 * u.month / u.month_quota)|round|int if u.month_quota else 0 %}
+            {% set dpct = (100 * u.today / u.day_quota)|round|int if u.day_quota else 0 %}
+            month <span{% if mpct >= 80 %} class="quota-hot"{% endif %}>{{ u.month }}{% if u.month_quota %} / {{ u.month_quota }} ({{ mpct }}%){% endif %}</span>
+            &nbsp;·&nbsp;
+            today <span{% if dpct >= 80 %} class="quota-hot"{% endif %}>{{ u.today }}{% if u.day_quota %} / {{ u.day_quota }}{% endif %}</span>
+            &nbsp;·&nbsp;
+            rolling 24h {{ u.rolling }}{% if u.day_quota %} / {{ u.day_quota }}{% endif %}
+          </td>
+        </tr>
+      {% endfor %}
     </table>
   </section>
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -105,6 +105,8 @@ def test_admin_renders_new_metrics(client):
     assert r.status_code == 200
     # Always-present labels (Overview + System sections render regardless of data).
     for label in (b"Slots cached", b"Emails sent", b"Failure alert", b"Last backup",
+                  # People, not subscription rows — the two counts differ.
+                  b"Distinct subscribers",
                   # The gating window, next to the UTC-day counter it disagrees with.
                   b"rolling 24h", b"combined"):
         assert label in r.data, f"missing admin metric: {label!r}"
@@ -184,6 +186,24 @@ def test_stats_notification_metrics(tmp_path):
     assert s["active_awaiting_first_match"] == 1            # s2 still waiting
     assert s["last_notification"]["sub_id"] == s1
     assert s["emails_by_provider_7d"] == {"mailjet": 1, "resend": 1}  # 'pending' excluded
+
+def test_stats_distinct_active_subscribers(tmp_path):
+    from datetime import time
+    from app.models import Filter
+    from app.repo import insert_pending, confirm
+    conn = connect(str(tmp_path / "e.db")); init_schema(conn)
+    f = Filter(appointment_types=["A"], locations="all", weekdays=[1, 2, 3, 4, 5, 6, 7],
+               time_window_start=time(0, 0), time_window_end=time(23, 59))
+    # One person holds two subscriptions — here differing only in case, which
+    # rows from before the subscribe form lowercased can still do.
+    for email in ("one@example.com", "One@Example.com", "two@example.com"):
+        confirm(conn, insert_pending(conn, email=email, city="leipzig",
+                                     language="de", filter_=f, ttl_days=90))
+    insert_pending(conn, email="pending@example.com", city="leipzig",
+                   language="de", filter_=f, ttl_days=90)   # never confirmed
+    s = stats(conn)
+    assert s["active_subscriptions"] == 3
+    assert s["active_subscribers"] == 2
 
 
 # ---------- ops-summary: anomaly detection + compact email ----------
@@ -446,6 +466,23 @@ def test_stats_email_usage_lists_new_providers_only_when_configured(tmp_path):
     cfg = SimpleNamespace(**base, email_provider_order=("mailjet", "resend"))
     assert "brevo" not in stats(conn, cfg)["email_usage"]
 
+def test_stats_email_usage_follows_provider_chain_order(tmp_path):
+    """The quota table lists providers in EMAIL_PROVIDER_ORDER — the order a
+    send actually falls back along — not alphabetically. A provider that only
+    exists in the counters (retired from the chain) trails it."""
+    from types import SimpleNamespace
+    conn = connect(str(tmp_path / "o.db")); init_schema(conn)
+    conn.execute("INSERT INTO email_send_counts (provider, day, n) "
+                 "VALUES ('acme-retired', date('now'), 7)")
+    cfg = SimpleNamespace(
+        mailjet_monthly_quota=6000, mailjet_daily_quota=200,
+        resend_monthly_quota=3000, resend_daily_quota=100,
+        brevo_api_key="k", brevo_monthly_quota=9000, brevo_daily_quota=300,
+        sweego_api_key="k", sweego_monthly_quota=3000, sweego_daily_quota=100,
+        email_provider_order=("mailjet", "brevo", "sweego", "resend"))
+    u = stats(conn, cfg)["email_usage"]
+    assert list(u) == ["mailjet", "brevo", "sweego", "resend", "acme-retired"]
+
 def test_init_schema_backfills_counters_once(tmp_path):
     conn = connect(str(tmp_path / "b.db")); init_schema(conn)
     for k, p in (("k1", "mailjet"), ("k2", "mailjet"), ("k3", "resend"),
@@ -469,6 +506,10 @@ def test_admin_renders_email_quota_section(client):
     assert "Email quota" in html
     assert "483 / 6000" in html          # MAILJET_MONTHLY_QUOTA default
     assert "0 / 3000" in html            # RESEND_MONTHLY_QUOTA default
+    # combined + deferred lead the section; the per-provider rows follow.
+    q = html.index("Email quota")
+    assert (q < html.index(">combined</td>") < html.index(">deferred</td>")
+            < html.index(">mailjet</td>"))
 
 def test_summary_email_quota_line_lists_each_provider():
     text = render_summary_email(_summary_stats(email_usage={


### PR DESCRIPTION
Three admin-page changes:

- **Distinct subscribers tile** — the headline number counts subscription rows, but one address can hold several subscriptions (currently 57 rows ≈ 52 people). The new tile counts case-folded distinct addresses among active subscriptions.
- **Quota table in chain order** — `_email_usage` now returns providers in `EMAIL_PROVIDER_ORDER` (the actual fallback chain) instead of the page dict-sorting them alphabetically; providers that only exist in the counters (retired ones) trail. The ops-mail quota line follows the same order.
- **Combined + deferred rows lead the quota section** — the pool-level figures come before the per-provider detail.