### PR TITLE
docs: branch worktrees from origin/main, not the local main ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,14 @@ did not create mean someone else is mid-task, and a `git add -A` or `git checkou
 their work with no warning. Isolate instead:
 
 ```bash
-git worktree add -b <branch> ~/gitlab/.worktrees/buergerwecker-<task> main
+git fetch origin
+git worktree add -b <branch> ~/gitlab/.worktrees/buergerwecker-<task> origin/main
 ```
+
+Branch from `origin/main`, never the local `main` — that ref is whatever a past session left
+checked out, and fetching is safe from any session while pulling rewrites files under a
+concurrent one. For the same reason, read `git show origin/main:<path>` rather than the shared
+checkout when you need to know what is on `main`.
 
 Stage by naming paths, never `git add -A` / `git commit -a`, in any checkout you share.
 


### PR DESCRIPTION
The `git worktree add` line in this file ends in `main`, which branches from the local `main` ref — whatever a past session happened to leave checked out. Branching from `origin/main` after a fetch removes the dependency on that ref entirely, so no session ever has to pull the shared checkout.

Fetching writes refs only and is safe from any session at any moment. Pulling is the one operation that rewrites files under a concurrent session, which is why scheduling it between sessions never worked.

Real near-miss on 2026-08-24: a shared checkout sat one commit behind `origin/main` and a config file read from it returned pre-merge code that was quoted as current. Hence the second half of the note — read `git show origin/main:<path>`, not the shared tree.

Same one-line change is going to every repo that carries this section.