### PR TITLE
feat(digests): per-tenant notify granularity, day-level for Münster-KFZ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,16 @@ links in already-sent mail silently misparse.
 **Mail sends are idempotent by key** — `subscription_id | sorted slot hashes | cycle_id`. Changing
 how that key is built means re-notifying people about slots they were already told about.
 
+**What counts as "already told you" is per tenant** — `notify_granularity` in
+`scraper_config.json`, read by `Catalog.seen_key`. `slot` (the default) keys `seen_slots` on
+(day, time, office, service); `day` drops the time, and is only correct for a tenant whose vendor
+exposes just the *earliest* slot per office, where the replacement slot appearing after a booking
+is the same inventory rather than new availability. Getting this backwards on a tenant that lists
+real inventory silently withholds genuine second chances. The cycle filters on `seen_key` and the
+flush records the key the cycle computed (carried on `QueuedDigest.seen_keys`) — never recompute it
+on the recording side, because a check/record mismatch is either a digest every cycle forever or
+silence forever, both invisible.
+
 **Several providers, and the From domain must be verified in every one of them.**
 `EMAIL_PROVIDER_ORDER` falls back along the configured chain (Mailjet, Brevo, Sweego); an
 unverified sender domain makes a fallback provider reject the mail at exactly the moment it is

--- a/Dockerfile.poller
+++ b/Dockerfile.poller
@@ -4,5 +4,9 @@ COPY pyproject.toml ./
 RUN pip install --no-cache-dir .
 COPY app/ app/
 COPY catalog/ catalog/
+# Operational one-offs the DEPLOY runbook invokes with `docker compose run`
+# (e.g. the notify_granularity backfill). Without this they are simply
+# absent from the image and the documented command fails on a missing file.
+COPY scripts/ scripts/
 ENV PYTHONUNBUFFERED=1
 CMD ["python", "-m", "app.poller"]

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -11,6 +11,9 @@ CATALOG_ROOT = Path(__file__).parent.parent / "catalog"
 # will look up. Notably excludes "/", "\" and "." — see load_catalog.
 _SLUG_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 
+_NOTIFY_GRANULARITIES = ("slot", "day")
+
+
 class CatalogError(Exception):
     pass
 
@@ -68,6 +71,32 @@ class Catalog:
     # (confirmation, digest), so folding the Amt into it would give the game
     # away there.
     sensitive_services: frozenset = field(default_factory=frozenset)
+    # What counts as one piece of news for this tenant, from
+    # `notify_granularity` in scraper_config.json:
+    #
+    #   "slot" (default) — every distinct (day, time, office, service). Right
+    #       for a vendor that lists real inventory: each slot is a separate
+    #       perishable opportunity, and a subscriber told about a 09:00 that
+    #       someone else then books genuinely wants to hear about the 14:00.
+    #   "day" — (day, office, service), the time dropped. Right for a tenant
+    #       that only ever exposes the *earliest* slot per office (TEVIS): the
+    #       "new" slot appearing after someone books is the same inventory
+    #       seen a minute later, not new availability, so notifying again says
+    #       nothing the subscriber does not already know.
+    #
+    # Unknown values fall back to "slot", the never-suppress-anything side.
+    notify_granularity: str = "slot"
+
+    def seen_key(self, slot) -> str:
+        """The seen_slots key for `slot` under this tenant's granularity.
+
+        Single source of truth: the cycle filters on it and the flush records
+        it, and those two must never disagree — checking one key while
+        recording another means either a digest every cycle forever or silence
+        forever, both silent.
+        """
+        return (slot.day_hash() if self.notify_granularity == "day"
+                else slot.hash())
 
     def is_sensitive(self, uuid: str) -> bool:
         """Does subscribing to this service reveal special-category data?
@@ -158,11 +187,15 @@ def load_catalog(city: str) -> Catalog:
         ats_en = {n: u for n, u in ats_en.items() if u not in excluded}
         svc_locs = {u: v for u, v in svc_locs.items() if u not in excluded}
     sensitive = frozenset(str(s) for s in (scfg.get("sensitive_services") or ()))
+    granularity = str(scfg.get("notify_granularity") or "slot")
+    if granularity not in _NOTIFY_GRANULARITIES:
+        granularity = "slot"
     return Catalog(city=city, appointment_types=ats, locations=locs,
                    scraper_config=scfg,
                    appointment_types_en=ats_en, locations_en=locs_en,
                    display=display, service_locations=svc_locs,
-                   sensitive_services=sensitive)
+                   sensitive_services=sensitive,
+                   notify_granularity=granularity)
 
 
 def city_display_name(city: str, lang: str) -> str | None:

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -85,6 +85,17 @@ class Catalog:
     #       nothing the subscriber does not already know.
     #
     # Unknown values fall back to "slot", the never-suppress-anything side.
+    #
+    # Known limitation, and the reason "day" is not simply switched on for
+    # every TEVIS tenant: the key cannot tell the earliest slot moving
+    # *forward* (someone booked — redundant news) from it moving *back* (a
+    # cancellation — real news). Once a day is recorded, an earlier slot
+    # opening on that same day is suppressed until housekeeping prunes the row
+    # at 7 days. Harmless where the tenant only ever offers same-day slots, so
+    # a day is reported once and never revisited; a genuine loss on a tenant
+    # whose horizon is weeks, where the earliest can walk out to a distant date
+    # and a cancellation pull it back. Fix that before enabling "day" on any
+    # multi-day tenant.
     notify_granularity: str = "slot"
 
     def seen_key(self, slot) -> str:
@@ -189,6 +200,10 @@ def load_catalog(city: str) -> Catalog:
     sensitive = frozenset(str(s) for s in (scfg.get("sensitive_services") or ()))
     granularity = str(scfg.get("notify_granularity") or "slot")
     if granularity not in _NOTIFY_GRANULARITIES:
+        # A typo ("Day", "daily") would otherwise leave the tenant looking
+        # correctly configured while the intended suppression never happens.
+        print(f"catalog {city}: unknown notify_granularity "
+              f"{granularity!r}, using 'slot'", flush=True)
         granularity = "slot"
     return Catalog(city=city, appointment_types=ats, locations=locs,
                    scraper_config=scfg,

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -91,11 +91,16 @@ class Catalog:
     # *forward* (someone booked — redundant news) from it moving *back* (a
     # cancellation — real news). Once a day is recorded, an earlier slot
     # opening on that same day is suppressed until housekeeping prunes the row
-    # at 7 days. Harmless where the tenant only ever offers same-day slots, so
-    # a day is reported once and never revisited; a genuine loss on a tenant
-    # whose horizon is weeks, where the earliest can walk out to a distant date
-    # and a cancellation pull it back. Fix that before enabling "day" on any
-    # multi-day tenant.
+    # at 7 days.
+    #
+    # This applies to muenster-kfz too — probed live 2026-08-25, its 2407 was a
+    # day out and its 2408 sixteen days out, so the tenant is NOT the same-day
+    # -only case an earlier draft of this comment assumed. Accepted knowingly:
+    # the loss is confined to a day that was reported, vanished, and reopened
+    # inside a week, against 4-8 mails a day telling subscribers about times on
+    # a day they had already been told about. Weigh it again for any other
+    # tenant, and prefer teaching the key "earlier than last told" over
+    # widening the rollout on this trade alone.
     notify_granularity: str = "slot"
 
     def seen_key(self, slot) -> str:

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -103,6 +103,20 @@ def _poll_interval_s(city: str) -> int:
         return 60
 
 
+def _seen_key_fn(city: str):
+    """Return this tenant's slot → seen_slots key function.
+
+    Falls back to per-slot identity when the catalog cannot be read: a missing
+    or malformed file must never coarsen a tenant's notifications, because the
+    coarse direction is the one that can *withhold* mail.
+    """
+    try:
+        from app.catalog import load_catalog
+        return load_catalog(city).seen_key
+    except Exception:
+        return Slot.hash
+
+
 def _due_cities(conn: sqlite3.Connection, cities: set[str]) -> set[str]:
     """Cities whose poll interval has elapsed since city_state.last_polled_at.
 
@@ -249,6 +263,8 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
     # deferred tail is whoever was most recently served — so nobody is
     # permanently starved across cycles. datetime.min sorts NULLs to the front.
     outbox: list = []
+    # Per-cycle memo so a tenant's catalog is resolved once, not per subscriber.
+    seen_key_fns: dict = {}
     for sub in sorted(subs, key=lambda s: s.last_notified_at or datetime.min):
         # Each subscriber's floor is their own: scarce filters keep the base
         # interval, filters swimming in slots wait longer. Cheap to evaluate
@@ -277,8 +293,12 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
         # service) can surface from two resources (counters) or two overlapping
         # plans — Slot.hash() excludes the resource, so collapse them to one line.
         candidates: list[Slot] = []
+        candidate_keys: list[str] = []
         seen_in_cycle: set[str] = set()
         matched_total = 0
+        if sub.city not in seen_key_fns:
+            seen_key_fns[sub.city] = _seen_key_fn(sub.city)
+        seen_key = seen_key_fns[sub.city]
         for plan in plans:
             if plan.city != sub.city:
                 continue
@@ -297,9 +317,15 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
                 # of thirty standing ones is the abundant case, not the scarce
                 # one, and counting only candidates would read it backwards.
                 matched_total += 1
-                if has_seen_slot(conn, sub.id, slot_hash):
+                # What counts as already-told is the tenant's call, not the
+                # slot's: an earliest-slot-only tenant keys on the day, so the
+                # replacement slot that appears the moment someone books is
+                # not news. See Catalog.seen_key.
+                key = seen_key(slot)
+                if has_seen_slot(conn, sub.id, key):
                     continue
                 candidates.append(slot)
+                candidate_keys.append(key)
         if not candidates:
             continue
         # No per-slot slots_cache writes anymore: Smart-CJM bookings are
@@ -315,5 +341,6 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
         # quota-deferred ones stay unrecorded so a later cycle re-sends them.
         send_digest(conn=conn, subscription=sub, matched_slots=candidates,
                     cycle_id=cycle_id, cfg=cfg, sink=outbox,
-                    match_count=matched_total)
+                    match_count=matched_total,
+                    seen_keys=candidate_keys)
     flush_digests(conn, outbox, cfg)

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -103,17 +103,28 @@ def _poll_interval_s(city: str) -> int:
         return 60
 
 
+# Cities already warned about a catalog that would not load, so a persistent
+# failure says so once per process rather than once a minute forever.
+_KEY_FALLBACK_WARNED: set[str] = set()
+
+
 def _seen_key_fn(city: str):
     """Return this tenant's slot → seen_slots key function.
 
     Falls back to per-slot identity when the catalog cannot be read: a missing
     or malformed file must never coarsen a tenant's notifications, because the
-    coarse direction is the one that can *withhold* mail.
+    coarse direction is the one that can *withhold* mail. The fallback is loud
+    — silently reverting a `day` tenant to per-slot keys shows up only as mail
+    volume creeping back, which nothing alerts on.
     """
     try:
         from app.catalog import load_catalog
         return load_catalog(city).seen_key
-    except Exception:
+    except Exception as exc:
+        if city not in _KEY_FALLBACK_WARNED:
+            _KEY_FALLBACK_WARNED.add(city)
+            print(f"notify_granularity: catalog unreadable for {city}, "
+                  f"falling back to per-slot keys: {exc}", flush=True)
         return Slot.hash
 
 

--- a/app/digest.py
+++ b/app/digest.py
@@ -239,8 +239,14 @@ def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
         subscription=subscription,
         slots=list(matched_slots),
         match_count=match_count,
+        # Falling back to the tenant's own key, not to slot.hash(): recording
+        # a key the cycle will never query is how a `day` tenant would mail
+        # twice about one day. `catalog` is already loaded above; without it
+        # (unknown tenant) per-slot identity is the safe default.
         seen_keys=(list(seen_keys) if seen_keys is not None
-                   else [s.hash() for s in matched_slots]),
+                   else [(catalog.seen_key(s) if catalog is not None
+                          else s.hash())
+                         for s in matched_slots]),
     )
     if sink is None:
         flush_digests(conn, [queued], cfg)

--- a/app/digest.py
+++ b/app/digest.py
@@ -176,18 +176,29 @@ class QueuedDigest:
     # Slots the filter matched this cycle, already-seen ones included. Recorded
     # on delivery as the subscriber's abundance, which sets their next interval.
     match_count: int | None = None
+    # The seen_slots keys to write once this digest is actually delivered, as
+    # computed by the caller that decided these slots were unseen. Carried
+    # rather than recomputed so the check and the record cannot drift apart
+    # under a tenant's notify_granularity. None = per-slot identity.
+    seen_keys: list[str] | None = None
 
 def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
                 matched_slots: list[Slot], cycle_id: str, cfg,
                 sink: list | None = None,
-                match_count: int | None = None) -> None:
+                match_count: int | None = None,
+                seen_keys: list[str] | None = None) -> None:
     """Render a digest and stage it for delivery. `cfg` is the loaded Config
     (passed in by callers that already have it loaded — never re-read from
     os.environ here). render_digest_text loads the per-city catalog itself.
 
     With a `sink` list (the normal cycle path), the rendered digest is appended
     for batched delivery via `flush_digests`. Without one, it is delivered
-    immediately (used for one-off sends outside a poll cycle)."""
+    immediately (used for one-off sends outside a poll cycle).
+
+    `seen_keys` are the seen_slots keys to record on delivery, one per slot in
+    `matched_slots` as judged unseen by the caller. Omitted (the one-off path)
+    they default to per-slot identity, which is the pre-existing behaviour and
+    the safe side of a tenant with coarser granularity."""
     from app.tokens import sign
     unsub_token = sign(subscription.id, "unsubscribe",
                        primary=cfg.token_secret_primary,
@@ -228,6 +239,8 @@ def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
         subscription=subscription,
         slots=list(matched_slots),
         match_count=match_count,
+        seen_keys=(list(seen_keys) if seen_keys is not None
+                   else [s.hash() for s in matched_slots]),
     )
     if sink is None:
         flush_digests(conn, [queued], cfg)
@@ -258,7 +271,11 @@ def flush_digests(conn: sqlite3.Connection, sink: list, cfg) -> None:
         if q.item.idem_key not in result.delivered:
             continue
         with transaction(conn):
-            for slot in q.slots:
-                record_seen_slot(conn, q.subscription.id, slot.hash())
+            # Several slots can share one key at day granularity (the whole
+            # point), so write each distinct key once.
+            keys = (q.seen_keys if q.seen_keys is not None
+                    else [slot.hash() for slot in q.slots])
+            for key in dict.fromkeys(keys):
+                record_seen_slot(conn, q.subscription.id, key)
             set_last_notified(conn, q.subscription.id, q.match_count)
     maybe_quota_alert(conn, cfg, deferred=result.deferred)

--- a/app/models.py
+++ b/app/models.py
@@ -70,6 +70,18 @@ class Slot:
         payload = f"{self.date}|{self.time_str}|{self.location_uuid}|{self.service_uuid}"
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
+    def day_hash(self) -> str:
+        """Identity at day granularity: (day, office, service), no time.
+
+        The coarse half of `Catalog.seen_key` — see `notify_granularity` there.
+        Deliberately a different payload *shape* from `hash()` rather than the
+        same string with a blank time, so the two key spaces cannot alias: a
+        subscriber's seen_slots rows may hold both after a tenant switches
+        granularity, and a coarse key must never be mistaken for a fine one.
+        """
+        payload = f"{self.date}|{self.location_uuid}|{self.service_uuid}"
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
 @dataclass(frozen=True)
 class Subscription:
     id: int

--- a/catalog/muenster-kfz/scraper_config.json
+++ b/catalog/muenster-kfz/scraper_config.json
@@ -3,5 +3,6 @@
   "base_url": "https://termine.stadt-muenster.de",
   "md": 19,
   "mdt": 214,
-  "poll_interval_seconds": 120
+  "poll_interval_seconds": 120,
+  "notify_granularity": "day"
 }

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -260,20 +260,36 @@ already been told about and writes the day key for it. Run the dry run first and
 check `unrecognized` is at or near zero — each unrecognized row is one
 subscriber who may still get a single redundant mail:
 
+**The backfill has to run between the build and the restart**, and the ordering
+below is the only one that works. `docker exec` into the *running* poller cannot
+do it: that container is the old image, which has neither the script nor
+`Slot.day_hash`. And once `up -d` has recreated the poller there is no window to
+catch — it sleeps to the next minute boundary and runs a cycle, so the burst has
+already gone out. `docker compose run` threads the needle: it uses the freshly
+built image while the old poller keeps running, unchanged, on the old
+granularity.
+
 ```bash
-# on the VPS, where the DB lives inside the poller container
-docker exec termine-notifier-poller-1 \
-    python scripts/backfill_day_keys.py <tenant> --db /data/app.db
-docker exec termine-notifier-poller-1 \
-    python scripts/backfill_day_keys.py <tenant> --db /data/app.db --apply
+ssh vps 'cd ~/termine-notifier && git pull --ff-only && docker compose build poller'
+
+# Dry run first: check `unrecognized` is at or near zero before applying.
+ssh vps 'cd ~/termine-notifier && docker compose run --rm poller \
+    python scripts/backfill_day_keys.py <tenant> --db /data/app.db'
+ssh vps 'cd ~/termine-notifier && docker compose run --rm poller \
+    python scripts/backfill_day_keys.py <tenant> --db /data/app.db --apply'
+
+ssh vps 'cd ~/termine-notifier && docker compose up -d --build'
 ```
 
-Idempotent, and safe to run *before* the new code is deployed — the keys sit
-unused until something asks for them. Measured on muenster-kfz on 2026-08-25:
-557 of 557 rows recovered, 231 day keys written, first-cycle burst 35 digests →
-2 (those 2 being subscribers genuinely never told about that date). Without the
-backfill, deploy when the pool has headroom and check `/admin` → Email quota
-first.
+The keys are inert until the new poller asks for them, so the gap between the
+backfill and `up -d` is safe to take at whatever pace you like. The script is
+idempotent — rerun it freely — and it waits out the live poller's write lock
+rather than failing on it.
+
+Measured on muenster-kfz on 2026-08-25: 557 of 557 rows recovered, 231 day keys
+written, first-cycle burst 35 digests → 2 (those 2 being subscribers genuinely
+never told about that date). If you deploy *without* the backfill anyway, do it
+when the pool has headroom and check `/admin` → Email quota first.
 
 ## Load testing
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -213,6 +213,27 @@ polled less often (e.g. 180 for a city that mandates one request per three
 minutes). Skipped cycles leave the tenant's counters, canary, and
 last-polled timestamp untouched.
 
+## Notification granularity
+
+A tenant can set `notify_granularity` in its `scraper_config.json` to decide
+what counts as one piece of news:
+
+- `slot` (default, and what every tenant gets by omitting the key) — a distinct
+  (day, time, office, service).
+- `day` — (day, office, service), the time dropped. Only correct for a vendor
+  that exposes the *earliest* free slot per office (TEVIS): there, the slot
+  that appears the moment somebody books is the same inventory a minute later,
+  and mailing about it again tells the subscriber nothing new. On a vendor that
+  lists real inventory (smartCJM), `day` would withhold genuine second chances
+  — do not set it.
+
+**Changing it re-notifies once.** The old and new keys are different values in
+`seen_slots`, so on the first cycle after the deploy every affected subscriber
+with a currently-matching slot gets one digest, and only then does the new
+suppression apply. That is a one-time burst of up to one mail per affected
+subscriber — deploy a granularity change when the mail pool has headroom, not
+during a saturated morning. Check the pool first: `/admin` → Email quota.
+
 ## Load testing
 
 `scripts/loadtest.py` measures sign-up write contention and `run_cycle` time at

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -248,12 +248,32 @@ Whether a tenant shows only its earliest slot is measurable rather than assumed:
 GROUP BY city` — TEVIS tenants read exactly 1, smartCJM tenants read hundreds
 or thousands.
 
-**Changing it re-notifies once.** The old and new keys are different values in
-`seen_slots`, so on the first cycle after the deploy every affected subscriber
-with a currently-matching slot gets one digest, and only then does the new
-suppression apply. That is a one-time burst of up to one mail per affected
-subscriber — deploy a granularity change when the mail pool has headroom, not
-during a saturated morning. Check the pool first: `/admin` → Email quota.
+**Changing it re-notifies once unless you backfill first.** The old and new keys
+are different values in `seen_slots`, so on the first cycle after the deploy
+every affected subscriber with a currently-matching slot gets one digest — which
+is one last round of exactly the noise the setting removes.
+
+`scripts/backfill_day_keys.py` prevents that. The stored hashes cannot be read
+back, but the tenant's slot space (date x time x office x service) is small
+enough to enumerate and match, which recovers every date each subscriber has
+already been told about and writes the day key for it. Run the dry run first and
+check `unrecognized` is at or near zero — each unrecognized row is one
+subscriber who may still get a single redundant mail:
+
+```bash
+# on the VPS, where the DB lives inside the poller container
+docker exec termine-notifier-poller-1 \
+    python scripts/backfill_day_keys.py <tenant> --db /data/app.db
+docker exec termine-notifier-poller-1 \
+    python scripts/backfill_day_keys.py <tenant> --db /data/app.db --apply
+```
+
+Idempotent, and safe to run *before* the new code is deployed — the keys sit
+unused until something asks for them. Measured on muenster-kfz on 2026-08-25:
+557 of 557 rows recovered, 231 day keys written, first-cycle burst 35 digests →
+2 (those 2 being subscribers genuinely never told about that date). Without the
+backfill, deploy when the pool has headroom and check `/admin` → Email quota
+first.
 
 ## Load testing
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -231,13 +231,17 @@ what counts as one piece of news:
 deliberately are not. `day` cannot distinguish the earliest slot moving forward
 (booked — nothing new to say) from it moving back (a cancellation — worth
 saying), so once a day has been reported, an earlier slot on that day stays
-quiet until housekeeping prunes the row after 7 days. Münster-KFZ releases
-same-day slots each morning and nothing further ahead, so a day is reported
-once and never revisited and the limitation cannot bite. On a tenant whose
-horizon is weeks — Braunschweig, Mainz, Kiel — the earliest slot can walk out
-to a distant date and a cancellation pull it back, and that is exactly the mail
-a subscriber wants. **Teach the key about earlier-than-last-told before
-enabling `day` anywhere with a multi-day horizon.**
+quiet until housekeeping prunes the row after 7 days.
+
+That is a real trade even on Münster-KFZ, whose horizon is **not** same-day:
+probed live on 2026-08-25, service 2407 stood a day out and 2408 sixteen days
+out. It is accepted there because the alternative is measured at 4-8 mails per
+subscriber per day, every one of them a different time on a day they had
+already been told about, and because the earliest slot usually moves *within* a
+day (a day holds many slots, so a booking rarely exhausts it). The loss is
+confined to a day that was reported, vanished, and reopened within the week.
+**Before enabling `day` on any further tenant, teach the key
+"earlier than last told" rather than re-making this trade by hand.**
 
 Whether a tenant shows only its earliest slot is measurable rather than assumed:
 `SELECT city, MAX(n_slots) FROM availability_samples WHERE location_uuid <> ''

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -227,6 +227,23 @@ what counts as one piece of news:
   lists real inventory (smartCJM), `day` would withhold genuine second chances
   — do not set it.
 
+**Only `muenster-kfz` is set to `day` today**, and the other 30 TEVIS tenants
+deliberately are not. `day` cannot distinguish the earliest slot moving forward
+(booked — nothing new to say) from it moving back (a cancellation — worth
+saying), so once a day has been reported, an earlier slot on that day stays
+quiet until housekeeping prunes the row after 7 days. Münster-KFZ releases
+same-day slots each morning and nothing further ahead, so a day is reported
+once and never revisited and the limitation cannot bite. On a tenant whose
+horizon is weeks — Braunschweig, Mainz, Kiel — the earliest slot can walk out
+to a distant date and a cancellation pull it back, and that is exactly the mail
+a subscriber wants. **Teach the key about earlier-than-last-told before
+enabling `day` anywhere with a multi-day horizon.**
+
+Whether a tenant shows only its earliest slot is measurable rather than assumed:
+`SELECT city, MAX(n_slots) FROM availability_samples WHERE location_uuid <> ''
+GROUP BY city` — TEVIS tenants read exactly 1, smartCJM tenants read hundreds
+or thousands.
+
 **Changing it re-notifies once.** The old and new keys are different values in
 `seen_slots`, so on the first cycle after the deploy every affected subscriber
 with a currently-matching slot gets one digest, and only then does the new

--- a/scripts/backfill_day_keys.py
+++ b/scripts/backfill_day_keys.py
@@ -34,12 +34,21 @@ On the VPS the DB lives inside the poller container:
 from __future__ import annotations
 
 import argparse
+import pathlib
 import sqlite3
 import sys
 from datetime import date, timedelta
 
-from app.catalog import load_catalog
-from app.models import Filter, Slot
+# Running `python scripts/backfill_day_keys.py` puts *this* directory on
+# sys.path, not the repo root, so `app` would not import. The poller image
+# installs only the dependencies from pyproject.toml (the `app/` tree is copied
+# in afterwards and reached via WORKDIR), so there is no installed copy to fall
+# back on there either — in-container this bootstrap is the only thing that
+# makes the runbook's command work.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.catalog import load_catalog  # noqa: E402
+from app.models import Filter, Slot  # noqa: E402
 
 # seen_slots rows are pruned at 7 days, so anything still present was recorded
 # recently — but the *slot* it points at can sit far in the future (Münster's
@@ -177,7 +186,11 @@ def main(argv=None) -> int:
                          "offices if the run drags.")
     args = ap.parse_args(argv)
 
-    conn = sqlite3.connect(args.db)
+    # The live poller writes to this DB while the backfill runs (that is the
+    # point — it runs before the stack is recreated), so wait out a held write
+    # lock rather than dying on it. Python's default is 5s; a cycle mid-flush
+    # can exceed that.
+    conn = sqlite3.connect(args.db, timeout=30.0)
     conn.row_factory = sqlite3.Row
     stats = backfill(conn, args.city, apply=args.apply,
                      days_ahead=args.days_ahead)

--- a/scripts/backfill_day_keys.py
+++ b/scripts/backfill_day_keys.py
@@ -1,0 +1,204 @@
+"""Backfill day-granularity seen_slots keys before flipping a tenant to
+`notify_granularity: "day"`.
+
+Without this, the first cycle after the flip finds no day key for anybody and
+mails every subscriber once about a day they have usually just been told about
+— one last round of exactly the noise the setting exists to remove. Measured on
+muenster-kfz before its flip: 50 of 66 subscribers had already been told about
+the live date, 40 of them more than once, one of them eight times.
+
+**How it recovers the dates.** `seen_slots` stores only a sha256, so the dates
+cannot be read back out of it. They can be *enumerated*: a tenant's slot
+identity is (date, time, office, service), and all four are small, bounded sets
+— the catalog knows its offices and services, the dates that matter span at most
+a year, and TEVIS/smartCJM times are minutes of a day. Hashing that space and
+testing each candidate against the rows a subscriber actually holds recovers
+every (date, office, service) they were told about, exactly.
+
+Anything not recovered is not a correctness problem: that subscriber gets one
+redundant mail, the same as with no backfill at all. The `unrecognized` count in
+the report is the honest measure of how complete the run was — investigate it if
+it is not near zero, because it means the enumeration missed part of the space
+(an unusual time, or an office the catalog no longer lists).
+
+Dry run by default; `--apply` writes. Idempotent — a second run inserts nothing.
+
+    python scripts/backfill_day_keys.py muenster-kfz --db /data/app.db
+    python scripts/backfill_day_keys.py muenster-kfz --db /data/app.db --apply
+
+On the VPS the DB lives inside the poller container:
+
+    docker exec termine-notifier-poller-1 \
+        python scripts/backfill_day_keys.py muenster-kfz --db /data/app.db
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from datetime import date, timedelta
+
+from app.catalog import load_catalog
+from app.models import Filter, Slot
+
+# seen_slots rows are pruned at 7 days, so anything still present was recorded
+# recently — but the *slot* it points at can sit far in the future (Münster's
+# Führerschein Pflichtumtausch ran 16 days out on 2026-08-25, and a quieter
+# tenant can be months). Past days are included because a row can outlive the
+# day it names by up to the prune window.
+DAYS_BACK = 14
+DAYS_AHEAD = 400
+
+
+def _services_in_play(conn: sqlite3.Connection, city: str, catalog) -> set[str]:
+    """Every service id worth enumerating: what the catalog offers now, plus
+    what subscribers actually hold. A service withdrawn from the catalog (or
+    excluded under `exclude_services`) still has live subscriptions and live
+    seen_slots rows, and skipping it would leave exactly those people with the
+    redundant mail this script exists to prevent."""
+    services = set(catalog.appointment_types.values())
+    for row in conn.execute(
+            "SELECT filters_json FROM subscriptions WHERE city=?", (city,)):
+        try:
+            services.update(Filter.from_json(row["filters_json"]).appointment_types)
+        except Exception:
+            continue
+    return {str(s) for s in services if s}
+
+
+def _locations_in_play(conn: sqlite3.Connection, city: str, catalog) -> set[str]:
+    locations = set(catalog.locations.values())
+    for row in conn.execute(
+            "SELECT filters_json FROM subscriptions WHERE city=?", (city,)):
+        try:
+            locs = Filter.from_json(row["filters_json"]).locations
+        except Exception:
+            continue
+        if locs != "all":
+            locations.update(locs)
+    return {str(loc) for loc in locations if loc}
+
+
+def _seen_rows(conn: sqlite3.Connection, city: str) -> dict[int, dict[str, str]]:
+    """subscription_id → {slot_hash: sent_at} for the tenant's active subs."""
+    rows = conn.execute(
+        """SELECT s.subscription_id sid, s.slot_hash h, s.sent_at t
+             FROM seen_slots s
+             JOIN subscriptions sub ON sub.id = s.subscription_id
+            WHERE sub.city = ?
+              AND sub.deleted_at IS NULL
+              AND sub.confirmed_at IS NOT NULL
+              AND sub.expires_at > datetime('now')""", (city,)).fetchall()
+    out: dict[int, dict[str, str]] = {}
+    for r in rows:
+        out.setdefault(r["sid"], {})[r["h"]] = r["t"]
+    return out
+
+
+def backfill(conn: sqlite3.Connection, city: str, *, apply: bool,
+             days_ahead: int = DAYS_AHEAD) -> dict:
+    catalog = load_catalog(city)
+    if catalog.notify_granularity != "day":
+        print(f"note: {city} is not set to notify_granularity=day. Backfilling "
+              f"anyway is harmless — the keys are simply unused until it is.",
+              file=sys.stderr)
+
+    seen = _seen_rows(conn, city)
+    if not seen:
+        return {"subs": 0, "rows": 0, "recognized": 0, "unrecognized": 0,
+                "keys": 0, "written": 0}
+
+    services = _services_in_play(conn, city, catalog)
+    locations = _locations_in_play(conn, city, catalog)
+    wanted = {h for rows in seen.values() for h in rows}
+
+    # One pass over the candidate space, testing against the hashes actually
+    # held. Inverted deliberately: building the full hash→slot map would be
+    # hundreds of megabytes on a multi-office tenant, while the rows we are
+    # trying to explain number in the hundreds.
+    found: dict[str, tuple[str, str, str]] = {}
+    start = date.today() - timedelta(days=DAYS_BACK)
+    for offset in range(DAYS_BACK + days_ahead):
+        day = (start + timedelta(days=offset)).isoformat()
+        for loc in locations:
+            for svc in services:
+                for minute in range(24 * 60):
+                    slot = Slot(day, f"{minute // 60:02d}:{minute % 60:02d}",
+                                loc, svc, "")
+                    h = slot.hash()
+                    if h in wanted:
+                        found[h] = (day, loc, svc)
+        if len(found) == len(wanted):
+            break  # every row explained; the rest of the calendar is empty
+
+    # Earliest sighting wins, so the day key ages out on the same schedule the
+    # original rows would have — a backfilled key must not outlive them.
+    to_write: dict[tuple[int, str], str] = {}
+    recognized = 0
+    for sid, rows in seen.items():
+        for h, sent_at in rows.items():
+            hit = found.get(h)
+            if hit is None:
+                continue
+            recognized += 1
+            day, loc, svc = hit
+            key = Slot(day, "00:00", loc, svc, "").day_hash()
+            prev = to_write.get((sid, key))
+            if prev is None or sent_at < prev:
+                to_write[(sid, key)] = sent_at
+
+    written = 0
+    if apply and to_write:
+        with conn:
+            for (sid, key), sent_at in to_write.items():
+                cur = conn.execute(
+                    "INSERT OR IGNORE INTO seen_slots "
+                    "(subscription_id, slot_hash, sent_at) VALUES (?,?,?)",
+                    (sid, key, sent_at))
+                written += cur.rowcount
+
+    total_rows = sum(len(r) for r in seen.values())
+    return {"subs": len(seen), "rows": total_rows, "recognized": recognized,
+            "unrecognized": total_rows - recognized, "keys": len(to_write),
+            "written": written}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("city", help="tenant slug, e.g. muenster-kfz")
+    ap.add_argument("--db", required=True, help="path to app.db")
+    ap.add_argument("--apply", action="store_true",
+                    help="write the keys (default: report only)")
+    ap.add_argument("--days-ahead", type=int, default=DAYS_AHEAD,
+                    help="how far forward to enumerate dates. The scan is "
+                         "days x offices x services x 1440 and stops early "
+                         "once every row is explained, so a one-office tenant "
+                         "is seconds; lower this for a tenant with many "
+                         "offices if the run drags.")
+    args = ap.parse_args(argv)
+
+    conn = sqlite3.connect(args.db)
+    conn.row_factory = sqlite3.Row
+    stats = backfill(conn, args.city, apply=args.apply,
+                     days_ahead=args.days_ahead)
+
+    print(f"tenant:              {args.city}")
+    print(f"active subscribers:  {stats['subs']}")
+    print(f"seen_slots rows:     {stats['rows']}")
+    print(f"  recognized:        {stats['recognized']}")
+    print(f"  unrecognized:      {stats['unrecognized']}")
+    print(f"day keys implied:    {stats['keys']}")
+    if args.apply:
+        print(f"rows written:        {stats['written']}")
+    else:
+        print("dry run — nothing written. Re-run with --apply.")
+    if stats["unrecognized"]:
+        print(f"\nWARNING: {stats['unrecognized']} rows could not be mapped to a "
+              f"(date, office, service). Each is one subscriber who may still "
+              f"get a single redundant mail. Check that the catalog lists every "
+              f"office and service those subscriptions use.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backfill_day_keys.py
+++ b/tests/test_backfill_day_keys.py
@@ -1,0 +1,143 @@
+"""The one-off backfill that makes a granularity flip silent.
+
+Flipping a tenant to `day` without it mails every subscriber once about a day
+they were usually just told about — the exact noise the flip removes. The script
+recovers the dates behind the stored hashes by enumerating the tenant's slot
+space, so the new keys are already in place when the new code starts asking for
+them.
+"""
+import pathlib
+import sqlite3
+import sys
+from datetime import date, time, timedelta
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from scripts.backfill_day_keys import backfill  # noqa: E402
+
+from app.db import connect, init_schema  # noqa: E402
+from app.models import Filter, Slot  # noqa: E402
+from app.repo import confirm, insert_pending, record_seen_slot  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path):
+    conn = connect(str(tmp_path / "t.db"))
+    init_schema(conn)
+    return conn
+
+
+def _sub(db, services=("2408",)):
+    f = Filter(appointment_types=list(services), locations="all",
+               weekdays=[1, 2, 3, 4, 5, 6, 7],
+               time_window_start=time(0, 0), time_window_end=time(23, 59))
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=f, ttl_days=90)
+    confirm(db, sid)
+    return sid
+
+
+def _soon(days=3):
+    """A date inside the script's enumeration window, computed rather than
+    hardcoded — a fixed date would silently fall out of range as time passes and
+    turn this test into a no-op."""
+    return (date.today() + timedelta(days=days)).isoformat()
+
+
+def test_backfill_writes_the_day_key_behind_a_stored_slot_hash(db):
+    sid = _sub(db)
+    slot = Slot(_soon(), "09:00", "243", "2408", "tok")
+    record_seen_slot(db, sid, slot.hash())
+
+    stats = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    assert stats["unrecognized"] == 0
+    assert stats["written"] == 1
+    row = db.execute("SELECT 1 FROM seen_slots WHERE subscription_id=? AND "
+                     "slot_hash=?", (sid, slot.day_hash())).fetchone()
+    assert row is not None
+
+
+def test_dry_run_writes_nothing(db):
+    sid = _sub(db)
+    slot = Slot(_soon(), "09:00", "243", "2408", "tok")
+    record_seen_slot(db, sid, slot.hash())
+
+    stats = backfill(db, "muenster-kfz", apply=False, days_ahead=30)
+    assert stats["keys"] == 1
+    assert stats["written"] == 0
+    assert db.execute("SELECT COUNT(*) c FROM seen_slots").fetchone()["c"] == 1
+
+
+def test_backfill_is_idempotent(db):
+    sid = _sub(db)
+    record_seen_slot(db, sid, Slot(_soon(), "09:00", "243", "2408", "t").hash())
+
+    assert backfill(db, "muenster-kfz", apply=True, days_ahead=30)["written"] == 1
+    assert backfill(db, "muenster-kfz", apply=True, days_ahead=30)["written"] == 0
+
+
+def test_many_times_on_one_day_collapse_to_a_single_key(db):
+    sid = _sub(db)
+    day = _soon()
+    for hhmm in ("08:00", "09:20", "14:45"):
+        record_seen_slot(db, sid, Slot(day, hhmm, "243", "2408", "t").hash())
+
+    stats = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    assert stats["recognized"] == 3
+    assert stats["written"] == 1
+
+
+def test_the_backfilled_key_inherits_the_earliest_sighting(db):
+    """It must age out of the 7-day prune on the original schedule — a key that
+    outlived the rows it stands for would keep suppressing after those rows are
+    gone."""
+    sid = _sub(db)
+    day = _soon()
+    db.execute("INSERT INTO seen_slots (subscription_id, slot_hash, sent_at) "
+               "VALUES (?,?,?)",
+               (sid, Slot(day, "08:00", "243", "2408", "t").hash(),
+                "2026-01-01 07:00:00"))
+    db.execute("INSERT INTO seen_slots (subscription_id, slot_hash, sent_at) "
+               "VALUES (?,?,?)",
+               (sid, Slot(day, "09:00", "243", "2408", "t").hash(),
+                "2026-01-02 07:00:00"))
+    db.commit()
+
+    backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    sent_at = db.execute(
+        "SELECT sent_at FROM seen_slots WHERE subscription_id=? AND slot_hash=?",
+        (sid, Slot(day, "00:00", "243", "2408", "t").day_hash())).fetchone()["sent_at"]
+    assert sent_at == "2026-01-01 07:00:00"
+
+
+def test_an_unexplainable_row_is_reported_not_swallowed(db):
+    """A hash outside the enumerated space costs one redundant mail, not
+    correctness — but it must show up in the report, because a large count means
+    the enumeration is missing part of the tenant's slot space."""
+    sid = _sub(db)
+    record_seen_slot(db, sid, "f" * 64)
+
+    stats = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    assert stats["unrecognized"] == 1
+    assert stats["written"] == 0
+
+
+def test_a_service_no_longer_in_the_catalog_is_still_recovered(db):
+    """Subscriptions outlive catalog entries (a withdrawn or excluded service),
+    and those subscribers are exactly the ones a partial backfill would leave
+    with the redundant mail."""
+    sid = _sub(db, services=("9999",))
+    slot = Slot(_soon(), "09:00", "243", "9999", "t")
+    record_seen_slot(db, sid, slot.hash())
+
+    stats = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    assert stats["unrecognized"] == 0
+    assert db.execute("SELECT 1 FROM seen_slots WHERE subscription_id=? AND "
+                      "slot_hash=?", (sid, slot.day_hash())).fetchone() is not None
+
+
+def test_a_tenant_with_no_subscribers_is_a_no_op(db):
+    stats = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    assert stats == {"subs": 0, "rows": 0, "recognized": 0, "unrecognized": 0,
+                     "keys": 0, "written": 0}

--- a/tests/test_deploy_script_packaging.py
+++ b/tests/test_deploy_script_packaging.py
@@ -1,0 +1,60 @@
+"""The runbook's in-container commands must actually work in the container.
+
+`scripts/backfill_day_keys.py` shipped as a documented `docker compose run`
+command while `Dockerfile.poller` copied only `app/` and `catalog/`, so the
+image did not contain the file at all — and even once copied, running it by path
+puts `scripts/` on `sys.path` instead of the repo root, and the image installs
+only the dependencies from `pyproject.toml` (the `app/` tree arrives in a later
+COPY and is reached via WORKDIR), so there is no installed `app` to fall back
+on. Both failures surface only on the VPS, mid-deploy, which is the worst place
+to find them.
+"""
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "docs" / "DEPLOY.md"
+DOCKERFILE = ROOT / "Dockerfile.poller"
+
+
+def _scripts_run_in_the_poller_container() -> set[str]:
+    """Every `scripts/*.py` the runbook invokes via docker, line-continuations
+    folded so a wrapped command is still matched."""
+    text = DEPLOY.read_text().replace("\\\n", " ")
+    return set(re.findall(r"docker\s+(?:compose\s+run|exec)\b.*?python\s+(scripts/\S+\.py)",
+                          text))
+
+
+def test_the_runbook_only_names_scripts_that_exist():
+    for rel in _scripts_run_in_the_poller_container():
+        assert (ROOT / rel).is_file(), f"DEPLOY.md runs {rel}, which does not exist"
+
+
+def test_the_poller_image_ships_the_scripts_the_runbook_runs():
+    referenced = _scripts_run_in_the_poller_container()
+    if not referenced:
+        return
+    copied = re.findall(r"^COPY\s+(\S+)", DOCKERFILE.read_text(), re.M)
+    assert any(c.rstrip("/") == "scripts" for c in copied), (
+        f"DEPLOY.md runs {sorted(referenced)} inside the poller container, but "
+        f"Dockerfile.poller copies only {copied} — the file would be missing.")
+
+
+def test_the_backfill_bootstraps_its_own_import_path():
+    """`parents[1]` is only the repo root while the script sits directly in
+    `scripts/`; moving it deeper would break the in-container import silently."""
+    script = ROOT / "scripts" / "backfill_day_keys.py"
+    assert script.parent.parent == ROOT
+    assert "sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))" \
+        in script.read_text()
+
+
+def test_the_backfill_runs_as_a_plain_script_from_a_foreign_cwd(tmp_path):
+    """Smoke test: argparse alone would pass, so this is guarding the imports at
+    module scope, which run before `main`."""
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "backfill_day_keys.py"), "--help"],
+        cwd=tmp_path, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr

--- a/tests/test_notify_granularity.py
+++ b/tests/test_notify_granularity.py
@@ -267,3 +267,48 @@ def test_a_deferred_digest_records_nothing(db):
     sent = []
     _run(db, [slot], cycle_id="c2", sent=sent)
     assert len(sent) == 1
+
+
+def test_an_earlier_slot_on_an_already_reported_day_is_suppressed(db):
+    """Pins the known limitation, so it stays a decision rather than a
+    surprise: the day key cannot tell a booking (earliest moves forward,
+    redundant) from a cancellation (earliest moves back, real news), and
+    suppresses both. Harmless on a same-day-release tenant like Münster-KFZ,
+    where a day is reported once and never revisited — which is why `day` must
+    not be switched on for a tenant with a multi-day horizon until the key
+    learns about earlier-than-last-told.
+    """
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    _run(db, [Slot("2026-06-10", "11:00", "243", "2408", "tok")],
+         cycle_id="c1", sent=sent)
+    assert len(sent) == 1
+
+    _make_due_again(db)
+    _run(db, [Slot("2026-06-10", "08:30", "243", "2408", "tok2")],
+         cycle_id="c2", sent=sent)
+    assert len(sent) == 1
+
+
+def test_a_one_off_send_records_the_tenants_own_key(db):
+    """send_digest without `seen_keys` (the one-off path, no cycle) must still
+    record what the cycle would later query — recording a slot hash for a `day`
+    tenant would earn the subscriber a second mail about the same day."""
+    from app.config import load_config
+    from app.digest import send_digest
+    from app.repo import active_subscriptions
+
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    sub = next(s for s in active_subscriptions(db) if s.id == sid)
+    slot = Slot("2026-06-10", "09:00", "243", "2408", "tok")
+    sent = []
+    with patch("app.digest.send_batch", side_effect=_deliver_everything(sent)):
+        send_digest(conn=db, subscription=sub, matched_slots=[slot],
+                    cycle_id="one-off", cfg=load_config())
+    assert len(sent) == 1
+    assert has_seen_slot(db, sid, slot.day_hash()) is True
+    assert has_seen_slot(db, sid, slot.hash()) is False

--- a/tests/test_notify_granularity.py
+++ b/tests/test_notify_granularity.py
@@ -1,0 +1,269 @@
+"""Per-tenant notification granularity (`notify_granularity`).
+
+A tenant whose vendor only ever exposes the *earliest* slot per office keys
+seen_slots on the day, not on the slot: the "new" slot that appears the moment
+somebody books is the same inventory a minute later, and re-notifying about it
+tells the subscriber nothing they don't already know. Every other tenant keeps
+per-slot identity, where a different time genuinely is a different opportunity.
+"""
+import json
+from datetime import time
+from unittest.mock import patch
+
+import pytest
+
+from app import catalog as catalog_mod
+from app.catalog import Catalog, load_catalog
+from app.db import connect, init_schema
+from app.mail import BatchResult
+from app.models import Filter, Slot
+from app.repo import confirm, has_seen_slot, insert_pending
+from app.cycle import run_cycle
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    for k, v in {
+        "MAILJET_API_KEY": "m", "MAILJET_API_SECRET": "m",
+        "MAILJET_FROM_EMAIL": "x@x", "MAILJET_FROM_NAME": "x",
+        "MAILJET_DAILY_QUOTA": "6000",
+        "TOKEN_SECRET_PRIMARY": "x" * 32, "TOKEN_SECRET_PREVIOUS": "",
+        "ADMIN_TOKEN": "a" * 32, "PUBLIC_BASE_URL": "https://x",
+        "DEDUP_WINDOW_HOURS": "24", "RATE_LIMIT_MINUTES": "15",
+        "SUBSCRIPTION_TTL_DAYS": "90", "RENEWAL_REMINDER_DAYS_BEFORE": "10",
+        "MAX_PLANS_PER_CITY": "10", "PARSER_CANARY_THRESHOLD_HOURS": "2",
+        "SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR": "99",
+        "SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY": "99",
+        "DEVELOPER_EMAIL": "dev@x", "KOFI_URL": "https://k",
+    }.items():
+        monkeypatch.setenv(k, v)
+    conn = connect(str(tmp_path / "t.db"))
+    init_schema(conn)
+    return conn
+
+
+def _f(types, locs="all"):
+    return Filter(appointment_types=list(types),
+                  locations="all" if locs == "all" else list(locs),
+                  weekdays=[1, 2, 3, 4, 5, 6, 7],
+                  time_window_start=time(0, 0), time_window_end=time(23, 59))
+
+
+def _deliver_everything(sent):
+    """Stand-in for send_batch that reports every staged item delivered."""
+    def fake(conn, items, cfg):
+        sent.extend(items)
+        return BatchResult(delivered={it.idem_key for it in items})
+    return fake
+
+
+def _run(db, slots, *, cycle_id, sent):
+    """One full cycle through the real digest/flush path."""
+    with patch("app.cycle.get_scraper") as gs, \
+         patch("app.digest.send_batch", side_effect=_deliver_everything(sent)):
+        gs.return_value.poll.return_value = slots
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15,
+                  cycle_id=cycle_id)
+
+
+def _make_due_again(db):
+    """Clear the two clocks that would suppress a second cycle: the
+    subscriber's rate limit and the tenant's poll interval. Both are wall-clock
+    in production; the test drives the state directly instead of freezing time,
+    because last_notified_at is written by SQLite's CURRENT_TIMESTAMP and would
+    not follow a frozen Python clock."""
+    db.execute("UPDATE subscriptions SET last_notified_at=NULL")
+    db.execute("UPDATE city_state SET last_polled_at=NULL")
+    db.commit()
+
+
+# --- the key itself -------------------------------------------------------
+
+def test_day_hash_drops_the_time_but_keeps_day_office_and_service():
+    base = Slot("2026-06-10", "09:00", "loc-1", "svc-A", "tok", "r1")
+    later = Slot("2026-06-10", "09:20", "loc-1", "svc-A", "tok2", "r2")
+    assert base.day_hash() == later.day_hash()
+    assert base.hash() != later.hash()
+    # …and nothing coarser than that: a different day, office or service is a
+    # different piece of news.
+    assert base.day_hash() != Slot("2026-06-11", "09:00", "loc-1", "svc-A", "t").day_hash()
+    assert base.day_hash() != Slot("2026-06-10", "09:00", "loc-2", "svc-A", "t").day_hash()
+    assert base.day_hash() != Slot("2026-06-10", "09:00", "loc-1", "svc-B", "t").day_hash()
+
+
+def test_the_two_key_spaces_cannot_alias():
+    """A coarse key must never collide with a fine one — seen_slots holds both
+    for a subscriber whose tenant switched granularity."""
+    slot = Slot("2026-06-10", "09:00", "loc-1", "svc-A", "tok")
+    assert slot.day_hash() != slot.hash()
+    # The payloads differ in shape, not just content: 3 fields vs 4.
+    weird = Slot("2026-06-10", "loc-1", "svc-A", "", "tok")
+    assert weird.hash() != slot.day_hash()
+
+
+# --- reading the tenant declaration ---------------------------------------
+
+def test_shipped_tenants_declare_the_granularity_they_need():
+    assert load_catalog("muenster-kfz").notify_granularity == "day"
+    # Everyone else keeps per-slot identity by omitting the key entirely.
+    assert load_catalog("leipzig").notify_granularity == "slot"
+
+
+def test_seen_key_follows_the_declaration():
+    slot = Slot("2026-06-10", "09:00", "243", "2408", "tok")
+    assert load_catalog("muenster-kfz").seen_key(slot) == slot.day_hash()
+    assert load_catalog("leipzig").seen_key(slot) == slot.hash()
+
+
+def test_unknown_granularity_falls_back_to_per_slot(tmp_path, monkeypatch):
+    """The fail-safe direction is the one that can only ever send *more* mail:
+    a typo must not silently start suppressing notifications."""
+    city = tmp_path / "testcity"
+    city.mkdir()
+    (city / "scraper_config.json").write_text(json.dumps(
+        {"vendor": "tevis", "base_url": "https://x", "md": 1, "mdt": 2,
+         "notify_granularity": "weekly"}), encoding="utf-8")
+    (city / "appointment_type.json").write_text(json.dumps({"A": "svc-A"}),
+                                                encoding="utf-8")
+    (city / "locations.json").write_text(json.dumps({"Amt": "loc-1"}),
+                                         encoding="utf-8")
+    monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", tmp_path)
+    catalog_mod.load_catalog.cache_clear()
+    try:
+        cat = catalog_mod.load_catalog("testcity")
+        assert cat.notify_granularity == "slot"
+        slot = Slot("2026-06-10", "09:00", "loc-1", "svc-A", "tok")
+        assert cat.seen_key(slot) == slot.hash()
+    finally:
+        catalog_mod.load_catalog.cache_clear()
+
+
+def test_a_catalog_object_with_a_bogus_value_still_keys_per_slot():
+    """load_catalog normalizes, but Catalog is constructed directly elsewhere
+    (tests, catalog_sync); the method itself must not fail open into 'day'."""
+    slot = Slot("2026-06-10", "09:00", "loc-1", "svc-A", "tok")
+    cat = Catalog(city="x", appointment_types={}, locations={},
+                  scraper_config={}, notify_granularity="hourly")
+    assert cat.seen_key(slot) == slot.hash()
+
+
+# --- behaviour through a real cycle ---------------------------------------
+
+def test_day_tenant_is_not_renotified_when_the_earliest_slot_moves(db):
+    """Münster-KFZ exposes only the earliest slot for its one office. When
+    somebody books it, the next one surfaces — same day, same office, later
+    time. That is not new availability and must not produce a second mail."""
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    first = Slot("2026-06-10", "09:00", "243", "2408", "tok")
+    _run(db, [first], cycle_id="c1", sent=sent)
+    assert len(sent) == 1
+    assert has_seen_slot(db, sid, first.day_hash()) is True
+
+    _make_due_again(db)
+    moved = Slot("2026-06-10", "09:20", "243", "2408", "tok2")
+    _run(db, [moved], cycle_id="c2", sent=sent)
+    assert len(sent) == 1, "the replacement earliest slot re-notified"
+
+
+def test_day_tenant_notifies_again_once_a_new_day_opens(db):
+    """The suppression is per day, not a mute button: tomorrow's release is
+    news."""
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    _run(db, [Slot("2026-06-10", "09:00", "243", "2408", "tok")],
+         cycle_id="c1", sent=sent)
+    assert len(sent) == 1
+
+    _make_due_again(db)
+    _run(db, [Slot("2026-06-11", "08:00", "243", "2408", "tok2")],
+         cycle_id="c2", sent=sent)
+    assert len(sent) == 2
+
+
+def test_day_tenant_notifies_again_for_another_service_the_same_day(db):
+    """Zulassung and Führerschein are separate news even at the same office on
+    the same day."""
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2407", "2408"]),
+                         ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    _run(db, [Slot("2026-06-10", "09:00", "243", "2408", "tok")],
+         cycle_id="c1", sent=sent)
+    assert len(sent) == 1
+
+    _make_due_again(db)
+    _run(db, [Slot("2026-06-10", "09:00", "243", "2408", "tok"),
+              Slot("2026-06-10", "10:00", "243", "2407", "tok2")],
+         cycle_id="c2", sent=sent)
+    assert len(sent) == 2
+
+
+def test_slot_tenant_still_notifies_about_a_different_time_the_same_day(db):
+    """The regression guard for everyone else: in a tenant that lists real
+    inventory, the 09:00 a subscriber was told about may already be gone, so
+    the 14:00 is a genuine second opportunity."""
+    sid = insert_pending(db, email="a@example.com", city="leipzig",
+                         language="de", filter_=_f(["svc-A"]), ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    _run(db, [Slot("2026-06-10", "09:00", "loc-1", "svc-A", "tok")],
+         cycle_id="c1", sent=sent)
+    assert len(sent) == 1
+
+    _make_due_again(db)
+    _run(db, [Slot("2026-06-10", "14:00", "loc-1", "svc-A", "tok2")],
+         cycle_id="c2", sent=sent)
+    assert len(sent) == 2
+
+
+def test_day_tenant_collapses_a_whole_day_into_one_seen_row(db):
+    """Several times on one day arrive in a single digest and are recorded
+    once; none of them can trigger a further mail."""
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    slots = [Slot("2026-06-10", "09:00", "243", "2408", "t1"),
+             Slot("2026-06-10", "11:00", "243", "2408", "t2"),
+             Slot("2026-06-10", "15:00", "243", "2408", "t3")]
+    _run(db, slots, cycle_id="c1", sent=sent)
+    assert len(sent) == 1
+    rows = db.execute("SELECT COUNT(*) c FROM seen_slots WHERE subscription_id=?",
+                      (sid,)).fetchone()["c"]
+    assert rows == 1
+
+    _make_due_again(db)
+    _run(db, slots, cycle_id="c2", sent=sent)
+    assert len(sent) == 1
+
+
+def test_a_deferred_digest_records_nothing(db):
+    """A digest dropped for quota must leave no seen key behind — at day
+    granularity that would silently cost the subscriber the whole day's news,
+    not one slot's."""
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    slot = Slot("2026-06-10", "09:00", "243", "2408", "tok")
+
+    def defer_everything(conn, items, cfg):
+        return BatchResult(delivered=set(), deferred=len(items))
+
+    with patch("app.cycle.get_scraper") as gs, \
+         patch("app.digest.send_batch", side_effect=defer_everything):
+        gs.return_value.poll.return_value = [slot]
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15,
+                  cycle_id="c1")
+    assert has_seen_slot(db, sid, slot.day_hash()) is False
+
+    # …and the next cycle really does re-send it.
+    _make_due_again(db)
+    sent = []
+    _run(db, [slot], cycle_id="c2", sent=sent)
+    assert len(sent) == 1


### PR DESCRIPTION
## Why

`muenster-kfz` is 64 of 90 active subscriptions and most of the mail. Its vendor
(TEVIS) exposes only the **earliest** free slot per office, and the office has
exactly one. So when somebody books the 09:00, the 09:20 surfaces a minute
later — a slot hash we have never seen, and therefore, to `seen_slots`, news.
It is not news: the subscriber already knows that office has something today.

Replayed over the live snapshot, Münster-KFZ subscribers received **one slot per
digest**, 3.1–8.1 digests per day each, worst case **16 in a day**:

| day | subs | digests | avg/sub | worst |
| --- | --- | --- | --- | --- |
| 2026-08-24 | 42 | 340 | 8.1 | 16 |
| 2026-08-25 (to midday) | 46 | 182 | 4.0 | 8 |

That is what took the rolling-24h mail pool to 534/600 with Mailjet and Brevo
both exhausted.

## What

Tenants declare `notify_granularity` in `scraper_config.json`:

- **`slot`** (default, unchanged for all 37 other tenants) — a distinct
  (day, time, office, service).
- **`day`** — (day, office, service). Only for a vendor that shows the earliest
  slot per office.

`Catalog.seen_key` is the single source of truth, and **the key the cycle
computed is carried** on `QueuedDigest.seen_keys` to the flush rather than
recomputed there. A check/record mismatch would be either a digest every cycle
forever or silence forever, both invisible.

Unknown values fall back to `slot` — the only direction that sends *more* mail
rather than silently withholding it — and say so on stdout, as does a catalog
that will not load. `muenster-kfz` is the one tenant enabled: expected effect
~340 digests/day → ~46.

## The limitation, and why the other 30 TEVIS tenants are not enabled

The day key cannot tell the earliest slot moving **forward** (someone booked —
redundant) from moving **back** (a cancellation — real news). Once a day is
recorded, an earlier slot on that day is suppressed until housekeeping prunes
the row at 7 days.

**This is a real trade on Münster-KFZ too, not a non-issue.** Probed live on
2026-08-25: service 2407's earliest slot stood a day out and 2408's sixteen days
out, so the tenant is not the same-day-only case an earlier draft of this PR
claimed. It is accepted here because the measured alternative is 4-8 mails per
subscriber per day, each one a different *time* on a day they had already been
told about, and because the earliest slot usually moves within a day rather than
past it — a day holds many slots, so one booking rarely exhausts it. The loss is
confined to a day that was reported, vanished, and reopened within the week.

For any further tenant — Braunschweig, Mainz, Kiel, all with multi-week horizons
— teach the key "earlier than last told" instead of re-making this trade by hand.
Written down in `app/catalog.py`, `docs/DEPLOY.md` and pinned by a test.

Whether a tenant shows only its earliest slot is **measured**, not assumed —
`MAX(n_slots)` per (city, service, office) over the last 7 days reads exactly 1
for every TEVIS tenant and 57–5,096 for every smartCJM one.

## Deploy note

Changing granularity **re-notifies once**: old and new keys are different values
in `seen_slots`, so on the first cycle every affected subscriber with a matching
slot gets one digest (~64 mails), and only then does the suppression apply.
Deploy when the pool has headroom, not mid-morning.

## Tests

14 new in `tests/test_notify_granularity.py` — the key itself (no aliasing
between the two key spaces), the declaration read from the shipped catalog, the
unknown-value fallback, and behaviour through a real cycle + flush: the earliest
slot moving does not re-notify, a new day does, a second service does, a `slot`
tenant still notifies about a different time the same day (the guard for
everyone else), a quota-deferred digest records nothing, and the one-off
`send_digest` path records the tenant's own key.

**473 passed, ruff clean.**
