### PR TITLE
fix(backfill): count existing day keys as explained, not unrecognized

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -284,7 +284,8 @@ ssh vps 'cd ~/termine-notifier && docker compose up -d --build'
 The keys are inert until the new poller asks for them, so the gap between the
 backfill and `up -d` is safe to take at whatever pace you like. The script is
 idempotent — rerun it freely — and it waits out the live poller's write lock
-rather than failing on it.
+rather than failing on it. On a rerun the keys from the first run show up under
+`already day keys`, not `unrecognized`; `written: 0` is the expected result.
 
 Measured on muenster-kfz on 2026-08-25: 557 of 557 rows recovered, 231 day keys
 written, first-cycle burst 35 digests → 2 (those 2 being subscribers genuinely

--- a/scripts/backfill_day_keys.py
+++ b/scripts/backfill_day_keys.py
@@ -114,8 +114,8 @@ def backfill(conn: sqlite3.Connection, city: str, *, apply: bool,
 
     seen = _seen_rows(conn, city)
     if not seen:
-        return {"subs": 0, "rows": 0, "recognized": 0, "unrecognized": 0,
-                "keys": 0, "written": 0}
+        return {"subs": 0, "rows": 0, "recognized": 0, "already_day_keys": 0,
+                "unrecognized": 0, "keys": 0, "written": 0}
 
     services = _services_in_play(conn, city, catalog)
     locations = _locations_in_play(conn, city, catalog)
@@ -126,18 +126,27 @@ def backfill(conn: sqlite3.Connection, city: str, *, apply: bool,
     # hundreds of megabytes on a multi-office tenant, while the rows we are
     # trying to explain number in the hundreds.
     found: dict[str, tuple[str, str, str]] = {}
+    already_day: set[str] = set()
     start = date.today() - timedelta(days=DAYS_BACK)
     for offset in range(DAYS_BACK + days_ahead):
         day = (start + timedelta(days=offset)).isoformat()
         for loc in locations:
             for svc in services:
+                # A rerun sees the day keys a previous run wrote. They can never
+                # match a slot hash, so without recognising them here every one
+                # of them lands in `unrecognized` — the single number the
+                # runbook tells you to check before applying — and a clean
+                # second run reads as a broken one.
+                day_key = Slot(day, "00:00", loc, svc, "").day_hash()
+                if day_key in wanted:
+                    already_day.add(day_key)
                 for minute in range(24 * 60):
                     slot = Slot(day, f"{minute // 60:02d}:{minute % 60:02d}",
                                 loc, svc, "")
                     h = slot.hash()
                     if h in wanted:
                         found[h] = (day, loc, svc)
-        if len(found) == len(wanted):
+        if len(found) + len(already_day) == len(wanted):
             break  # every row explained; the rest of the calendar is empty
 
     # Earliest sighting wins, so the day key ages out on the same schedule the
@@ -167,9 +176,11 @@ def backfill(conn: sqlite3.Connection, city: str, *, apply: bool,
                 written += cur.rowcount
 
     total_rows = sum(len(r) for r in seen.values())
+    already = sum(1 for rows in seen.values() for h in rows if h in already_day)
     return {"subs": len(seen), "rows": total_rows, "recognized": recognized,
-            "unrecognized": total_rows - recognized, "keys": len(to_write),
-            "written": written}
+            "already_day_keys": already,
+            "unrecognized": total_rows - recognized - already,
+            "keys": len(to_write), "written": written}
 
 
 def main(argv=None) -> int:
@@ -199,6 +210,7 @@ def main(argv=None) -> int:
     print(f"active subscribers:  {stats['subs']}")
     print(f"seen_slots rows:     {stats['rows']}")
     print(f"  recognized:        {stats['recognized']}")
+    print(f"  already day keys:  {stats['already_day_keys']}")
     print(f"  unrecognized:      {stats['unrecognized']}")
     print(f"day keys implied:    {stats['keys']}")
     if args.apply:

--- a/tests/test_backfill_day_keys.py
+++ b/tests/test_backfill_day_keys.py
@@ -139,5 +139,21 @@ def test_a_service_no_longer_in_the_catalog_is_still_recovered(db):
 
 def test_a_tenant_with_no_subscribers_is_a_no_op(db):
     stats = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
-    assert stats == {"subs": 0, "rows": 0, "recognized": 0, "unrecognized": 0,
-                     "keys": 0, "written": 0}
+    assert stats == {"subs": 0, "rows": 0, "recognized": 0,
+                     "already_day_keys": 0, "unrecognized": 0, "keys": 0,
+                     "written": 0}
+
+
+def test_a_rerun_reports_existing_day_keys_as_such_not_as_unrecognized(db):
+    """The keys a first run writes are themselves seen_slots rows, and no slot
+    hash can ever equal one. Counting them as unrecognized made a clean rerun on
+    prod report 266 unexplained rows — the exact number it had just written, and
+    the exact number the runbook says to check before applying."""
+    sid = _sub(db)
+    record_seen_slot(db, sid, Slot(_soon(), "09:00", "243", "2408", "t").hash())
+    backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+
+    again = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    assert again["written"] == 0
+    assert again["already_day_keys"] == 1
+    assert again["unrecognized"] == 0


### PR DESCRIPTION
A rerun of `scripts/backfill_day_keys.py` sees the day keys the previous run wrote. No slot hash can ever equal one, so every key landed in `unrecognized` — the single number the runbook tells you to check before applying.

Observed during tonight's deploy: the second run reported

```
seen_slots rows:     935
  recognized:        669
  unrecognized:      266   <- exactly the 266 it had just written
rows written:        0
```

A clean, correct rerun reading as a broken one. The data was fine (`written: 0`, and 935 = 669 + 266 confirmed in the DB) — only the report was wrong.

## Change

Recognise day keys during the same enumeration pass and report them under `already day keys`. Side benefit: this restores the early exit, which could not fire once day keys were in the target set — a rerun was scanning the full 414-day calendar instead of stopping when every row was explained.

## Tests

`test_a_rerun_reports_existing_day_keys_as_such_not_as_unrecognized` covers it. 486 passing, ruff clean.