### PR TITLE
fix(admin): grade the quota alert on the window that gates sending

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -85,12 +85,28 @@ def summary_anomalies(s: dict, *, now: datetime) -> list[str]:
     #    still has a third of its capacity free. Monthly stays per-provider —
     #    those caps are hard, per-account walls that no failover can borrow
     #    against.
+    #    Graded on the ROLLING 24h window, not the UTC-day counters, because
+    #    that is what mail._send_batch actually gates on. The two diverge, and
+    #    the divergence is worst exactly when it matters: just after UTC
+    #    midnight `today` snaps to 0 while `rolling` still carries last
+    #    evening's traffic, so grading on `today` reports all-clear at the
+    #    moment the real gate is closest to deferring. It also read low the rest
+    #    of the day — on 2026-08-25 the alert said 89% (532/600) while the gate
+    #    stood at 92% (555/600), i.e. the warning fired late and disagreed with
+    #    the Email quota section of the same page.
     usage = sorted((s.get("email_usage") or {}).items())
-    day_used = sum((u.get("today") or 0) for _, u in usage if u.get("day_quota"))
-    day_cap = sum(u["day_quota"] for _, u in usage if u.get("day_quota"))
-    if day_cap and day_used >= day_cap * QUOTA_WARN_PCT / 100:
-        out.append(f"combined day quota at {round(day_used * 100 / day_cap)}% "
-                   f"({day_used}/{day_cap})")
+    capped = [(p, u) for p, u in usage if u.get("day_quota")]
+    #    `rolling` is missing only on a pre-migration DB, where the counters are
+    #    all zero anyway. Fall back to `today` rather than let a missing key
+    #    read as "no sends" and silence the warning.
+    roll_used = sum(u["rolling"] if u.get("rolling") is not None
+                    else (u.get("today") or 0)
+                    for _, u in capped)
+    roll_cap = sum(u["day_quota"] for _, u in capped)
+    if roll_cap and roll_used >= roll_cap * QUOTA_WARN_PCT / 100:
+        out.append(f"combined rolling 24h quota at "
+                   f"{round(roll_used * 100 / roll_cap)}% "
+                   f"({roll_used}/{roll_cap})")
     for prov, u in usage:
         cap, used = u.get("month_quota"), u.get("month") or 0
         if cap and used >= cap * QUOTA_WARN_PCT / 100:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -261,9 +261,10 @@ def test_healthy_baseline_has_no_anomalies():
 def test_anomaly_quota_near_cap():
     # Mailjet alone in the pool, so its 170/200 IS the combined 85%.
     a = summary_anomalies(_summary_stats(email_usage={
-        "mailjet": {"month": 100, "today": 170, "month_quota": 6000, "day_quota": 200},
+        "mailjet": {"month": 100, "today": 170, "rolling": 170,
+                    "month_quota": 6000, "day_quota": 200},
     }), now=NOW)
-    assert any("combined day quota at 85% (170/200)" in x for x in a)
+    assert any("combined rolling 24h quota at 85% (170/200)" in x for x in a)
 
 
 def test_anomaly_day_quota_grades_the_pool_not_one_provider():
@@ -271,10 +272,54 @@ def test_anomaly_day_quota_grades_the_pool_not_one_provider():
     anything, so a hot primary is a busy day, not a warning. 196 of a combined
     300 is 65%."""
     a = summary_anomalies(_summary_stats(email_usage={
-        "mailjet": {"month": 100, "today": 196, "month_quota": 6000, "day_quota": 200},
-        "brevo": {"month": 0, "today": 0, "month_quota": 9000, "day_quota": 100},
+        "mailjet": {"month": 100, "today": 196, "rolling": 196,
+                    "month_quota": 6000, "day_quota": 200},
+        "brevo": {"month": 0, "today": 0, "rolling": 0,
+                  "month_quota": 9000, "day_quota": 100},
     }), now=NOW)
-    assert not any("day quota" in x for x in a)
+    assert not any("quota at" in x and "rolling" in x for x in a)
+
+
+def test_anomaly_quota_grades_the_window_that_actually_gates_sending():
+    """The admin page showed `combined day quota at 89% (532/600)` in the alert
+    box while the Email quota section right below it showed the gating figure at
+    92% (555/600) — the same page disagreeing with itself, because the alert
+    read the UTC-day counters and the gate is the rolling 24h window."""
+    a = summary_anomalies(_summary_stats(email_usage={
+        "mailjet": {"month": 100, "today": 193, "rolling": 200,
+                    "month_quota": 6000, "day_quota": 200},
+        "brevo": {"month": 100, "today": 258, "rolling": 274,
+                  "month_quota": 9000, "day_quota": 300},
+        "sweego": {"month": 100, "today": 81, "rolling": 81,
+                   "month_quota": 3000, "day_quota": 100},
+    }), now=NOW)
+    assert any("combined rolling 24h quota at 92% (555/600)" in x for x in a)
+
+
+def test_anomaly_quota_still_warns_just_after_utc_midnight():
+    """The failure this fixes. At 00:05 UTC the day counters have snapped to 0
+    while the rolling window still carries last evening's sends, so the old
+    grading reported all-clear at the exact moment the real gate was closest to
+    deferring — and Bürgerwecker sends heavily in the evening."""
+    a = summary_anomalies(_summary_stats(email_usage={
+        "mailjet": {"month": 0, "today": 0, "rolling": 200,
+                    "month_quota": 6000, "day_quota": 200},
+        "brevo": {"month": 0, "today": 0, "rolling": 290,
+                  "month_quota": 9000, "day_quota": 300},
+        "sweego": {"month": 0, "today": 0, "rolling": 60,
+                   "month_quota": 3000, "day_quota": 100},
+    }), now=NOW)
+    assert any("combined rolling 24h quota at 92% (550/600)" in x for x in a)
+
+
+def test_anomaly_quota_falls_back_to_today_when_rolling_is_absent():
+    """A pre-migration DB returns usage without `rolling`. Reading the missing
+    key as zero sends would silence the warning entirely."""
+    a = summary_anomalies(_summary_stats(email_usage={
+        "mailjet": {"month": 100, "today": 190, "month_quota": 6000,
+                    "day_quota": 200},
+    }), now=NOW)
+    assert any("combined rolling 24h quota at 95% (190/200)" in x for x in a)
 
 
 def test_anomaly_month_quota_stays_per_provider():


### PR DESCRIPTION
The admin page contradicted itself. Alert box:

> combined day quota at 89% (532/600)

Email quota section, directly below:

> combined rolling 24h 555 / 600 (92%) · spillover means a single provider at its cap is not the ceiling

Both are real; they measure different things. `mail._send_batch` gates on the **rolling 24h window**, and the alert was grading the **UTC-day counters** instead.

Confirmed on prod just now:

| provider | today | rolling | cap |
|---|---|---|---|
| mailjet | 193 | **200** | 200 |
| brevo | 258 | 274 | 300 |
| sweego | 81 | 81 | 100 |
| **sum** | **532** (89%) | **555** (92%) | 600 |

## Why it matters beyond the cosmetics

The alert read low all day, so it fired late. Worse, the two diverge most exactly where it counts: **just after UTC midnight `today` snaps to 0 while `rolling` still carries last evening's sends.** The old grading reported all-clear at the moment the real gate was closest to deferring — and this service sends heavily in the evening, with UTC midnight landing at 01:00/02:00 local.

`_email_usage` already computed `rolling` per provider, and its docstring already spelled out this exact trap ("what made the admin page and the low-quota mail look like they were contradicting each other"). The ops mail was moved to a `Gating 24h` line at the time; `summary_anomalies` was not.

## Change

Grade the combined-pool warning on `rolling`, label it to match the section below it. Falls back to `today` when `rolling` is absent (pre-migration DB) rather than reading a missing key as zero sends and silencing the warning. Monthly grading stays per-provider — those are hard per-account walls no failover borrows against.

## Tests

489 passing. Three new, including the post-UTC-midnight case that was silently unguarded and one built from the exact production numbers above.