### PR TITLE
feat(mail): record which quota wall a deferral hit, and when it frees

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -76,6 +76,20 @@ def _parse_ts(iso: str | None) -> datetime | None:
         return None
 
 
+def _walls_detail(walls: dict | None) -> str:
+    """" (hourly 2, daily 1 — ...)" for a day's deferrals, or "" when the
+    split is unknown. The daily wall is the one that costs appointments, so it
+    gets the sentence; an hourly deferral is cleared by the next cycle and an
+    outage by the next retry."""
+    if not walls:
+        return ""
+    bits = [f"{w} {walls[w]}" for w in ("outage", "hourly", "daily") if walls.get(w)]
+    tail = ""
+    if walls.get("daily"):
+        tail = (" — the daily ones wait for the rolling 24h window, and the "
+                "slot may be gone by then")
+    return f" ({', '.join(bits)}{tail})"
+
 def summary_anomalies(s: dict, *, now: datetime) -> list[str]:
     """Short, human-readable lines for anything worth a look — empty when all is
     healthy. Pure: reads a stats() dict + injected `now`.
@@ -129,7 +143,8 @@ def summary_anomalies(s: dict, *, now: datetime) -> list[str]:
     #    percentages say.
     deferred = s.get("deferrals_today") or 0
     if deferred:
-        out.append(f"{deferred} notification(s) deferred today for lack of quota")
+        out.append(f"{deferred} notification(s) deferred today for lack of quota"
+                   f"{_walls_detail(s.get('deferral_walls_today'))}")
 
     # 2. Deliverability. This is the one failure in this list that cannot be
     #    fixed after the fact: once large receivers throttle the sending domain
@@ -241,7 +256,8 @@ def render_summary_email(s: dict, *, now: datetime, anomalies: list[str],
         lines.append(f"  Gating 24h    {roll_used}/{roll_cap} combined rolling")
     if s.get("deferrals_today") or s.get("deferrals_7d"):
         lines.append(f"  Deferred      today {s.get('deferrals_today', 0)}"
-                     f" · 7d {s.get('deferrals_7d', 0)}")
+                     f" · 7d {s.get('deferrals_7d', 0)}"
+                     f"{_walls_detail(s.get('deferral_walls_today'))}")
 
     admin = f"{base_url.rstrip('/')}/admin" if base_url else "/admin"
     lines += ["", f"Full dashboard → {admin}"]
@@ -403,6 +419,8 @@ def _deliverability(conn: sqlite3.Connection, cfg=None) -> dict:
     return out
 
 def stats(conn: sqlite3.Connection, cfg=None) -> dict:
+    from app.mail import deferral_walls_today, last_deferral
+
     def scalar(q, *args):
         row = conn.execute(q, args).fetchone()
         return row[0] if row else 0
@@ -632,6 +650,8 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         "deferrals_7d":
             scalar("SELECT COALESCE(SUM(n), 0) FROM email_deferral_counts "
                    "WHERE day >= date('now','-7 days')"),
+        "last_deferral": last_deferral(conn),
+        "deferral_walls_today": deferral_walls_today(conn),
         "last_failure_alert_at": meta_val("last_failure_alert_at"),
         "last_housekeeping_at": meta_val("last_housekeeping_at"),
         "last_backup_at":       meta_val("last_backup_at"),

--- a/app/db.py
+++ b/app/db.py
@@ -3,7 +3,7 @@ import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS subscriptions (
@@ -60,6 +60,23 @@ CREATE TABLE IF NOT EXISTS email_deferral_counts (
   day TEXT PRIMARY KEY,
   n   INTEGER NOT NULL DEFAULT 0
 );
+
+-- One row per cycle that deferred, saying which wall it hit. The counter above
+-- cannot tell a deferral against Mailjet's hourly warm-up cap — cleared by the
+-- next cycle, nobody notices — from one against the combined daily pool, which
+-- holds until the rolling 24h window frees a slot, by which time the
+-- appointment is usually gone. `wall` is 'hourly', 'daily' or 'outage' (every
+-- provider with room failed at the HTTP level); `frees_at` is when the
+-- tightest-bound provider gets one slot back, i.e. the earliest a retry can
+-- succeed. Pruned after 90 days; the per-day counter keeps the totals.
+CREATE TABLE IF NOT EXISTS email_deferrals (
+  id       INTEGER PRIMARY KEY AUTOINCREMENT,
+  at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  n        INTEGER NOT NULL,
+  wall     TEXT NOT NULL,
+  frees_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_email_deferrals_at ON email_deferrals(at);
 
 -- Per-address delivery failures. A provider that parses our request and still
 -- rejects it (HTTP 400/422) is refusing the recipient, not failing itself; once

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -21,6 +21,7 @@ def run_once(conn: sqlite3.Connection) -> None:
     _send_heartbeats(conn, cfg, milestone_days=60, milestone_col="heartbeat_60d_at")
     _prune_seen_slots(conn)
     _prune_idempotency(conn)
+    _prune_deferrals(conn)
     _prune_email_failures(conn)
     _prune_suppressions(conn, cfg)
     _prune_slots_cache(conn)
@@ -126,6 +127,11 @@ def _prune_seen_slots(conn):
 
 def _prune_idempotency(conn):
     conn.execute("DELETE FROM sent_idempotency WHERE sent_at < datetime('now','-14 days')")
+
+def _prune_deferrals(conn):
+    # The event log is one row per deferring cycle — bounded by the poll
+    # cadence, but unbounded in time. The per-day counter keeps the totals.
+    conn.execute("DELETE FROM email_deferrals WHERE at < datetime('now','-90 days')")
 
 def _prune_email_failures(conn):
     """The bounce counter is keyed by the address itself, so it has to age out

--- a/app/mail.py
+++ b/app/mail.py
@@ -505,6 +505,7 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
 
     remaining = list(pending)
     refused: list[Outgoing] = []
+    unusable: set[str] = set()   # providers that had room and still failed
     for name, send_fn, batch_size, limits in _providers(cfg):
         # Anything the previous provider refused gets one more chance here: a
         # content rejection can be provider-specific (a domain one provider
@@ -540,6 +541,7 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
                 # Leave whatever is left claimed (still 'pending') so the next
                 # provider can take it. If every provider fails, the trailing
                 # deferral block releases them.
+                unusable.add(name)
                 break
         if (len(refused) >= _SYSTEMIC_REJECTION_MIN
                 and not result.sent_by_provider.get(name)):
@@ -548,6 +550,7 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
             # Hand the mail on to the next provider (or the deferral path at
             # the bottom) with no failure strikes recorded.
             remaining, refused = remaining + refused, []
+            unusable.add(name)
 
     if refused:
         # Refused by every provider that could try it. Release the claim so a
@@ -565,23 +568,106 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
         # the next cycle can retry — do NOT mark seen; the caller must skip
         # recording seen_slots for these so they resurface. One transaction so
         # the release is a single fsync, not one per deferred item.
+        wall, frees_at = _deferral_wall(conn, cfg, unusable)
         with transaction(conn):
             conn.executemany("DELETE FROM sent_idempotency WHERE idem_key=?",
                              [(c.idem_key,) for c in remaining])
-            _record_deferrals(conn, len(remaining))
+            _record_deferrals(conn, len(remaining), wall, frees_at)
         result.deferred = len(remaining)
     return result
 
-def _record_deferrals(conn: sqlite3.Connection, n: int) -> None:
-    """Bump the durable per-UTC-day deferral counter. Deferral is the only event
-    that means a subscriber was not told about a slot, and nothing else records
-    it: the idempotency claim is deleted on the way out and the digest itself is
-    never written anywhere."""
+# Which wall a deferral hit. Ordered by how soon it gives way.
+WALL_OUTAGE = "outage"   # a provider had room and failed: next cycle retries
+WALL_HOURLY = "hourly"   # Mailjet's warm-up throttle: clears within the hour
+WALL_DAILY = "daily"     # the combined pool: waits for the rolling 24h window
+
+def _deferral_wall(conn: sqlite3.Connection, cfg,
+                   unusable: set[str]) -> tuple[str, str | None]:
+    """Which wall this deferral hit, and when it gives way.
+
+    "3 deferred" on the counter reads the same for two opposite situations.
+    Against Mailjet's hourly warm-up cap the next cycle sends them and nobody
+    notices. Against the combined daily pool nothing moves until the rolling
+    24h window frees a slot — hours away, by which time the appointment is
+    gone and that subscriber genuinely never heard. So say which, and when: for
+    every provider take the tightest window that is spent, work out when its
+    oldest send ages out (one slot back), and report the earliest across
+    providers, because that is the first moment a retry can succeed. A
+    provider that had room and failed at the HTTP level is an outage — the
+    next cycle retries it, so it is the earliest of all.
+    """
+    best: tuple[str, str | None] | None = None
+    for name, _send_fn, _batch_size, limits in _providers(cfg):
+        if name in unusable:
+            return WALL_OUTAGE, None
+        spent = [(window, limit) for limit, window in limits
+                 if limit - _window_used(conn, name, window) <= 0]
+        if not spent:
+            continue
+        window, _limit = min(spent)          # shortest spent window frees first
+        row = conn.execute(
+            "SELECT datetime(MIN(sent_at), ?) AS t FROM sent_idempotency "
+            "WHERE provider = ? AND sent_at > datetime('now', ?)",
+            (f"+{window} seconds", name, f"-{window} seconds"),
+        ).fetchone()
+        frees_at = row["t"] if row else None  # None: cap is 0, never frees
+        wall = WALL_HOURLY if window <= 3600 else WALL_DAILY
+        if best is None or (frees_at or "9") < (best[1] or "9"):
+            best = (wall, frees_at)
+    return best or (WALL_OUTAGE, None)
+
+def _record_deferrals(conn: sqlite3.Connection, n: int, wall: str = WALL_DAILY,
+                      frees_at: str | None = None) -> None:
+    """Bump the durable per-UTC-day deferral counter and log the event with
+    the wall it hit. Deferral is the only event that means a subscriber was not
+    told about a slot, and nothing else records it: the idempotency claim is
+    deleted on the way out and the digest itself is never written anywhere."""
     conn.execute(
         "INSERT INTO email_deferral_counts (day, n) VALUES (date('now'), ?) "
         "ON CONFLICT (day) DO UPDATE SET n = n + excluded.n",
         (n,),
     )
+    conn.execute(
+        "INSERT INTO email_deferrals (n, wall, frees_at) VALUES (?, ?, ?)",
+        (n, wall, frees_at),
+    )
+
+def last_deferral(conn: sqlite3.Connection) -> dict | None:
+    """The most recent deferral event: at, n, wall, frees_at (all UTC)."""
+    try:
+        row = conn.execute(
+            "SELECT at, n, wall, frees_at FROM email_deferrals "
+            "ORDER BY id DESC LIMIT 1").fetchone()
+    except sqlite3.OperationalError:
+        return None  # pre-migration DB
+    return dict(row) if row else None
+
+def deferral_walls_today(conn: sqlite3.Connection) -> dict[str, int]:
+    """Today's (UTC) deferrals split by the wall they hit, e.g.
+    {'hourly': 2, 'daily': 1}."""
+    try:
+        rows = conn.execute(
+            "SELECT wall, SUM(n) AS n FROM email_deferrals "
+            "WHERE at >= date('now') GROUP BY wall").fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    return {r["wall"]: r["n"] for r in rows}
+
+def describe_deferral(d: dict) -> str:
+    """One sentence for humans about what a deferral event means."""
+    at = (d.get("at") or "")[:16]
+    frees = (d.get("frees_at") or "")[:16]
+    wall = d.get("wall")
+    if wall == WALL_OUTAGE:
+        return (f"At {at} UTC a provider with quota left failed outright — an "
+                "outage, not the quota; the next cycle retries.")
+    if wall == WALL_HOURLY:
+        return (f"At {at} UTC they hit an hourly cap (Mailjet's warm-up "
+                f"throttle); a slot frees at {frees or '?'} UTC, so the next "
+                "cycles clear them.")
+    return (f"At {at} UTC they hit the daily pool; the rolling 24h window frees "
+            f"a slot at {frees or '?'} UTC — every cycle until then re-defers "
+            "them, and a slot taken in the meantime is gone.")
 
 def deferrals_today(conn: sqlite3.Connection) -> int:
     try:
@@ -659,6 +745,9 @@ def maybe_quota_alert(conn: sqlite3.Connection, cfg, *, deferred: int) -> None:
                "subscribers were not told about a slot. They are re-sent next "
                "cycle, longest-waiting first, but a slot taken in the meantime "
                "is simply gone.")
+        last = last_deferral(conn)
+        if last:
+            why += " " + describe_deferral(last)
     else:
         subject = "[buergerwecker] email quota running low"
         why = ("Nothing was deferred — every subscriber was notified. This is "

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -203,7 +203,8 @@
       <tr>
         <td class="k">deferred</td>
         <td class="v"><span{% if s.deferrals_today %} class="quota-hot"{% endif %}>today {{ s.deferrals_today }}</span> · 7d {{ s.deferrals_7d }}
-          <span class="adm-muted">· notifications the quota could not send — re-tried next cycle, longest wait first</span></td>
+          {%- if s.last_deferral %} · last {{ s.last_deferral.at[11:16] }} UTC, {{ s.last_deferral.n }} against the <span{% if s.last_deferral.wall == 'daily' %} class="quota-hot"{% endif %}>{{ s.last_deferral.wall }} wall</span>{% if s.last_deferral.frees_at %}, frees {{ s.last_deferral.frees_at[:16] }} UTC{% endif %}{% endif %}
+          <span class="adm-muted">· notifications the quota could not send — re-tried next cycle, longest wait first · an hourly wall clears within the hour, a daily wall waits for the rolling 24h window</span></td>
       </tr>
       {# per-provider rows follow in EMAIL_PROVIDER_ORDER — the fallback chain #}
       {% for p, u in s.email_usage.items() %}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -170,6 +170,15 @@ failing:
   `email_deferral_counts` per UTC day — visible on `/admin`, in the ops summary,
   and in the alert mail. That counter is the **only** record that a subscriber
   was not told about a slot; nothing else persists it.
+- **A deferral also says which wall it hit.** `email_deferrals` logs each
+  deferring cycle with `wall` = `hourly` (Mailjet's warm-up throttle — the next
+  cycles clear it), `daily` (the combined pool — nothing moves until the rolling
+  24h window frees a slot, and the appointment is usually gone by then) or
+  `outage` (a provider with room failed; the next cycle retries), plus
+  `frees_at`, the earliest moment a retry can succeed. `/admin` shows the last
+  event next to the counter and the ops summary splits the day's total by wall:
+  "3 deferred" against the hourly wall is noise, against the daily wall it is
+  the case for a per-subscriber daily cap.
 - **The deferred tail rotates.** Batches are filled in list order, so without
   care the same subscribers land at the back of every saturated cycle.
   `flush_digests` sorts by `last_notified_at` (never-notified first), and a

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -591,3 +591,38 @@ def test_anomaly_deferral_reported_even_below_quota_thresholds():
     }), now=NOW)
     assert any("deferred today" in x for x in a)
     assert not any("quota at" in x for x in a)
+
+
+def test_stats_expose_the_wall_behind_the_deferral_count(tmp_path):
+    from types import SimpleNamespace
+    conn = connect(str(tmp_path / "d.db")); init_schema(conn)
+    conn.execute("INSERT INTO email_deferral_counts (day, n) VALUES (date('now'), 3)")
+    conn.executemany(
+        "INSERT INTO email_deferrals (n, wall, frees_at) VALUES (?, ?, ?)",
+        [(2, "hourly", "2026-08-26 13:05:00"), (1, "daily", "2026-08-27 09:31:00")])
+    s = stats(conn, SimpleNamespace(mailjet_monthly_quota=6000, mailjet_daily_quota=200))
+    assert s["deferral_walls_today"] == {"hourly": 2, "daily": 1}
+    assert s["last_deferral"]["wall"] == "daily"
+    assert s["last_deferral"]["frees_at"] == "2026-08-27 09:31:00"
+
+
+def test_anomaly_and_summary_split_deferrals_by_wall():
+    a = summary_anomalies(_summary_stats(deferrals_today=3, deferral_walls_today={
+        "hourly": 2, "daily": 1}), now=NOW)
+    line = next(x for x in a if "deferred today" in x)
+    assert "hourly 2, daily 1" in line and "rolling 24h window" in line
+    text = render_summary_email(_summary_stats(deferrals_today=3, deferrals_7d=3,
+                                               deferral_walls_today={"hourly": 3}),
+                                now=NOW, anomalies=[])
+    d = _line(text, "Deferred")
+    assert "hourly 3" in d and "rolling 24h window" not in d   # nothing lost
+
+
+def test_admin_page_shows_the_last_deferral_and_its_wall(client):
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("INSERT INTO email_deferral_counts (day, n) VALUES (date('now'), 1)")
+    conn.execute("INSERT INTO email_deferrals (at, n, wall, frees_at) VALUES "
+                 "('2026-08-26 12:05:11', 1, 'daily', '2026-08-27 09:31:00')")
+    html = client.get("/admin?token=admin-tok").data.decode()
+    assert "last 12:05 UTC, 1 against the" in html
+    assert "daily wall" in html and "frees 2026-08-27 09:31 UTC" in html

--- a/tests/test_send_batch.py
+++ b/tests/test_send_batch.py
@@ -670,3 +670,111 @@ def test_quota_alert_ignores_new_providers_without_keys(db, monkeypatch):
                                    brevo_daily_quota=100, sweego_daily_quota=100),
                           deferred=0)
     snd.assert_not_called()
+
+
+# --- Which wall a deferral hit ------------------------------------------------
+# "3 deferred" against Mailjet's hourly warm-up cap clears on the next cycle;
+# against the combined daily pool it waits for the rolling 24h window, by which
+# time the slot is gone. The counter cannot tell them apart — the event log can.
+
+def _oldest_plus(db, provider, seconds):
+    return db.execute(
+        "SELECT datetime(MIN(sent_at), ?) AS t FROM sent_idempotency "
+        "WHERE provider=?", (f"+{seconds} seconds", provider)).fetchone()["t"]
+
+
+def test_deferral_against_the_hourly_cap_says_so_and_when_it_frees(db):
+    from app.mail import last_deferral
+    cfg = _cfg(order=("mailjet",), mailjet_hourly_quota=2)  # daily unbounded
+    with patch("app.mail._call_mailjet_batch", return_value=200):
+        res = send_batch(db, _items(3), cfg)
+    assert res.deferred == 1
+    last = last_deferral(db)
+    assert last["wall"] == "hourly" and last["n"] == 1
+    # One slot comes back when the oldest send inside the window ages out.
+    assert last["frees_at"] == _oldest_plus(db, "mailjet", 3600)
+
+
+def test_deferral_against_the_daily_cap_is_the_expensive_one(db):
+    from app.mail import last_deferral
+    cfg = _cfg(order=("mailjet",), mailjet_hourly_quota=100, mailjet_daily_quota=2)
+    with patch("app.mail._call_mailjet_batch", return_value=200):
+        res = send_batch(db, _items(3), cfg)
+    assert res.deferred == 1
+    last = last_deferral(db)
+    assert last["wall"] == "daily"
+    assert last["frees_at"] == _oldest_plus(db, "mailjet", 86400)
+
+
+def test_both_windows_spent_reports_the_one_that_frees_first(db):
+    from app.mail import last_deferral
+    cfg = _cfg(order=("mailjet",), mailjet_hourly_quota=2, mailjet_daily_quota=2)
+    with patch("app.mail._call_mailjet_batch", return_value=200):
+        send_batch(db, _items(3), cfg)
+    assert last_deferral(db)["wall"] == "hourly"
+
+
+def test_wall_is_the_earliest_across_providers(db, brevo_sweego_on):
+    """With Mailjet hourly-bound and Brevo daily-bound, the next cycle after
+    Mailjet's window frees can send again — so the deferral is hourly, whatever
+    Brevo's state. Flip it and it is daily."""
+    from app.mail import last_deferral
+    with patch("app.mail._call_mailjet_batch", return_value=200), \
+         patch("app.mail._call_brevo_batch", return_value=201):
+        res = send_batch(db, _items(4, "a"), _cfg(order=("mailjet", "brevo"),
+                                                  mailjet_hourly_quota=1,
+                                                  brevo_daily_quota=1))
+        assert res.deferred == 2 and last_deferral(db)["wall"] == "hourly"
+        db.execute("DELETE FROM sent_idempotency")
+        res = send_batch(db, _items(4, "b"), _cfg(order=("mailjet", "brevo"),
+                                                  mailjet_hourly_quota=100,
+                                                  mailjet_daily_quota=1,
+                                                  brevo_daily_quota=1))
+        assert res.deferred == 2 and last_deferral(db)["wall"] == "daily"
+
+
+def test_every_provider_failing_is_an_outage_not_a_wall(db, brevo_sweego_on):
+    from app.mail import last_deferral
+    with patch("app.mail._call_mailjet_batch", return_value=500), \
+         patch("app.mail._call_brevo_batch", return_value=503), \
+         patch("app.mail._call_sweego_batch", return_value=503):
+        res = send_batch(db, _items(3), _cfg())
+    assert res.deferred == 3
+    last = last_deferral(db)
+    assert last["wall"] == "outage" and last["frees_at"] is None
+
+
+def test_deferral_walls_are_split_per_utc_day(db):
+    from app.mail import deferral_walls_today
+    cfg = _cfg(order=("mailjet",), mailjet_hourly_quota=1)
+    with patch("app.mail._call_mailjet_batch", return_value=200):
+        send_batch(db, _items(3, "a"), cfg)   # 1 sent, 2 deferred (hourly)
+        send_batch(db, _items(1, "b"), cfg)   # 1 deferred (hourly)
+    db.execute("INSERT INTO email_deferrals (at, n, wall) "
+               "VALUES (datetime('now','-2 days'), 40, 'daily')")
+    assert deferral_walls_today(db) == {"hourly": 3}
+
+
+def test_deferral_readers_survive_a_pre_migration_db(db):
+    from app.mail import deferral_walls_today, last_deferral
+    db.execute("DROP TABLE email_deferrals")
+    assert last_deferral(db) is None
+    assert deferral_walls_today(db) == {}
+
+
+def test_quota_alert_names_the_wall(db):
+    db.execute("INSERT INTO email_deferrals (n, wall, frees_at) VALUES "
+               "(3, 'daily', datetime('now','+20 hours'))")
+    with patch("app.mail.send") as snd:
+        maybe_quota_alert(db, _cfg(), deferred=3)
+    body = snd.call_args.args[3]
+    assert "hit the daily pool" in body and "rolling 24h window frees a slot" in body
+
+
+def test_deferral_events_are_pruned_after_90_days(db):
+    from app.housekeeping import _prune_deferrals
+    db.execute("INSERT INTO email_deferrals (at, n, wall) VALUES "
+               "(datetime('now','-91 days'), 1, 'daily')")
+    db.execute("INSERT INTO email_deferrals (n, wall) VALUES (1, 'hourly')")
+    _prune_deferrals(db)
+    assert db.execute("SELECT COUNT(*) AS n FROM email_deferrals").fetchone()["n"] == 1


### PR DESCRIPTION
## Why

`email_deferral_counts` records that notifications were deferred, but not which wall they hit. A deferral against Mailjet's hourly warm-up cap clears on the next cycle; one against the combined daily pool waits for the rolling 24h window, by which time the slot is usually gone. Both render as the same "3 deferred" — today 3 of them, and no way to tell which kind.

## What

- New `email_deferrals` event log (schema v9): one row per deferring cycle with `n`, `wall` (`hourly` / `daily` / `outage`) and `frees_at` — the earliest moment a retry can succeed, taken across providers as the shortest spent window's oldest send plus the window length. A provider that had room and failed at the HTTP level is an `outage`, retried next cycle.
- `/admin` shows the last event next to the counter; the ops summary and its anomaly line split the day's total by wall; the quota alert mail says in one sentence what the deferral it reports means.
- Housekeeping prunes the log after 90 days. Readers tolerate a pre-migration DB.
- `docs/DEPLOY.md` documents the wall semantics.

## Tests

Nine new: hourly vs daily wall, both spent picks the one that frees first, earliest across providers (and its flip), all-providers-down is an outage, per-UTC-day split, pre-migration readers, alert body names the wall, 90-day prune; plus stats/anomaly/summary/template rendering in `test_admin.py`.