### PR TITLE
feat(mail): cap digests per subscriber at two per rolling 24h

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,11 @@ ADMIN_TOKEN=
 PUBLIC_BASE_URL=https://buergerwecker.de
 DEDUP_WINDOW_HOURS=24
 RATE_LIMIT_MINUTES=15
+# Hard ceiling on notification digests per subscriber in any rolling 24h. The
+# adaptive cadence stretches the interval but cannot bound the day; this can.
+# A held digest is dropped, not queued (its slots go out once the window
+# frees). 0 disables. Optional; 2 if unset.
+MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY=2
 SUBSCRIPTION_TTL_DAYS=90
 # Subscriptions to a service flagged `sensitive_services` in the catalog hold
 # special-category data (Art. 9 GDPR) and expire sooner. Optional; 30 if unset.

--- a/app/admin.py
+++ b/app/admin.py
@@ -258,6 +258,12 @@ def render_summary_email(s: dict, *, now: datetime, anomalies: list[str],
         lines.append(f"  Deferred      today {s.get('deferrals_today', 0)}"
                      f" · 7d {s.get('deferrals_7d', 0)}"
                      f"{_walls_detail(s.get('deferral_walls_today'))}")
+    if s.get("subscriber_cap"):
+        d = s.get("digests_per_sub_24h") or {}
+        lines.append(f"  Sub cap {s['subscriber_cap']}/24h  held today "
+                     f"{s.get('cap_holds_today', 0)} · capped now "
+                     f"{s.get('capped_now', 0)} · {d.get('digests', 0)} digests "
+                     f"to {d.get('subs', 0)} subscribers, {d.get('mean', 0)}/sub")
 
     admin = f"{base_url.rstrip('/')}/admin" if base_url else "/admin"
     lines += ["", f"Full dashboard → {admin}"]
@@ -424,6 +430,24 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
     def scalar(q, *args):
         row = conn.execute(q, args).fetchone()
         return row[0] if row else 0
+
+    # The per-subscriber daily cap and what it is doing: who is capped right
+    # now, who it held today, and the number it exists to move — digests per
+    # notified subscriber over the last 24h (was 4.6 with 57 of 103 at 5+
+    # when it was introduced).
+    sub_cap = getattr(cfg, "max_digests_per_subscriber_per_day", 0) or 0
+    capped_now = scalar(
+        "SELECT COUNT(*) FROM (SELECT subscription_id FROM digest_deliveries "
+        "WHERE sent_at > datetime('now','-24 hours') "
+        "GROUP BY subscription_id HAVING COUNT(*) >= ?)", sub_cap) if sub_cap else 0
+    row = conn.execute(
+        "SELECT COUNT(DISTINCT subscription_id) AS subs, COUNT(*) AS digests "
+        "FROM digest_deliveries WHERE sent_at > datetime('now','-24 hours')"
+    ).fetchone()
+    digests_per_sub = {
+        "subs": row["subs"], "digests": row["digests"],
+        "mean": round(row["digests"] / row["subs"], 1) if row["subs"] else 0,
+    }
 
     def meta_val(key):
         row = conn.execute("SELECT value FROM meta WHERE key=?", (key,)).fetchone()
@@ -652,6 +676,14 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
                    "WHERE day >= date('now','-7 days')"),
         "last_deferral": last_deferral(conn),
         "deferral_walls_today": deferral_walls_today(conn),
+        "subscriber_cap": sub_cap,
+        "cap_holds_today":
+            scalar("SELECT COUNT(*) FROM digest_cap_holds WHERE day = date('now')"),
+        "cap_holds_7d":
+            scalar("SELECT COUNT(DISTINCT subscription_id) FROM digest_cap_holds "
+                   "WHERE day >= date('now','-7 days')"),
+        "capped_now": capped_now,
+        "digests_per_sub_24h": digests_per_sub,
         "last_failure_alert_at": meta_val("last_failure_alert_at"),
         "last_housekeeping_at": meta_val("last_housekeeping_at"),
         "last_backup_at":       meta_val("last_backup_at"),

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,7 @@ class Config:
     dedup_window_hours: int
     rate_limit_minutes: int
     adaptive_rate_limit_max_multiplier: int
+    max_digests_per_subscriber_per_day: int
     subscription_ttl_days: int
     sensitive_subscription_ttl_days: int
     renewal_reminder_days_before: int
@@ -128,6 +129,15 @@ def load_config() -> Config:
         # put everyone back on the flat floor — the kill switch, no redeploy.
         adaptive_rate_limit_max_multiplier=int(
             os.environ.get("ADAPTIVE_RATE_LIMIT_MAX_MULTIPLIER", "8")),
+        # Hard ceiling on digests per subscriber in any rolling 24h. The
+        # adaptive ladder only stretches the interval, and it disengages on
+        # exactly the earliest-slot-only tenants that produce most of the
+        # volume ("the earliest slot changed again", several times a day —
+        # the shape that draws spam complaints). A held digest is dropped,
+        # not queued: its slots stay unseen and go out in the first cycle
+        # after the window frees. 0 disables the cap.
+        max_digests_per_subscriber_per_day=int(
+            os.environ.get("MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY", "2")),
         subscription_ttl_days=_req_int("SUBSCRIPTION_TTL_DAYS"),
         # Special-category subscriptions (Art. 9 GDPR) expire sooner than
         # ordinary ones: the data is more sensitive, so it should exist for

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -4,7 +4,8 @@ from datetime import datetime, timedelta
 import requests
 from app.filters import matches
 from app.planning import build_plans
-from app.repo import active_subscriptions, has_seen_slot, reset_digest_streak
+from app.repo import (active_subscriptions, digests_in_window, has_seen_slot,
+                      record_cap_hold, reset_digest_streak)
 from app.scrapers import get_scraper
 from app.http_session import CountingSession
 from app.models import Slot
@@ -338,6 +339,15 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
                 candidates.append(slot)
                 candidate_keys.append(key)
         if not candidates:
+            continue
+        # The per-subscriber daily cap, checked only once there is something
+        # to send so a hold always means a real digest was held. Nothing is
+        # recorded as seen and last_notified_at is not stamped: the first
+        # cycle after the rolling window frees re-evaluates the live slots
+        # and sends whatever is still open — never a queued, stale digest.
+        cap = getattr(cfg, "max_digests_per_subscriber_per_day", 0)
+        if cap and digests_in_window(conn, sub.id) >= cap:
+            record_cap_hold(conn, sub.id)
             continue
         # No per-slot slots_cache writes anymore: Smart-CJM bookings are
         # session-bound (the step machine rejects /booking without walking

--- a/app/db.py
+++ b/app/db.py
@@ -85,9 +85,10 @@ CREATE INDEX IF NOT EXISTS idx_email_deferrals_at ON email_deferrals(at);
 CREATE TABLE IF NOT EXISTS digest_deliveries (
   subscription_id INTEGER NOT NULL,
   sent_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (subscription_id, sent_at),
   FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
 );
+CREATE INDEX IF NOT EXISTS idx_digest_deliveries_sub_at
+  ON digest_deliveries(subscription_id, sent_at);
 
 -- Subscribers the cap held back, one row per subscriber per UTC day. A held
 -- digest is not queued: its slots stay unseen and go out once the window
@@ -281,19 +282,26 @@ def init_schema(conn: sqlite3.Connection) -> None:
     # The per-subscriber cap counts digest_deliveries over the last 24h. A
     # migrated DB has none, which would lift the cap for everyone on the first
     # day — seed it once from seen_slots, where every delivered digest wrote
-    # its slots under one timestamp, so distinct minutes ≈ digests. The
-    # (subscription_id, sent_at) key plus OR IGNORE keeps the web workers and
-    # the poller from seeding twice when they all start on the same `up -d`.
-    empty = conn.execute(
-        "SELECT NOT EXISTS (SELECT 1 FROM digest_deliveries)"
-    ).fetchone()[0]
-    if empty:
-        conn.execute(
-            "INSERT OR IGNORE INTO digest_deliveries (subscription_id, sent_at) "
-            "SELECT subscription_id, MIN(sent_at) FROM seen_slots "
-            "WHERE sent_at > datetime('now','-1 day') "
-            "GROUP BY subscription_id, strftime('%Y-%m-%d %H:%M', sent_at)"
-        )
+    # its slots under one timestamp, so distinct minutes ≈ digests. The web
+    # workers and the poller all run this on the same `up -d`; BEGIN IMMEDIATE
+    # takes the write lock before the emptiness check, so the second process
+    # waits and then sees the seed instead of adding its own.
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        empty = conn.execute(
+            "SELECT NOT EXISTS (SELECT 1 FROM digest_deliveries)"
+        ).fetchone()[0]
+        if empty:
+            conn.execute(
+                "INSERT INTO digest_deliveries (subscription_id, sent_at) "
+                "SELECT subscription_id, MIN(sent_at) FROM seen_slots "
+                "WHERE sent_at > datetime('now','-1 day') "
+                "GROUP BY subscription_id, strftime('%Y-%m-%d %H:%M', sent_at)"
+            )
+        conn.execute("COMMIT")
+    except BaseException:
+        conn.execute("ROLLBACK")
+        raise
     conn.execute(
         "INSERT INTO meta (key, value) VALUES ('schema_version', ?) "
         "ON CONFLICT (key) DO UPDATE SET value=excluded.value, "

--- a/app/db.py
+++ b/app/db.py
@@ -3,7 +3,7 @@ import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS subscriptions (
@@ -77,6 +77,28 @@ CREATE TABLE IF NOT EXISTS email_deferrals (
   frees_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_email_deferrals_at ON email_deferrals(at);
+
+-- One row per delivered digest. subscriptions.last_notified_at only keeps the
+-- latest, and the per-subscriber daily cap (MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY)
+-- needs to count them over a rolling 24h window. Goes with the subscription;
+-- housekeeping prunes after 7 days.
+CREATE TABLE IF NOT EXISTS digest_deliveries (
+  subscription_id INTEGER NOT NULL,
+  sent_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (subscription_id, sent_at),
+  FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+);
+
+-- Subscribers the cap held back, one row per subscriber per UTC day. A held
+-- digest is not queued: its slots stay unseen and go out once the window
+-- frees. This is the measurement behind the cap's value, so it deliberately
+-- has no FOREIGN KEY — a subscriber who churns the same day still counts.
+-- Pruned after 90 days.
+CREATE TABLE IF NOT EXISTS digest_cap_holds (
+  day             TEXT NOT NULL,
+  subscription_id INTEGER NOT NULL,
+  PRIMARY KEY (day, subscription_id)
+);
 
 -- Per-address delivery failures. A provider that parses our request and still
 -- rejects it (HTTP 400/422) is refusing the recipient, not failing itself; once
@@ -255,6 +277,22 @@ def init_schema(conn: sqlite3.Connection) -> None:
             "INSERT OR IGNORE INTO email_send_counts (provider, day, n) "
             "SELECT provider, date(sent_at), COUNT(*) FROM sent_idempotency "
             "WHERE provider != 'pending' GROUP BY provider, date(sent_at)"
+        )
+    # The per-subscriber cap counts digest_deliveries over the last 24h. A
+    # migrated DB has none, which would lift the cap for everyone on the first
+    # day — seed it once from seen_slots, where every delivered digest wrote
+    # its slots under one timestamp, so distinct minutes ≈ digests. The
+    # (subscription_id, sent_at) key plus OR IGNORE keeps the web workers and
+    # the poller from seeding twice when they all start on the same `up -d`.
+    empty = conn.execute(
+        "SELECT NOT EXISTS (SELECT 1 FROM digest_deliveries)"
+    ).fetchone()[0]
+    if empty:
+        conn.execute(
+            "INSERT OR IGNORE INTO digest_deliveries (subscription_id, sent_at) "
+            "SELECT subscription_id, MIN(sent_at) FROM seen_slots "
+            "WHERE sent_at > datetime('now','-1 day') "
+            "GROUP BY subscription_id, strftime('%Y-%m-%d %H:%M', sent_at)"
         )
     conn.execute(
         "INSERT INTO meta (key, value) VALUES ('schema_version', ?) "

--- a/app/digest.py
+++ b/app/digest.py
@@ -270,7 +270,8 @@ def flush_digests(conn: sqlite3.Connection, sink: list, cfg) -> None:
     if not sink:
         return
     from app.db import transaction
-    from app.repo import record_seen_slot, set_last_notified
+    from app.repo import (record_digest_delivery, record_seen_slot,
+                          set_last_notified)
     sink = sorted(sink, key=lambda q: str(q.subscription.last_notified_at or ""))
     result = send_batch(conn, [q.item for q in sink], cfg)
     for q in sink:
@@ -284,4 +285,5 @@ def flush_digests(conn: sqlite3.Connection, sink: list, cfg) -> None:
             for key in dict.fromkeys(keys):
                 record_seen_slot(conn, q.subscription.id, key)
             set_last_notified(conn, q.subscription.id, q.match_count)
+            record_digest_delivery(conn, q.subscription.id)
     maybe_quota_alert(conn, cfg, deferred=result.deferred)

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -22,6 +22,8 @@ def run_once(conn: sqlite3.Connection) -> None:
     _prune_seen_slots(conn)
     _prune_idempotency(conn)
     _prune_deferrals(conn)
+    _prune_digest_deliveries(conn)
+    _prune_cap_holds(conn)
     _prune_email_failures(conn)
     _prune_suppressions(conn, cfg)
     _prune_slots_cache(conn)
@@ -132,6 +134,15 @@ def _prune_deferrals(conn):
     # The event log is one row per deferring cycle — bounded by the poll
     # cadence, but unbounded in time. The per-day counter keeps the totals.
     conn.execute("DELETE FROM email_deferrals WHERE at < datetime('now','-90 days')")
+
+def _prune_digest_deliveries(conn):
+    # The cap reads a rolling 24h; a week keeps /admin's per-subscriber
+    # volume readable without holding a per-digest row forever.
+    conn.execute("DELETE FROM digest_deliveries "
+                 "WHERE sent_at < datetime('now','-7 days')")
+
+def _prune_cap_holds(conn):
+    conn.execute("DELETE FROM digest_cap_holds WHERE day < date('now','-90 days')")
 
 def _prune_email_failures(conn):
     """The bounce counter is keyed by the address itself, so it has to age out

--- a/app/repo.py
+++ b/app/repo.py
@@ -135,8 +135,8 @@ def has_seen_slot(conn: sqlite3.Connection, sub_id: int, slot_hash: str) -> bool
 
 def record_digest_delivery(conn: sqlite3.Connection, sub_id: int) -> None:
     """One delivered digest — what the per-subscriber daily cap counts."""
-    conn.execute("INSERT OR IGNORE INTO digest_deliveries (subscription_id) "
-                 "VALUES (?)", (sub_id,))
+    conn.execute("INSERT INTO digest_deliveries (subscription_id) VALUES (?)",
+                 (sub_id,))
 
 def digests_in_window(conn: sqlite3.Connection, sub_id: int, *,
                       hours: int = 24) -> int:

--- a/app/repo.py
+++ b/app/repo.py
@@ -133,6 +133,27 @@ def has_seen_slot(conn: sqlite3.Connection, sub_id: int, slot_hash: str) -> bool
         (sub_id, slot_hash),
     ).fetchone() is not None
 
+def record_digest_delivery(conn: sqlite3.Connection, sub_id: int) -> None:
+    """One delivered digest — what the per-subscriber daily cap counts."""
+    conn.execute("INSERT OR IGNORE INTO digest_deliveries (subscription_id) "
+                 "VALUES (?)", (sub_id,))
+
+def digests_in_window(conn: sqlite3.Connection, sub_id: int, *,
+                      hours: int = 24) -> int:
+    """Digests delivered to this subscriber in the last `hours` (rolling)."""
+    return conn.execute(
+        "SELECT COUNT(*) FROM digest_deliveries "
+        "WHERE subscription_id=? AND sent_at > datetime('now', ?)",
+        (sub_id, f"-{int(hours)} hours"),
+    ).fetchone()[0]
+
+def record_cap_hold(conn: sqlite3.Connection, sub_id: int) -> None:
+    """This subscriber had a digest ready and the cap held it back today
+    (UTC). Idempotent per day — a capped subscriber is re-evaluated every
+    cycle, and the record is 'was held', not 'how many cycles'."""
+    conn.execute("INSERT OR IGNORE INTO digest_cap_holds (day, subscription_id) "
+                 "VALUES (date('now'), ?)", (sub_id,))
+
 # --------------------------------------------------------------------------
 # Suppression list (see the email_suppressions comment in app/db.py).
 # --------------------------------------------------------------------------

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -206,6 +206,14 @@
           {%- if s.last_deferral %} · last {{ s.last_deferral.at[11:16] }} UTC, {{ s.last_deferral.n }} against the <span{% if s.last_deferral.wall == 'daily' %} class="quota-hot"{% endif %}>{{ s.last_deferral.wall }} wall</span>{% if s.last_deferral.frees_at %}, frees {{ s.last_deferral.frees_at[:16] }} UTC{% endif %}{% endif %}
           <span class="adm-muted">· notifications the quota could not send — re-tried next cycle, longest wait first · an hourly wall clears within the hour, a daily wall waits for the rolling 24h window</span></td>
       </tr>
+      {% if s.subscriber_cap %}
+      <tr>
+        <td class="k">per-subscriber cap</td>
+        <td class="v">{{ s.subscriber_cap }} per rolling 24h · held today <span{% if s.cap_holds_today %} class="quota-hot"{% endif %}>{{ s.cap_holds_today }}</span> subscriber(s) · 7d {{ s.cap_holds_7d }} · capped now {{ s.capped_now }}
+          {%- if s.digests_per_sub_24h and s.digests_per_sub_24h.subs %} · last 24h {{ s.digests_per_sub_24h.digests }} digests to {{ s.digests_per_sub_24h.subs }} subscribers, {{ s.digests_per_sub_24h.mean }}/sub{% endif %}
+          <span class="adm-muted">· a held digest is dropped, not queued — its slots stay unseen and go out in the first cycle after that subscriber's window frees · MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY, 0 disables</span></td>
+      </tr>
+      {% endif %}
       {# per-provider rows follow in EMAIL_PROVIDER_ORDER — the fallback chain #}
       {% for p, u in s.email_usage.items() %}
         <tr>

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -178,7 +178,20 @@ failing:
   `frees_at`, the earliest moment a retry can succeed. `/admin` shows the last
   event next to the counter and the ops summary splits the day's total by wall:
   "3 deferred" against the hourly wall is noise, against the daily wall it is
-  the case for a per-subscriber daily cap.
+  the case for a tighter per-subscriber daily cap.
+- **Each subscriber gets at most `MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY` digests
+  per rolling 24h** (default 2, `0` disables — env only, no redeploy). The
+  adaptive cadence only stretches the interval and disengages on the
+  earliest-slot-only tenants that generate most of the volume, so before the
+  cap the mean was 4.6 digests per notified subscriber per day with more than
+  half at 5+. A held digest is **dropped, not queued**: nothing is recorded as
+  seen, so the first cycle after the subscriber's window frees re-evaluates the
+  live slots and sends what is still open. `/admin` shows who is capped right
+  now, how many subscribers were held today (`digest_cap_holds`, one row per
+  subscriber per UTC day, 90-day prune) and the digests-per-subscriber number
+  the cap exists to move; the ops summary carries the same line. Deliveries
+  are counted in `digest_deliveries` (7-day prune), seeded once at migration
+  from `seen_slots` so the cap binds from the first cycle.
 - **The deferred tail rotates.** Batches are filled in list order, so without
   care the same subscribers land at the back of every saturated cycle.
   `flush_digests` sorts by `last_notified_at` (never-notified first), and a

--- a/tests/test_adaptive_rate_limit.py
+++ b/tests/test_adaptive_rate_limit.py
@@ -23,6 +23,9 @@ def db(tmp_path, monkeypatch):
         "SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY": "99",
         "DEVELOPER_EMAIL": "dev@x", "KOFI_URL": "https://k",
         "BREVO_DAILY_QUOTA": "300", "MAILJET_HOURLY_QUOTA": "100",
+        # These tests measure the ladder alone; the per-subscriber daily cap
+        # (tests/test_subscriber_cap.py) would hold the runs they build.
+        "MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY": "0",
     }.items():
         monkeypatch.setenv(k, v)
     conn = connect(str(tmp_path / "t.db"))

--- a/tests/test_subscriber_cap.py
+++ b/tests/test_subscriber_cap.py
@@ -1,0 +1,223 @@
+"""The per-subscriber daily cap: at most MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY
+digests per rolling 24h, whatever the adaptive cadence would allow. A held
+digest is dropped, not queued — its slots stay unseen and go out in the first
+cycle after the window frees."""
+from datetime import time
+from unittest.mock import patch, MagicMock
+import pytest
+from app.db import connect, init_schema
+from app.models import Filter, Slot
+from app.repo import insert_pending, confirm, digests_in_window
+from app.cycle import run_cycle
+from datetime import datetime
+from app.admin import stats, render_summary_email
+
+
+_ENV = {
+    "MAILJET_API_KEY": "m", "MAILJET_API_SECRET": "m", "MAILJET_FROM_EMAIL": "x@x",
+    "MAILJET_FROM_NAME": "x", "MAILJET_DAILY_QUOTA": "6000", "BREVO_API_KEY": "b",
+    "TOKEN_SECRET_PRIMARY": "x" * 32, "TOKEN_SECRET_PREVIOUS": "",
+    "ADMIN_TOKEN": "a" * 32, "PUBLIC_BASE_URL": "https://x",
+    "DEDUP_WINDOW_HOURS": "24", "RATE_LIMIT_MINUTES": "15",
+    "SUBSCRIPTION_TTL_DAYS": "90", "RENEWAL_REMINDER_DAYS_BEFORE": "10",
+    "MAX_PLANS_PER_CITY": "10", "PARSER_CANARY_THRESHOLD_HOURS": "2",
+    "SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR": "99",
+    "SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY": "99",
+    "DEVELOPER_EMAIL": "dev@x", "KOFI_URL": "https://k",
+    "BREVO_DAILY_QUOTA": "300", "MAILJET_HOURLY_QUOTA": "100",
+    # The adaptive ladder off, so only the cap decides who is held.
+    "ADAPTIVE_RATE_LIMIT_MAX_MULTIPLIER": "1",
+    "MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY": "2",
+}
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    for k, v in _ENV.items():
+        monkeypatch.setenv(k, v)
+    conn = connect(str(tmp_path / "t.db"))
+    init_schema(conn)
+    return conn
+
+
+def _f():
+    return Filter(appointment_types=["svc-A"], locations="all",
+                  weekdays=[1, 2, 3, 4, 5, 6, 7],
+                  time_window_start=time(0, 0), time_window_end=time(23, 59))
+
+
+def _slot(i):
+    return Slot(f"2026-09-{(i % 28) + 1:02d}", f"{8 + (i % 12):02d}:{i % 60:02d}",
+                "loc-1", "svc-A", f"tok-{i}")
+
+
+def _sub(db, email="a@example.com"):
+    sid = insert_pending(db, email=email, city="leipzig", language="de",
+                         filter_=_f(), ttl_days=90)
+    confirm(db, sid)
+    return sid
+
+
+def _cycle(db, slots, cycle_id):
+    scraper = MagicMock()
+    scraper.poll.return_value = slots
+    with patch("app.cycle.get_scraper", return_value=scraper), \
+         patch("app.mail._call_mailjet_batch", return_value=200) as mb, \
+         patch("app.mail._call_brevo_batch", return_value=201):
+        run_cycle(db, max_plans_per_city=10, rate_limit_minutes=15,
+                  cycle_id=cycle_id)
+    return mb.call_count
+
+
+def _age_last_notified(db, sid, minutes):
+    db.execute(f"UPDATE subscriptions SET last_notified_at="
+               f"datetime('now','-{minutes} minutes') WHERE id=?", (sid,))
+
+
+def _seen(db, sid):
+    return db.execute("SELECT COUNT(*) FROM seen_slots WHERE subscription_id=?",
+                      (sid,)).fetchone()[0]
+
+
+def _holds(db):
+    return [tuple(r) for r in
+            db.execute("SELECT day, subscription_id FROM digest_cap_holds").fetchall()]
+
+
+def test_third_digest_in_24h_is_held_and_its_slots_stay_unseen(db):
+    sid = _sub(db)
+    assert _cycle(db, [_slot(1)], "c1") == 1
+    _age_last_notified(db, sid, 16)
+    assert _cycle(db, [_slot(2)], "c2") == 1
+    assert digests_in_window(db, sid) == 2
+    _age_last_notified(db, sid, 16)
+    # Fresh slot, cadence allows it, the cap does not.
+    assert _cycle(db, [_slot(3)], "c3") == 0
+    assert _seen(db, sid) == 2          # slot 3 was not recorded as seen
+    assert _holds(db) == [(db.execute("SELECT date('now')").fetchone()[0], sid)]
+    # Re-evaluated every cycle while capped, recorded once per day.
+    _age_last_notified(db, sid, 16)
+    assert _cycle(db, [_slot(3)], "c4") == 0
+    assert len(_holds(db)) == 1
+
+
+def test_digest_goes_out_once_the_window_frees(db):
+    sid = _sub(db)
+    _cycle(db, [_slot(1)], "c1")
+    _age_last_notified(db, sid, 16)
+    _cycle(db, [_slot(2)], "c2")
+    _age_last_notified(db, sid, 16)
+    assert _cycle(db, [_slot(3)], "c3") == 0
+    # The oldest delivery ages out of the rolling window.
+    db.execute("UPDATE digest_deliveries SET sent_at=datetime('now','-25 hours') "
+               "WHERE rowid = (SELECT MIN(rowid) FROM digest_deliveries)")
+    assert _cycle(db, [_slot(3)], "c4") == 1
+    assert _seen(db, sid) == 3
+    assert digests_in_window(db, sid) == 2
+
+
+def test_a_capped_subscriber_with_nothing_new_is_not_a_hold(db):
+    sid = _sub(db)
+    _cycle(db, [_slot(1)], "c1")
+    _age_last_notified(db, sid, 16)
+    _cycle(db, [_slot(2)], "c2")
+    _age_last_notified(db, sid, 16)
+    # Same slots again: nothing to send, so nothing was held either.
+    assert _cycle(db, [_slot(1), _slot(2)], "c3") == 0
+    assert _holds(db) == []
+
+
+def test_zero_disables_the_cap(db, monkeypatch):
+    monkeypatch.setenv("MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY", "0")
+    sid = _sub(db)
+    for i in range(1, 5):
+        _age_last_notified(db, sid, 16)
+        assert _cycle(db, [_slot(i)], f"c{i}") == 1
+    assert _holds(db) == []
+
+
+def test_cap_is_per_subscriber(db):
+    a = _sub(db, "a@example.com")
+    b = _sub(db, "b@example.com")
+    assert _cycle(db, [_slot(1)], "c1") == 1     # one batch call, two mails
+    for sid in (a, b):
+        _age_last_notified(db, sid, 16)
+    _cycle(db, [_slot(2)], "c2")
+    # Only `a` gets a third delivery pre-loaded into its window.
+    db.execute("INSERT INTO digest_deliveries (subscription_id) VALUES (?)", (a,))
+    for sid in (a, b):
+        _age_last_notified(db, sid, 16)
+    # Wait — a already has 3 ≥ 2, b has 2 ≥ 2: both capped. Free b by ageing
+    # one of its deliveries out of the window.
+    db.execute("UPDATE digest_deliveries SET sent_at=datetime('now','-25 hours') "
+               "WHERE rowid = (SELECT MIN(rowid) FROM digest_deliveries "
+               "WHERE subscription_id=?)", (b,))
+    assert _cycle(db, [_slot(3)], "c3") == 1
+    assert _seen(db, b) == 3
+    assert _seen(db, a) == 2
+    assert [h[1] for h in _holds(db)] == [a]
+
+
+def test_migration_seeds_deliveries_from_seen_slots(db):
+    sid = _sub(db)
+    # Two digests' worth of seen_slots in the last day, one older.
+    for h, minutes in (("h1", 30), ("h2", 30), ("h3", 90), ("h4", 26 * 60)):
+        db.execute("INSERT INTO seen_slots (subscription_id, slot_hash, sent_at) "
+                   "VALUES (?, ?, datetime('now', ?))", (sid, h, f"-{minutes} minutes"))
+    db.execute("DELETE FROM digest_deliveries")
+    init_schema(db)
+    assert digests_in_window(db, sid) == 2
+    # Idempotent: a second init on a non-empty table adds nothing.
+    init_schema(db)
+    assert digests_in_window(db, sid) == 2
+
+
+def test_deliveries_go_with_the_subscription(db):
+    sid = _sub(db)
+    _cycle(db, [_slot(1)], "c1")
+    assert digests_in_window(db, sid) == 1
+    db.execute("DELETE FROM subscriptions WHERE id=?", (sid,))
+    assert db.execute("SELECT COUNT(*) FROM digest_deliveries").fetchone()[0] == 0
+
+
+def test_housekeeping_prunes_old_rows(db):
+    from app.housekeeping import _prune_digest_deliveries, _prune_cap_holds
+    sid = _sub(db)
+    db.execute("INSERT INTO digest_deliveries (subscription_id, sent_at) "
+               "VALUES (?, datetime('now','-8 days'))", (sid,))
+    db.execute("INSERT INTO digest_deliveries (subscription_id) VALUES (?)", (sid,))
+    db.execute("INSERT INTO digest_cap_holds (day, subscription_id) "
+               "VALUES (date('now','-91 days'), ?)", (sid,))
+    db.execute("INSERT INTO digest_cap_holds (day, subscription_id) "
+               "VALUES (date('now'), ?)", (sid,))
+    _prune_digest_deliveries(db)
+    _prune_cap_holds(db)
+    assert db.execute("SELECT COUNT(*) FROM digest_deliveries").fetchone()[0] == 1
+    assert db.execute("SELECT COUNT(*) FROM digest_cap_holds").fetchone()[0] == 1
+
+
+def test_admin_stats_and_summary_carry_the_cap(db):
+    from app.config import load_config
+    cfg = load_config()
+    sid = _sub(db)
+    _cycle(db, [_slot(1)], "c1")
+    _age_last_notified(db, sid, 16)
+    _cycle(db, [_slot(2)], "c2")
+    _age_last_notified(db, sid, 16)
+    _cycle(db, [_slot(3)], "c3")
+    s = stats(db, cfg)
+    assert s["subscriber_cap"] == 2
+    assert s["cap_holds_today"] == 1
+    assert s["cap_holds_7d"] == 1
+    assert s["capped_now"] == 1
+    assert s["digests_per_sub_24h"] == {"subs": 1, "digests": 2, "mean": 2.0}
+    text = render_summary_email(s, now=datetime.utcnow(), anomalies=[], base_url="https://x")
+    assert "Sub cap 2/24h  held today 1 · capped now 1 · 2 digests to 1 subscribers, 2.0/sub" in text
+
+
+def test_summary_is_silent_when_the_cap_is_off(db, monkeypatch):
+    monkeypatch.setenv("MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY", "0")
+    from app.config import load_config
+    s = stats(db, load_config())
+    assert s["subscriber_cap"] == 0 and s["capped_now"] == 0
+    assert "Sub cap" not in render_summary_email(s, now=datetime.utcnow(), anomalies=[], base_url="https://x")


### PR DESCRIPTION
Roadmap step 2 of deliverability-before-capacity: a hard per-subscriber daily cap.

**Why now.** Over the last 24h, 103 notified subscribers received 475 digests — 4.6 each, 57 of them at five or more. The adaptive ladder disengages on earliest-slot-only tenants (one office can never match more than one slot, and the streak breaks often enough that flow never engages), so it cannot bound the day. Yesterday the combined pool ran at 559/600.

**What it does.** `MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY` (default 2, `0` disables, env only) is a ceiling per rolling 24h, checked only once a subscriber has unseen slots to send — so a hold always means a real digest was held. A held digest is **dropped, not queued**: nothing is recorded as seen and `last_notified_at` is untouched, so the first cycle after the window frees re-evaluates the live slots and sends what is still open. Never a stale queued digest.

**Schema v10.** `digest_deliveries` (one row per delivered digest, cascades with the subscription, 7-day prune), seeded once at migration from `seen_slots` so the cap binds from the first cycle; the seed runs under `BEGIN IMMEDIATE` so the web workers and the poller starting on the same `up -d` cannot double-seed. `digest_cap_holds` (one row per held subscriber per UTC day, no FK on purpose, 90-day prune) is the measurement.

**Observability.** `/admin` gains a "per-subscriber cap" row (cap, held today, 7d, capped now, digests per notified subscriber over 24h); the ops summary carries the same line. Not an anomaly: it is a product decision, not a failure.

**Tests.** `tests/test_subscriber_cap.py` covers the hold, the unseen slots, the window freeing, no hold without candidates, per-subscriber isolation, cap off, the migration seed and its idempotence, cascade, prunes, and the admin/summary rendering. The ladder tests now run with the cap off.

**Deploy.** `up -d --build`; the migration runs at start. No `.env` change needed for the default of 2.
