### PR TITLE
feat(digests): the day key remembers the earliest time it reported

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
+from app.models import SeenKey, per_slot_key
+
 CATALOG_ROOT = Path(__file__).parent.parent / "catalog"
 
 # The shape of every tenant directory name, and the only thing load_catalog
@@ -78,32 +80,30 @@ class Catalog:
     #       for a vendor that lists real inventory: each slot is a separate
     #       perishable opportunity, and a subscriber told about a 09:00 that
     #       someone else then books genuinely wants to hear about the 14:00.
-    #   "day" — (day, office, service), the time dropped. Right for a tenant
-    #       that only ever exposes the *earliest* slot per office (TEVIS): the
-    #       "new" slot appearing after someone books is the same inventory
-    #       seen a minute later, not new availability, so notifying again says
-    #       nothing the subscriber does not already know.
+    #   "day" — (day, office, service), and the row remembers the earliest
+    #       time already reported on that day. Right for a tenant that only
+    #       ever exposes the *earliest* slot per office (TEVIS): the "new" slot
+    #       appearing after someone books is the same inventory seen a minute
+    #       later, not new availability, so a same-or-later time on a reported
+    #       day stays quiet. A strictly *earlier* time can only mean a
+    #       cancellation opened a better slot, and that goes out. See
+    #       `SeenKey` in app.models for the rule and `repo.has_seen_slot` for
+    #       where it is applied.
     #
     # Unknown values fall back to "slot", the never-suppress-anything side.
     #
-    # Known limitation, and the reason "day" is not simply switched on for
-    # every TEVIS tenant: the key cannot tell the earliest slot moving
-    # *forward* (someone booked — redundant news) from it moving *back* (a
-    # cancellation — real news). Once a day is recorded, an earlier slot
-    # opening on that same day is suppressed until housekeeping prunes the row
-    # at 7 days.
-    #
-    # This applies to muenster-kfz too — probed live 2026-08-25, its 2407 was a
-    # day out and its 2408 sixteen days out, so the tenant is NOT the same-day
-    # -only case an earlier draft of this comment assumed. Accepted knowingly:
-    # the loss is confined to a day that was reported, vanished, and reopened
-    # inside a week, against 4-8 mails a day telling subscribers about times on
-    # a day they had already been told about. Weigh it again for any other
-    # tenant, and prefer teaching the key "earlier than last told" over
-    # widening the rollout on this trade alone.
+    # Why the time is remembered at all: a plain date key cannot tell the
+    # earliest slot moving *forward* (someone booked — redundant) from it
+    # moving *back* (a cancellation — real news), and the first version of
+    # "day" suppressed both. That was accepted for muenster-kfz against 4-8
+    # mails a day, but it is a real loss on any tenant with a multi-day
+    # horizon — and Münster's own 2408 stood sixteen days out when probed on
+    # 2026-08-25 — so the horizon was never the discriminator. What decides
+    # whether a tenant should be "day" is only whether its vendor shows one
+    # slot per office; docs/DEPLOY.md has the query that measures it.
     notify_granularity: str = "slot"
 
-    def seen_key(self, slot) -> str:
+    def seen_key(self, slot) -> SeenKey:
         """The seen_slots key for `slot` under this tenant's granularity.
 
         Single source of truth: the cycle filters on it and the flush records
@@ -111,8 +111,9 @@ class Catalog:
         recording another means either a digest every cycle forever or silence
         forever, both silent.
         """
-        return (slot.day_hash() if self.notify_granularity == "day"
-                else slot.hash())
+        if self.notify_granularity == "day":
+            return SeenKey(slot.day_hash(), best_time=slot.time_str)
+        return per_slot_key(slot)
 
     def is_sensitive(self, uuid: str) -> bool:
         """Does subscribing to this service reveal special-category data?

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -8,7 +8,7 @@ from app.repo import (active_subscriptions, digests_in_window, has_seen_slot,
                       record_cap_hold, reset_digest_streak)
 from app.scrapers import get_scraper
 from app.http_session import CountingSession
-from app.models import Slot
+from app.models import SeenKey, Slot, per_slot_key
 from app.analytics import record_availability
 
 # Imported here so tests can monkey-patch it.
@@ -126,7 +126,7 @@ def _seen_key_fn(city: str):
             _KEY_FALLBACK_WARNED.add(city)
             print(f"notify_granularity: catalog unreadable for {city}, "
                   f"falling back to per-slot keys: {exc}", flush=True)
-        return Slot.hash
+        return per_slot_key
 
 
 def _due_cities(conn: sqlite3.Connection, cities: set[str]) -> set[str]:
@@ -305,7 +305,7 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
         # service) can surface from two resources (counters) or two overlapping
         # plans — Slot.hash() excludes the resource, so collapse them to one line.
         candidates: list[Slot] = []
-        candidate_keys: list[str] = []
+        candidate_keys: list[SeenKey] = []
         seen_in_cycle: set[str] = set()
         matched_total = 0
         if sub.city not in seen_key_fns:
@@ -332,9 +332,11 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
                 # What counts as already-told is the tenant's call, not the
                 # slot's: an earliest-slot-only tenant keys on the day, so the
                 # replacement slot that appears the moment someone books is
-                # not news. See Catalog.seen_key.
+                # not news — unless it is *earlier* than the time already
+                # reported, which only a cancellation can produce. See
+                # Catalog.seen_key and models.SeenKey.
                 key = seen_key(slot)
-                if has_seen_slot(conn, sub.id, key):
+                if has_seen_slot(conn, sub.id, key.key, at=key.best_time):
                     continue
                 candidates.append(slot)
                 candidate_keys.append(key)

--- a/app/db.py
+++ b/app/db.py
@@ -3,7 +3,7 @@ import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS subscriptions (
@@ -32,6 +32,10 @@ CREATE TABLE IF NOT EXISTS seen_slots (
   subscription_id INTEGER NOT NULL,
   slot_hash       TEXT NOT NULL,
   sent_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  -- HH:MM of the earliest slot reported under a key coarser than the slot
+  -- (a day key). NULL = the key names the slot exactly, or the row predates
+  -- the column: either way "already told, whatever the time".
+  best_time       TEXT,
   PRIMARY KEY (subscription_id, slot_hash),
   FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
 );
@@ -265,6 +269,12 @@ def init_schema(conn: sqlite3.Connection) -> None:
         "consecutive_digests": "INTEGER NOT NULL DEFAULT 0",
         "consent_special_at": "TIMESTAMP",
     })
+    # best_time: the earliest time told under a day key. Existing day-key rows
+    # get NULL, which has_seen_slot reads as "told at an unknown time" and
+    # keeps suppressing the whole day exactly as before the column existed —
+    # the migration can't recover a time the old key never stored, and those
+    # rows are pruned within 7 days anyway.
+    _add_missing_columns(conn, "seen_slots", {"best_time": "TEXT"})
     # Durable per-day send counters power the admin page's provider-quota view.
     # sent_idempotency only lives 14 days (housekeeping prune), so month-to-date
     # can't be derived from it — seed the counters once from whatever history is

--- a/app/digest.py
+++ b/app/digest.py
@@ -3,7 +3,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from app.i18n import t
-from app.models import Subscription, Slot
+from app.models import SeenKey, Subscription, Slot, per_slot_key
 from app.mail import (send, send_batch, maybe_quota_alert, Outgoing,
                       _idem_key)
 
@@ -186,13 +186,13 @@ class QueuedDigest:
     # computed by the caller that decided these slots were unseen. Carried
     # rather than recomputed so the check and the record cannot drift apart
     # under a tenant's notify_granularity. None = per-slot identity.
-    seen_keys: list[str] | None = None
+    seen_keys: list[SeenKey] | None = None
 
 def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
                 matched_slots: list[Slot], cycle_id: str, cfg,
                 sink: list | None = None,
                 match_count: int | None = None,
-                seen_keys: list[str] | None = None) -> None:
+                seen_keys: list[SeenKey] | None = None) -> None:
     """Render a digest and stage it for delivery. `cfg` is the loaded Config
     (passed in by callers that already have it loaded — never re-read from
     os.environ here). render_digest_text loads the per-city catalog itself.
@@ -256,7 +256,7 @@ def send_digest(*, conn: sqlite3.Connection, subscription: Subscription,
         # (unknown tenant) per-slot identity is the safe default.
         seen_keys=(list(seen_keys) if seen_keys is not None
                    else [(catalog.seen_key(s) if catalog is not None
-                          else s.hash())
+                          else per_slot_key(s))
                          for s in matched_slots]),
     )
     if sink is None:
@@ -290,11 +290,13 @@ def flush_digests(conn: sqlite3.Connection, sink: list, cfg) -> None:
             continue
         with transaction(conn):
             # Several slots can share one key at day granularity (the whole
-            # point), so write each distinct key once.
+            # point); record_seen_slot keeps the earliest time among them,
+            # so the order they are written in does not matter.
             keys = (q.seen_keys if q.seen_keys is not None
-                    else [slot.hash() for slot in q.slots])
+                    else [per_slot_key(slot) for slot in q.slots])
             for key in dict.fromkeys(keys):
-                record_seen_slot(conn, q.subscription.id, key)
+                record_seen_slot(conn, q.subscription.id, key.key,
+                                 key.best_time)
             set_last_notified(conn, q.subscription.id, q.match_count)
             record_digest_delivery(conn, q.subscription.id)
     maybe_quota_alert(conn, cfg, deferred=result.deferred)

--- a/app/models.py
+++ b/app/models.py
@@ -82,6 +82,32 @@ class Slot:
         payload = f"{self.date}|{self.location_uuid}|{self.service_uuid}"
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
+
+@dataclass(frozen=True)
+class SeenKey:
+    """What a delivered slot leaves behind in seen_slots, as decided by the
+    tenant's `notify_granularity` (see `Catalog.seen_key`).
+
+    `key` is the row identity. `best_time` is the slot's HH:MM when the key is
+    coarser than the slot — a day key — so the row remembers the earliest time
+    the subscriber was told about on that day. The rule the cycle applies
+    against it: a slot at the same or a later time is the same inventory seen
+    again and stays quiet; a strictly earlier one is a cancellation that opened
+    a better slot, and goes out. None means the key already names the slot
+    exactly (per-slot identity), so there is nothing to compare.
+
+    Zero-padded HH:MM strings sort as times do, which is what makes the
+    comparison a plain string one in both Python and SQL.
+    """
+    key: str
+    best_time: str | None = None
+
+
+def per_slot_key(slot: Slot) -> SeenKey:
+    """Per-slot identity — the default granularity, and the never-suppress-
+    anything fallback when a tenant's declaration cannot be read."""
+    return SeenKey(slot.hash())
+
 @dataclass(frozen=True)
 class Subscription:
     id: int

--- a/app/repo.py
+++ b/app/repo.py
@@ -121,17 +121,48 @@ def reset_digest_streak(conn: sqlite3.Connection, sub_id: int) -> None:
     conn.execute("UPDATE subscriptions SET consecutive_digests=0 WHERE id=?",
                  (sub_id,))
 
-def record_seen_slot(conn: sqlite3.Connection, sub_id: int, slot_hash: str) -> None:
+def record_seen_slot(conn: sqlite3.Connection, sub_id: int, slot_hash: str,
+                     best_time: str | None = None) -> None:
+    """Record that `sub_id` was told about `slot_hash`.
+
+    `best_time` is the slot's HH:MM under a key coarser than the slot (see
+    models.SeenKey). A row that already exists is only touched when the new
+    time is strictly earlier than the one it holds: the row then remembers the
+    better time, and its sent_at moves to now because a genuinely better slot
+    was just delivered. A same-or-later time, or no time at all, leaves the
+    row alone — including a row whose best_time is NULL, which means "told at
+    an unknown time" and must keep suppressing the whole day.
+    """
     conn.execute(
-        "INSERT OR IGNORE INTO seen_slots (subscription_id, slot_hash) VALUES (?,?)",
-        (sub_id, slot_hash),
+        "INSERT INTO seen_slots (subscription_id, slot_hash, best_time) "
+        "VALUES (?,?,?) "
+        "ON CONFLICT (subscription_id, slot_hash) DO UPDATE SET "
+        "  best_time=excluded.best_time, sent_at=CURRENT_TIMESTAMP "
+        "WHERE excluded.best_time < seen_slots.best_time",
+        (sub_id, slot_hash, best_time),
     )
 
-def has_seen_slot(conn: sqlite3.Connection, sub_id: int, slot_hash: str) -> bool:
-    return conn.execute(
-        "SELECT 1 FROM seen_slots WHERE subscription_id=? AND slot_hash=?",
+def has_seen_slot(conn: sqlite3.Connection, sub_id: int, slot_hash: str,
+                  at: str | None = None) -> bool:
+    """Has `sub_id` already been told about `slot_hash` — or, with `at` (the
+    slot's HH:MM under a day key), about this key at `at` or an earlier time?
+
+    A slot strictly earlier than the recorded best_time is news: the earliest
+    slot only moves *back* when a cancellation opens a better one. Same or
+    later is the same inventory seen again. A row without a best_time was told
+    at an unknown time (a per-slot key, or a day key from before the column
+    existed) and counts as seen whatever `at` is.
+    """
+    row = conn.execute(
+        "SELECT best_time FROM seen_slots WHERE subscription_id=? AND slot_hash=?",
         (sub_id, slot_hash),
-    ).fetchone() is not None
+    ).fetchone()
+    if row is None:
+        return False
+    best = row[0]
+    if at is None or best is None:
+        return True
+    return at >= best
 
 def record_digest_delivery(conn: sqlite3.Connection, sub_id: int) -> None:
     """One delivered digest — what the per-subscriber daily cap counts."""

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -388,33 +388,33 @@ what counts as one piece of news:
 
 - `slot` (default, and what every tenant gets by omitting the key) — a distinct
   (day, time, office, service).
-- `day` — (day, office, service), the time dropped. Only correct for a vendor
-  that exposes the *earliest* free slot per office (TEVIS): there, the slot
-  that appears the moment somebody books is the same inventory a minute later,
-  and mailing about it again tells the subscriber nothing new. On a vendor that
-  lists real inventory (smartCJM), `day` would withhold genuine second chances
-  — do not set it.
+- `day` — (day, office, service), and the row remembers the **earliest time
+  already reported** on that day. A slot at the same or a later time on a
+  reported day stays quiet; a strictly earlier one goes out. Only correct for a
+  vendor that exposes the *earliest* free slot per office (TEVIS): there, the
+  slot that appears the moment somebody books is the same inventory a minute
+  later, and mailing about it again tells the subscriber nothing new — while
+  the earliest slot only ever moves *back* when somebody cancels, which is
+  exactly the news worth sending. On a vendor that lists real inventory
+  (smartCJM), `day` would withhold genuine second chances — do not set it.
 
-**Only `muenster-kfz` is set to `day` today**, and the other 30 TEVIS tenants
-deliberately are not. `day` cannot distinguish the earliest slot moving forward
-(booked — nothing new to say) from it moving back (a cancellation — worth
-saying), so once a day has been reported, an earlier slot on that day stays
-quiet until housekeeping prunes the row after 7 days.
-
-That is a real trade even on Münster-KFZ, whose horizon is **not** same-day:
-probed live on 2026-08-25, service 2407 stood a day out and 2408 sixteen days
-out. It is accepted there because the alternative is measured at 4-8 mails per
-subscriber per day, every one of them a different time on a day they had
-already been told about, and because the earliest slot usually moves *within* a
-day (a day holds many slots, so a booking rarely exhausts it). The loss is
-confined to a day that was reported, vanished, and reopened within the week.
-**Before enabling `day` on any further tenant, teach the key
-"earlier than last told" rather than re-making this trade by hand.**
-
-Whether a tenant shows only its earliest slot is measurable rather than assumed:
+**Only `muenster-kfz` is set to `day` today.** The first version of `day` was a
+plain date key that could not tell a booking (earliest moves forward — nothing
+to say) from a cancellation (earliest moves back — worth saying) and suppressed
+both, which is why the other TEVIS tenants were held back: that loss is small on
+a same-day horizon and real on a multi-day one. The key remembers the time now,
+so the horizon no longer matters. What decides whether a tenant should be `day`
+is only whether its vendor shows one slot per office, and that is measurable
+rather than assumed:
 `SELECT city, MAX(n_slots) FROM availability_samples WHERE location_uuid <> ''
 GROUP BY city` — TEVIS tenants read exactly 1, smartCJM tenants read hundreds
-or thousands.
+or thousands. Flip one tenant at a time, backfill first (below), and watch
+`/admin` → Email quota over the first cycles.
+
+Rows written under `day` before `seen_slots.best_time` existed (schema 11)
+carry no time and keep suppressing the whole day, as they always did, until
+housekeeping prunes them at 7 days — the migration cannot recover a time the
+old key never stored. Nothing to do; it works itself out within the week.
 
 **Changing it re-notifies once unless you backfill first.** The old and new keys
 are different values in `seen_slots`, so on the first cycle after the deploy
@@ -424,9 +424,10 @@ is one last round of exactly the noise the setting removes.
 `scripts/backfill_day_keys.py` prevents that. The stored hashes cannot be read
 back, but the tenant's slot space (date x time x office x service) is small
 enough to enumerate and match, which recovers every date each subscriber has
-already been told about and writes the day key for it. Run the dry run first and
-check `unrecognized` is at or near zero — each unrecognized row is one
-subscriber who may still get a single redundant mail:
+already been told about — and the earliest time on it, which the day key
+remembers — and writes the day key for it. Run the dry run first and check
+`unrecognized` is at or near zero — each unrecognized row is one subscriber who
+may still get a single redundant mail:
 
 **The backfill has to run between the build and the restart**, and the ordering
 below is the only one that works. `docker exec` into the *running* poller cannot

--- a/scripts/backfill_day_keys.py
+++ b/scripts/backfill_day_keys.py
@@ -125,7 +125,7 @@ def backfill(conn: sqlite3.Connection, city: str, *, apply: bool,
     # held. Inverted deliberately: building the full hash→slot map would be
     # hundreds of megabytes on a multi-office tenant, while the rows we are
     # trying to explain number in the hundreds.
-    found: dict[str, tuple[str, str, str]] = {}
+    found: dict[str, tuple[str, str, str, str]] = {}
     already_day: set[str] = set()
     start = date.today() - timedelta(days=DAYS_BACK)
     for offset in range(DAYS_BACK + days_ahead):
@@ -141,17 +141,18 @@ def backfill(conn: sqlite3.Connection, city: str, *, apply: bool,
                 if day_key in wanted:
                     already_day.add(day_key)
                 for minute in range(24 * 60):
-                    slot = Slot(day, f"{minute // 60:02d}:{minute % 60:02d}",
-                                loc, svc, "")
-                    h = slot.hash()
+                    hhmm = f"{minute // 60:02d}:{minute % 60:02d}"
+                    h = Slot(day, hhmm, loc, svc, "").hash()
                     if h in wanted:
-                        found[h] = (day, loc, svc)
+                        found[h] = (day, hhmm, loc, svc)
         if len(found) + len(already_day) == len(wanted):
             break  # every row explained; the rest of the calendar is empty
 
     # Earliest sighting wins, so the day key ages out on the same schedule the
-    # original rows would have — a backfilled key must not outlive them.
-    to_write: dict[tuple[int, str], str] = {}
+    # original rows would have — a backfilled key must not outlive them. The
+    # earliest *time* wins too: that is what the day key remembers, so a slot
+    # on that day is news again only if it beats the best one already sent.
+    to_write: dict[tuple[int, str], tuple[str, str]] = {}
     recognized = 0
     for sid, rows in seen.items():
         for h, sent_at in rows.items():
@@ -159,20 +160,22 @@ def backfill(conn: sqlite3.Connection, city: str, *, apply: bool,
             if hit is None:
                 continue
             recognized += 1
-            day, loc, svc = hit
+            day, hhmm, loc, svc = hit
             key = Slot(day, "00:00", loc, svc, "").day_hash()
             prev = to_write.get((sid, key))
-            if prev is None or sent_at < prev:
-                to_write[(sid, key)] = sent_at
+            to_write[(sid, key)] = (
+                sent_at if prev is None else min(sent_at, prev[0]),
+                hhmm if prev is None else min(hhmm, prev[1]))
 
     written = 0
     if apply and to_write:
         with conn:
-            for (sid, key), sent_at in to_write.items():
+            for (sid, key), (sent_at, best_time) in to_write.items():
                 cur = conn.execute(
                     "INSERT OR IGNORE INTO seen_slots "
-                    "(subscription_id, slot_hash, sent_at) VALUES (?,?,?)",
-                    (sid, key, sent_at))
+                    "(subscription_id, slot_hash, sent_at, best_time) "
+                    "VALUES (?,?,?,?)",
+                    (sid, key, sent_at, best_time))
                 written += cur.rowcount
 
     total_rows = sum(len(r) for r in seen.values())

--- a/tests/test_backfill_day_keys.py
+++ b/tests/test_backfill_day_keys.py
@@ -86,6 +86,13 @@ def test_many_times_on_one_day_collapse_to_a_single_key(db):
     stats = backfill(db, "muenster-kfz", apply=True, days_ahead=30)
     assert stats["recognized"] == 3
     assert stats["written"] == 1
+    # …remembering the earliest of them, so that after the flip only a slot
+    # before 08:00 on that day counts as news.
+    best = db.execute("SELECT best_time FROM seen_slots WHERE subscription_id=? "
+                      "AND slot_hash=?",
+                      (sid, Slot(day, "00:00", "243", "2408", "t").day_hash())
+                      ).fetchone()["best_time"]
+    assert best == "08:00"
 
 
 def test_the_backfilled_key_inherits_the_earliest_sighting(db):
@@ -109,6 +116,21 @@ def test_the_backfilled_key_inherits_the_earliest_sighting(db):
         "SELECT sent_at FROM seen_slots WHERE subscription_id=? AND slot_hash=?",
         (sid, Slot(day, "00:00", "243", "2408", "t").day_hash())).fetchone()["sent_at"]
     assert sent_at == "2026-01-01 07:00:00"
+
+
+def test_the_backfilled_key_carries_the_time_the_cycle_will_compare(db):
+    """End to end: a subscriber told about 09:00 under per-slot keys, the
+    tenant flips to day, and the next cycle sees a 10:00 (quiet) and later an
+    08:30 (news) — the backfill must leave the row in the state a delivered
+    day-key digest would have."""
+    from app.repo import has_seen_slot
+    sid = _sub(db)
+    day = _soon()
+    record_seen_slot(db, sid, Slot(day, "09:00", "243", "2408", "t").hash())
+    backfill(db, "muenster-kfz", apply=True, days_ahead=30)
+    key = Slot(day, "00:00", "243", "2408", "t").day_hash()
+    assert has_seen_slot(db, sid, key, at="10:00") is True
+    assert has_seen_slot(db, sid, key, at="08:30") is False
 
 
 def test_an_unexplainable_row_is_reported_not_swallowed(db):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -97,6 +97,26 @@ def test_migration_adds_counters_to_preexisting_city_state(tmp_path):
         assert c in cols, f"migration missed column: {c}"
     assert conn.execute("SELECT city FROM city_state").fetchone()["city"] == "leipzig"
 
+def test_migration_adds_best_time_to_preexisting_seen_slots(tmp_path):
+    """A DB whose seen_slots predates best_time must gain the column with
+    existing rows left NULL — which has_seen_slot reads as "told at an
+    unknown time", i.e. the old day-key behaviour, until they are pruned."""
+    from app.db import SCHEMA_SQL
+    old_sql = SCHEMA_SQL.replace("  best_time       TEXT,\n", "")
+    assert old_sql != SCHEMA_SQL, "the column line moved; update this fixture"
+    db = str(tmp_path / "old.db")
+    raw = sqlite3.connect(db)
+    raw.executescript(old_sql)
+    raw.execute("INSERT INTO subscriptions (id, email, city, filters_json, "
+                "expires_at) VALUES (1, 'a@example.com', 'leipzig', '{}', "
+                "'2099-01-01')")
+    raw.execute("INSERT INTO seen_slots (subscription_id, slot_hash) VALUES (1, 'k')")
+    raw.commit(); raw.close()
+    conn = connect(db)
+    init_schema(conn)
+    row = conn.execute("SELECT best_time FROM seen_slots").fetchone()
+    assert row["best_time"] is None
+
 def test_wal_mode_enabled(tmp_path):
     db_path = tmp_path / "test.db"
     conn = connect(str(db_path))

--- a/tests/test_notify_granularity.py
+++ b/tests/test_notify_granularity.py
@@ -3,8 +3,11 @@
 A tenant whose vendor only ever exposes the *earliest* slot per office keys
 seen_slots on the day, not on the slot: the "new" slot that appears the moment
 somebody books is the same inventory a minute later, and re-notifying about it
-tells the subscriber nothing they don't already know. Every other tenant keeps
-per-slot identity, where a different time genuinely is a different opportunity.
+tells the subscriber nothing they don't already know. The day key remembers the
+earliest time it reported, so the one case that *is* news — a cancellation
+opening an earlier slot on a day already reported — still goes out. Every other
+tenant keeps per-slot identity, where a different time genuinely is a different
+opportunity.
 """
 import json
 from datetime import time
@@ -16,8 +19,8 @@ from app import catalog as catalog_mod
 from app.catalog import Catalog, load_catalog
 from app.db import connect, init_schema
 from app.mail import BatchResult
-from app.models import Filter, Slot
-from app.repo import confirm, has_seen_slot, insert_pending
+from app.models import Filter, SeenKey, Slot
+from app.repo import confirm, has_seen_slot, insert_pending, record_seen_slot
 from app.cycle import run_cycle
 
 
@@ -111,8 +114,11 @@ def test_shipped_tenants_declare_the_granularity_they_need():
 
 def test_seen_key_follows_the_declaration():
     slot = Slot("2026-06-10", "09:00", "243", "2408", "tok")
-    assert load_catalog("muenster-kfz").seen_key(slot) == slot.day_hash()
-    assert load_catalog("leipzig").seen_key(slot) == slot.hash()
+    # A day key carries the time it is about to report, so the row can later
+    # tell a better slot from a worse one; a per-slot key needs no such memory.
+    assert (load_catalog("muenster-kfz").seen_key(slot)
+            == SeenKey(slot.day_hash(), best_time="09:00"))
+    assert load_catalog("leipzig").seen_key(slot) == SeenKey(slot.hash())
 
 
 def test_unknown_granularity_falls_back_to_per_slot(tmp_path, monkeypatch):
@@ -133,7 +139,7 @@ def test_unknown_granularity_falls_back_to_per_slot(tmp_path, monkeypatch):
         cat = catalog_mod.load_catalog("testcity")
         assert cat.notify_granularity == "slot"
         slot = Slot("2026-06-10", "09:00", "loc-1", "svc-A", "tok")
-        assert cat.seen_key(slot) == slot.hash()
+        assert cat.seen_key(slot) == SeenKey(slot.hash())
     finally:
         catalog_mod.load_catalog.cache_clear()
 
@@ -144,7 +150,7 @@ def test_a_catalog_object_with_a_bogus_value_still_keys_per_slot():
     slot = Slot("2026-06-10", "09:00", "loc-1", "svc-A", "tok")
     cat = Catalog(city="x", appointment_types={}, locations={},
                   scraper_config={}, notify_granularity="hourly")
-    assert cat.seen_key(slot) == slot.hash()
+    assert cat.seen_key(slot) == SeenKey(slot.hash())
 
 
 # --- behaviour through a real cycle ---------------------------------------
@@ -234,9 +240,10 @@ def test_day_tenant_collapses_a_whole_day_into_one_seen_row(db):
              Slot("2026-06-10", "15:00", "243", "2408", "t3")]
     _run(db, slots, cycle_id="c1", sent=sent)
     assert len(sent) == 1
-    rows = db.execute("SELECT COUNT(*) c FROM seen_slots WHERE subscription_id=?",
-                      (sid,)).fetchone()["c"]
-    assert rows == 1
+    rows = db.execute("SELECT best_time FROM seen_slots WHERE subscription_id=?",
+                      (sid,)).fetchall()
+    assert [r["best_time"] for r in rows] == ["09:00"], \
+        "one row, remembering the earliest of the three times"
 
     _make_due_again(db)
     _run(db, slots, cycle_id="c2", sent=sent)
@@ -269,15 +276,11 @@ def test_a_deferred_digest_records_nothing(db):
     assert len(sent) == 1
 
 
-def test_an_earlier_slot_on_an_already_reported_day_is_suppressed(db):
-    """Pins the known limitation, so it stays a decision rather than a
-    surprise: the day key cannot tell a booking (earliest moves forward,
-    redundant) from a cancellation (earliest moves back, real news), and
-    suppresses both. Harmless on a same-day-release tenant like Münster-KFZ,
-    where a day is reported once and never revisited — which is why `day` must
-    not be switched on for a tenant with a multi-day horizon until the key
-    learns about earlier-than-last-told.
-    """
+def test_an_earlier_slot_on_an_already_reported_day_is_news(db):
+    """The earliest slot only ever moves *back* when somebody cancels — and a
+    cancellation on a day the subscriber was already told about is exactly
+    the moment they want to hear from us. The day key remembers the time it
+    reported, so it can tell this from the redundant forward move above."""
     sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
                          language="de", filter_=_f(["2408"]), ttl_days=90)
     confirm(db, sid)
@@ -289,7 +292,76 @@ def test_an_earlier_slot_on_an_already_reported_day_is_suppressed(db):
     _make_due_again(db)
     _run(db, [Slot("2026-06-10", "08:30", "243", "2408", "tok2")],
          cycle_id="c2", sent=sent)
+    assert len(sent) == 2, "a cancellation opened an earlier slot: real news"
+    assert "08:30" in sent[-1].body
+
+
+def test_the_same_time_again_is_not_news(db):
+    """Equal is not earlier: the slot still sitting there next cycle is the
+    same slot, not a cancellation."""
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    slot = Slot("2026-06-10", "11:00", "243", "2408", "tok")
+    _run(db, [slot], cycle_id="c1", sent=sent)
+    _make_due_again(db)
+    _run(db, [slot], cycle_id="c2", sent=sent)
     assert len(sent) == 1
+
+
+def test_the_reported_time_ratchets_earlier_and_never_later(db, monkeypatch):
+    """Told 11:00, then a cancellation opens 08:30: the row now remembers
+    08:30, so when *that* gets booked and the 09:00 surfaces, nothing goes
+    out — 09:00 is worse than what they already heard. A second cancellation
+    at 08:00 beats the record and is news again."""
+    # Three digests in one day would trip the per-subscriber cap, which is
+    # not what this test is about.
+    monkeypatch.setenv("MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY", "0")
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    sent = []
+    day = "2026-06-10"
+    key = Slot(day, "00:00", "243", "2408", "").day_hash()
+
+    def best_time():
+        return db.execute("SELECT best_time FROM seen_slots WHERE "
+                          "subscription_id=? AND slot_hash=?",
+                          (sid, key)).fetchone()["best_time"]
+
+    _run(db, [Slot(day, "11:00", "243", "2408", "t1")], cycle_id="c1", sent=sent)
+    assert best_time() == "11:00"
+    _make_due_again(db)
+    _run(db, [Slot(day, "08:30", "243", "2408", "t2")], cycle_id="c2", sent=sent)
+    assert len(sent) == 2 and best_time() == "08:30"
+    _make_due_again(db)
+    _run(db, [Slot(day, "09:00", "243", "2408", "t3")], cycle_id="c3", sent=sent)
+    assert len(sent) == 2, "09:00 is later than the 08:30 already reported"
+    assert best_time() == "08:30", "a worse slot must not loosen the record"
+    _make_due_again(db)
+    _run(db, [Slot(day, "08:00", "243", "2408", "t4")], cycle_id="c4", sent=sent)
+    assert len(sent) == 3 and best_time() == "08:00"
+
+
+def test_a_day_key_without_a_time_keeps_suppressing_the_whole_day(db):
+    """Rows written before best_time existed carry NULL. The migration cannot
+    recover the time the old key never stored, so those rows mean "told at an
+    unknown time" and behave exactly as the old day key did — suppress every
+    time on that day — until housekeeping prunes them. Anything else would
+    mail every Münster subscriber once about a day they already know."""
+    sid = insert_pending(db, email="a@example.com", city="muenster-kfz",
+                         language="de", filter_=_f(["2408"]), ttl_days=90)
+    confirm(db, sid)
+    legacy = Slot("2026-06-10", "11:00", "243", "2408", "t")
+    record_seen_slot(db, sid, legacy.day_hash())  # no time, as before
+    sent = []
+    _run(db, [Slot("2026-06-10", "08:30", "243", "2408", "t2")],
+         cycle_id="c1", sent=sent)
+    assert sent == []
+    row = db.execute("SELECT best_time FROM seen_slots WHERE subscription_id=?",
+                     (sid,)).fetchone()
+    assert row["best_time"] is None, "nothing may loosen a legacy row"
 
 
 def test_a_one_off_send_records_the_tenants_own_key(db):
@@ -312,3 +384,5 @@ def test_a_one_off_send_records_the_tenants_own_key(db):
     assert len(sent) == 1
     assert has_seen_slot(db, sid, slot.day_hash()) is True
     assert has_seen_slot(db, sid, slot.hash()) is False
+    # …with the time, so a later cancellation on that day is still news.
+    assert has_seen_slot(db, sid, slot.day_hash(), at="08:00") is False

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -44,3 +44,34 @@ def test_seen_slot_dedup(db):
     assert has_seen_slot(db, sid, "hash1") is False
     record_seen_slot(db, sid, "hash1")
     assert has_seen_slot(db, sid, "hash1") is True
+
+
+def test_seen_slot_remembers_the_earliest_time_told(db):
+    """A day key answers "seen?" relative to the best time already sent:
+    same or later is seen, strictly earlier is not. Re-recording only ever
+    moves the record earlier."""
+    sid = insert_pending(db, email="a@example.com", city="leipzig",
+                         language="de", filter_=_f(), ttl_days=90)
+    record_seen_slot(db, sid, "day1", "11:00")
+    assert has_seen_slot(db, sid, "day1", at="11:00") is True
+    assert has_seen_slot(db, sid, "day1", at="14:00") is True
+    assert has_seen_slot(db, sid, "day1", at="08:30") is False
+    # No time asked → seen, whatever the row holds.
+    assert has_seen_slot(db, sid, "day1") is True
+
+    record_seen_slot(db, sid, "day1", "14:00")  # later: no-op
+    assert has_seen_slot(db, sid, "day1", at="11:00") is True
+    record_seen_slot(db, sid, "day1", "08:30")  # earlier: the record moves
+    assert has_seen_slot(db, sid, "day1", at="09:00") is True
+    assert has_seen_slot(db, sid, "day1", at="08:00") is False
+
+
+def test_a_timeless_seen_row_suppresses_every_time(db):
+    """NULL best_time = told at an unknown time (a per-slot key, or a day key
+    from before the column existed). Nothing recorded later may loosen it."""
+    sid = insert_pending(db, email="a@example.com", city="leipzig",
+                         language="de", filter_=_f(), ttl_days=90)
+    record_seen_slot(db, sid, "day1")
+    assert has_seen_slot(db, sid, "day1", at="00:01") is True
+    record_seen_slot(db, sid, "day1", "08:30")
+    assert has_seen_slot(db, sid, "day1", at="00:01") is True


### PR DESCRIPTION
Builds the "earlier than last told" key that `docs/DEPLOY.md` and the `notify_granularity` comment named as the prerequisite before flipping any further TEVIS tenant to `day`.

**Problem.** The `day` key was a plain date. It could not tell the earliest slot moving *forward* (someone booked the 09:00, the 14:00 is now earliest — nothing new) from it moving *back* (a cancellation opened an earlier time on a day already reported — real news), so it suppressed both. Small loss on a same-day horizon, real on a multi-day one, and Münster-KFZ's 2408 stood sixteen days out when probed.

**Change.**
- `seen_slots.best_time` (schema 11): under `day`, the row stores the HH:MM it reported. `has_seen_slot(..., at=)` answers "seen" only for the same or a later time. `record_seen_slot` only ever moves the record earlier, so a worse slot can never loosen it.
- `Catalog.seen_key` returns a `SeenKey(key, best_time)`; the cycle, `send_digest`, `flush_digests` and the fallback path carry it through.
- Rows written before the column exist carry NULL and keep suppressing the whole day, exactly as before, until housekeeping prunes them at 7 days — the migration cannot recover a time the old key never stored.
- `scripts/backfill_day_keys.py` writes the recovered earliest time too, so a future flip leaves rows in the state a delivered digest would have.
- Per-slot tenants are untouched: their keys carry no time.

**Not in this PR:** no tenant is flipped. That is a per-tenant decision plus the backfill runbook step; the runbook section now says what the decision hinges on.

**Tests:** the pinned-limitation test flips to "an earlier slot is news"; new coverage for same-time-is-quiet, the ratchet (11:00 → 08:30 news → 09:00 quiet → 08:00 news), legacy NULL rows, the repo upsert, the backfill's time, and the schema migration. 624 passed, ruff clean.
