### PR TITLE
feat(digests): day granularity is the TEVIS vendor default

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -16,6 +16,17 @@ _SLUG_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 _NOTIFY_GRANULARITIES = ("slot", "day")
 
 
+def _default_granularity(scfg: dict) -> str:
+    """The granularity a tenant gets by saying nothing.
+
+    TEVIS is "day" because earliest-slot-only is how *our* scraper reads it
+    (tevis.parse_slots: one earliest Slot per office), so every TEVIS tenant
+    has the same shape and the same redundancy. Everything else lists real
+    inventory and keeps per-slot identity.
+    """
+    return "day" if scfg.get("vendor") == "tevis" else "slot"
+
+
 class CatalogError(Exception):
     pass
 
@@ -73,10 +84,11 @@ class Catalog:
     # (confirmation, digest), so folding the Amt into it would give the game
     # away there.
     sensitive_services: frozenset = field(default_factory=frozenset)
-    # What counts as one piece of news for this tenant, from
-    # `notify_granularity` in scraper_config.json:
+    # What counts as one piece of news for this tenant. Defaults by vendor
+    # (see _default_granularity); `notify_granularity` in scraper_config.json
+    # overrides it for one tenant:
     #
-    #   "slot" (default) — every distinct (day, time, office, service). Right
+    #   "slot" — every distinct (day, time, office, service). Right
     #       for a vendor that lists real inventory: each slot is a separate
     #       perishable opportunity, and a subscriber told about a 09:00 that
     #       someone else then books genuinely wants to hear about the 14:00.
@@ -100,7 +112,10 @@ class Catalog:
     # horizon — and Münster's own 2408 stood sixteen days out when probed on
     # 2026-08-25 — so the horizon was never the discriminator. What decides
     # whether a tenant should be "day" is only whether its vendor shows one
-    # slot per office; docs/DEPLOY.md has the query that measures it.
+    # slot per office — and for TEVIS that is not a tenant property but how
+    # our scraper is built (tevis.parse_slots yields one earliest slot per
+    # office), which is why it is the vendor default rather than 30 config
+    # keys.
     notify_granularity: str = "slot"
 
     def seen_key(self, slot) -> SeenKey:
@@ -204,10 +219,13 @@ def load_catalog(city: str) -> Catalog:
         ats_en = {n: u for n, u in ats_en.items() if u not in excluded}
         svc_locs = {u: v for u, v in svc_locs.items() if u not in excluded}
     sensitive = frozenset(str(s) for s in (scfg.get("sensitive_services") or ()))
-    granularity = str(scfg.get("notify_granularity") or "slot")
+    granularity = str(scfg.get("notify_granularity")
+                      or _default_granularity(scfg))
     if granularity not in _NOTIFY_GRANULARITIES:
         # A typo ("Day", "daily") would otherwise leave the tenant looking
         # correctly configured while the intended suppression never happens.
+        # Falling back to 'slot' rather than the vendor default keeps the
+        # failure on the side that can only send *more* mail.
         print(f"catalog {city}: unknown notify_granularity "
               f"{granularity!r}, using 'slot'", flush=True)
         granularity = "slot"

--- a/catalog/muenster-kfz/scraper_config.json
+++ b/catalog/muenster-kfz/scraper_config.json
@@ -3,6 +3,5 @@
   "base_url": "https://termine.stadt-muenster.de",
   "md": 19,
   "mdt": 214,
-  "poll_interval_seconds": 120,
-  "notify_granularity": "day"
+  "poll_interval_seconds": 120
 }

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -383,40 +383,36 @@ last-polled timestamp untouched.
 
 ## Notification granularity
 
-A tenant can set `notify_granularity` in its `scraper_config.json` to decide
-what counts as one piece of news:
+What counts as one piece of news is decided per tenant by `notify_granularity`,
+which **defaults by vendor** — `day` for TEVIS, `slot` for everything else — and
+can be overridden per tenant in `scraper_config.json`:
 
-- `slot` (default, and what every tenant gets by omitting the key) — a distinct
-  (day, time, office, service).
+- `slot` — a distinct (day, time, office, service). Right for a vendor that
+  lists real inventory (smartCJM): each slot is a separate perishable
+  opportunity, and `day` there would withhold genuine second chances.
 - `day` — (day, office, service), and the row remembers the **earliest time
   already reported** on that day. A slot at the same or a later time on a
-  reported day stays quiet; a strictly earlier one goes out. Only correct for a
-  vendor that exposes the *earliest* free slot per office (TEVIS): there, the
-  slot that appears the moment somebody books is the same inventory a minute
-  later, and mailing about it again tells the subscriber nothing new — while
-  the earliest slot only ever moves *back* when somebody cancels, which is
-  exactly the news worth sending. On a vendor that lists real inventory
-  (smartCJM), `day` would withhold genuine second chances — do not set it.
+  reported day stays quiet; a strictly earlier one goes out. Right for TEVIS
+  because earliest-slot-only is how *our* scraper reads it
+  (`app/scrapers/tevis.py::parse_slots` yields one earliest slot per office),
+  not a property any tenant could differ on: the slot that appears the moment
+  somebody books is the same inventory a minute later, while the earliest slot
+  only ever moves *back* when somebody cancels — exactly the news worth sending.
 
-**Only `muenster-kfz` is set to `day` today.** The first version of `day` was a
-plain date key that could not tell a booking (earliest moves forward — nothing
-to say) from a cancellation (earliest moves back — worth saying) and suppressed
-both, which is why the other TEVIS tenants were held back: that loss is small on
-a same-day horizon and real on a multi-day one. The key remembers the time now,
-so the horizon no longer matters. What decides whether a tenant should be `day`
-is only whether its vendor shows one slot per office, and that is measurable
-rather than assumed:
-`SELECT city, MAX(n_slots) FROM availability_samples WHERE location_uuid <> ''
-GROUP BY city` — TEVIS tenants read exactly 1, smartCJM tenants read hundreds
-or thousands. Flip one tenant at a time, backfill first (below), and watch
-`/admin` → Email quota over the first cycles.
+History, for anyone tempted to narrow this again: the first version of `day`
+was a plain date key that suppressed cancellations along with bookings, so it
+ran on `muenster-kfz` alone from 2026-08-25. The key learnt the time on
+2026-08-26 (schema 11) and the vendor default followed the same day. If a
+vendor ever needs checking, `SELECT city, MAX(n_slots) FROM availability_samples
+WHERE location_uuid <> '' GROUP BY city` reads exactly 1 for earliest-slot-only
+tenants and hundreds or thousands for real inventory.
 
 Rows written under `day` before `seen_slots.best_time` existed (schema 11)
 carry no time and keep suppressing the whole day, as they always did, until
 housekeeping prunes them at 7 days — the migration cannot recover a time the
 old key never stored. Nothing to do; it works itself out within the week.
 
-**Changing it re-notifies once unless you backfill first.** The old and new keys
+**Changing a tenant's granularity re-notifies once unless you backfill first.** The old and new keys
 are different values in `seen_slots`, so on the first cycle after the deploy
 every affected subscriber with a currently-matching slot gets one digest — which
 is one last round of exactly the noise the setting removes.

--- a/tests/test_notify_granularity.py
+++ b/tests/test_notify_granularity.py
@@ -106,10 +106,37 @@ def test_the_two_key_spaces_cannot_alias():
 
 # --- reading the tenant declaration ---------------------------------------
 
-def test_shipped_tenants_declare_the_granularity_they_need():
+def test_the_default_follows_the_vendor():
+    """TEVIS is earliest-slot-only by construction of our scraper, so every
+    TEVIS tenant is `day` without saying so; real-inventory vendors are
+    `slot`."""
     assert load_catalog("muenster-kfz").notify_granularity == "day"
-    # Everyone else keeps per-slot identity by omitting the key entirely.
-    assert load_catalog("leipzig").notify_granularity == "slot"
+    assert load_catalog("mainz").notify_granularity == "day"
+    assert load_catalog("leipzig").notify_granularity == "slot"     # smartcjm
+    assert load_catalog("bonn").notify_granularity == "slot"        # smartcjm
+    for city in (d.name for d in catalog_mod.CATALOG_ROOT.iterdir()
+                 if (d / "scraper_config.json").exists()):
+        cat = load_catalog(city)
+        vendor = cat.scraper_config.get("vendor")
+        assert cat.notify_granularity == ("day" if vendor == "tevis" else "slot"), city
+
+
+def test_an_explicit_key_overrides_the_vendor_default(tmp_path, monkeypatch):
+    city = tmp_path / "testcity"
+    city.mkdir()
+    (city / "scraper_config.json").write_text(json.dumps(
+        {"vendor": "tevis", "base_url": "https://x", "md": 1, "mdt": 2,
+         "notify_granularity": "slot"}), encoding="utf-8")
+    (city / "appointment_type.json").write_text(json.dumps({"A": "svc-A"}),
+                                                encoding="utf-8")
+    (city / "locations.json").write_text(json.dumps({"Amt": "loc-1"}),
+                                         encoding="utf-8")
+    monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", tmp_path)
+    catalog_mod.load_catalog.cache_clear()
+    try:
+        assert catalog_mod.load_catalog("testcity").notify_granularity == "slot"
+    finally:
+        catalog_mod.load_catalog.cache_clear()
 
 
 def test_seen_key_follows_the_declaration():
@@ -123,7 +150,8 @@ def test_seen_key_follows_the_declaration():
 
 def test_unknown_granularity_falls_back_to_per_slot(tmp_path, monkeypatch):
     """The fail-safe direction is the one that can only ever send *more* mail:
-    a typo must not silently start suppressing notifications."""
+    a typo must not silently start suppressing notifications — so it falls to
+    'slot' even on a TEVIS tenant whose default would be 'day'."""
     city = tmp_path / "testcity"
     city.mkdir()
     (city / "scraper_config.json").write_text(json.dumps(


### PR DESCRIPTION
Follows #71. Earliest-slot-only is how *our* scraper reads TEVIS (`tevis.parse_slots` yields one earliest slot per office), not something a tenant can differ on — so every TEVIS tenant has the redundancy Münster-KFZ had, and with the key now remembering the earliest time it reported, the same fix is safe everywhere.

- `notify_granularity` defaults by vendor: `day` for `tevis`, `slot` for everything else. An explicit key in `scraper_config.json` still overrides per tenant; an unknown value still falls to `slot`.
- Münster's explicit key dropped; the default covers it.
- Runbook section rewritten; the backfill procedure is unchanged and will be run for the TEVIS tenants that hold `seen_slots` rows before the poller is recreated.
- Tests: every shipped tenant's granularity follows its vendor; an explicit key overrides; the typo fallback stays `slot` on a TEVIS tenant.
