### PR TITLE
feat(admin): chart distinct subscribers and cancellations per day

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timedelta
 
-from app.analytics import availability_daily, availability_summary, usage_daily
+from app.analytics import (availability_daily, availability_summary,
+                           cancellations_daily, subscribers_daily, usage_daily)
 
 # Thresholds for summary_anomalies(). Kept as module constants so the tests can
 # pin exact boundaries and prod can be retuned in one place.
@@ -695,6 +696,8 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
         "availability": _availability(conn, city_labels),
         "availability_daily": availability_daily(conn),
         "usage_daily": usage_daily(conn),
+        "subscribers_daily": subscribers_daily(conn),
+        "cancellations_daily": cancellations_daily(conn),
     }
 
 

--- a/app/analytics.py
+++ b/app/analytics.py
@@ -218,3 +218,73 @@ def usage_daily(conn: sqlite3.Connection, *, days: int = 30) -> list[dict]:
     return [{"day": r["day"], "signups": r["signups"],
              "confirmed": r["confirmed"], "deleted": r["deleted"],
              "by_city": by_city.get(r["day"], {})} for r in rows]
+
+
+def _day_series(conn: sqlite3.Connection, days: int, select_sql: str) -> list[dict]:
+    """Run `select_sql` once per UTC day of the last `days` days, oldest first.
+
+    The recursive CTE zero-fills: a quiet day is a row with zeros, not a hole,
+    so a column chart keeps its time axis honest. `select_sql` sees the
+    columns `day` (YYYY-MM-DD) and `cutoff` — the end of that day, clamped to
+    now for today, so the last point agrees with the live headline figures.
+    """
+    try:
+        rows = conn.execute(
+            "WITH RECURSIVE days(day) AS ("
+            f"  SELECT date('now','-{int(days) - 1} days') "
+            "  UNION ALL SELECT date(day,'+1 day') FROM days WHERE day < date('now')"
+            "), spans AS ("
+            "  SELECT day, min(datetime(day,'+1 day'), datetime('now')) AS cutoff "
+            "  FROM days"
+            ") "
+            f"SELECT day, {select_sql} FROM spans ORDER BY day"
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [dict(r) for r in rows]
+
+
+def subscribers_daily(conn: sqlite3.Connection, *, days: int = 30) -> list[dict]:
+    """Distinct active subscribers (people, not rows) at the end of each UTC day.
+
+    Reconstructed from the subscriptions table rather than snapshotted: a
+    subscription was active on a day if it had been confirmed by then, was
+    not yet deleted, and had not expired. `expires_at` only ever moves
+    forward (renewal), so a paused-then-renewed subscription reads as active
+    across its pause — a small overcount. Housekeeping hard-purges rows 30
+    days after deletion, so points older than that undercount; the default
+    window stops exactly where the record is still complete.
+    """
+    return _day_series(conn, days, (
+        "(SELECT COUNT(DISTINCT lower(email)) FROM subscriptions "
+        " WHERE confirmed_at IS NOT NULL AND confirmed_at <= cutoff "
+        "   AND (deleted_at IS NULL OR deleted_at > cutoff) "
+        "   AND datetime(expires_at) > cutoff) AS people, "
+        "(SELECT COUNT(*) FROM subscriptions "
+        " WHERE confirmed_at IS NOT NULL AND confirmed_at <= cutoff "
+        "   AND (deleted_at IS NULL OR deleted_at > cutoff) "
+        "   AND datetime(expires_at) > cutoff) AS subscriptions"
+    ))
+
+
+def cancellations_daily(conn: sqlite3.Connection, *, days: int = 30) -> list[dict]:
+    """Distinct people whose subscriptions ended on each UTC day, by cause.
+
+    `deleted_at` is stamped both by an unsubscribe and by housekeeping
+    soft-deleting an expired subscription after its grace period. The table
+    keeps no reason column, so the split is inferred: a deletion that comes
+    after `expires_at` is an expiry (or a cancellation during the grace
+    pause, which amounts to the same thing), anything earlier is a person
+    choosing to leave. Never-confirmed sign-ups are excluded — nobody was
+    subscribed, so nothing was cancelled.
+    """
+    live = "confirmed_at IS NOT NULL AND deleted_at >= day AND deleted_at < cutoff"
+    return _day_series(conn, days, (
+        f"(SELECT COUNT(DISTINCT lower(email)) FROM subscriptions WHERE {live}) "
+        "  AS people, "
+        f"(SELECT COUNT(*) FROM subscriptions WHERE {live}) AS subscriptions, "
+        f"(SELECT COUNT(DISTINCT lower(email)) FROM subscriptions WHERE {live} "
+        "   AND datetime(expires_at) > deleted_at) AS unsubscribed, "
+        f"(SELECT COUNT(DISTINCT lower(email)) FROM subscriptions WHERE {live} "
+        "   AND datetime(expires_at) <= deleted_at) AS expired"
+    ))

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -447,6 +447,82 @@
   </section>
 
   <section class="adm-section">
+    <details class="adm-collapse" open>
+      <summary><h2>Subscribers <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· distinct people with an active subscription at the end of each UTC day, last 30 days</span></h2></summary>
+      {% set days = s.subscribers_daily %}
+      {% if days %}
+        {% set smax = (days|map(attribute='people')|max) or 1 %}
+        {% set first_day = days|first %}{% set last_day = days|last %}
+        {% set delta = last_day.people - first_day.people %}
+        <div class="mini-stats">
+          <div><div class="ms-num">{{ last_day.people }}</div><div class="ms-lbl">Now</div></div>
+          <div><div class="ms-num">{{ first_day.people }}</div><div class="ms-lbl">30 days ago</div></div>
+          <div><div class="ms-num">{{ '%+d'|format(delta) }}</div><div class="ms-lbl">Change</div></div>
+          <div><div class="ms-num">{{ smax }}</div><div class="ms-lbl">Peak</div></div>
+        </div>
+        {# One column per day; hover for the people / subscription-row split. A
+           person holding several subscriptions counts once — this is the
+           headline "active subscribers" figure, back in time. #}
+        <div class="bars">
+          {% for d in days %}
+            <div class="bar-col" title="{{ d.day }} · {{ d.people }} people · {{ d.subscriptions }} subscriptions">
+              {% if d.people %}
+                <div class="bar" style="height: {{ (100 * d.people / smax)|round(1) }}%">
+                  <div class="bar-fill" style="height: 100%"></div>
+                </div>
+              {% else %}
+                <div class="bar empty"></div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+        <div class="bar-axis"><span>{{ first_day.day }}</span><span>{{ last_day.day }}</span></div>
+      {% else %}
+        <p class="adm-muted">No subscriber history yet.</p>
+      {% endif %}
+    </details>
+  </section>
+
+  <section class="adm-section">
+    <details class="adm-collapse" open>
+      <summary><h2>Cancellations <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· distinct people whose subscription ended, per UTC day, last 30 days</span></h2></summary>
+      {% set days = s.cancellations_daily %}
+      {% if days %}
+        {% set cmax = (days|map(attribute='people')|max) or 1 %}
+        {% set first_day = days|first %}{% set last_day = days|last %}
+        <div class="mini-stats">
+          <div><div class="ms-num">{{ days|sum(attribute='people') }}</div><div class="ms-lbl">Cancelled · 30d</div></div>
+          <div><div class="ms-num">{{ days|sum(attribute='unsubscribed') }}</div><div class="ms-lbl">Unsubscribed</div></div>
+          <div><div class="ms-num">{{ days|sum(attribute='expired') }}</div><div class="ms-lbl">Expired, not renewed</div></div>
+        </div>
+        {# Stacked column: people who chose to leave (solid) at the base, people
+           whose subscription ran out unrenewed (light) on top. The split is
+           inferred from deleted_at vs expires_at — there is no reason column. #}
+        <div class="bars">
+          {% for d in days %}
+            <div class="bar-col" title="{{ d.day }} · {{ d.people }} people ({{ d.unsubscribed }} unsubscribed, {{ d.expired }} expired) · {{ d.subscriptions }} subscriptions">
+              {% if d.people %}
+                <div class="bar" style="height: {{ (100 * d.people / cmax)|round(1) }}%">
+                  <div class="bar-fill" style="height: {{ (100 * d.unsubscribed / d.people)|round(1) }}%"></div>
+                </div>
+              {% else %}
+                <div class="bar empty"></div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+        <div class="bar-axis"><span>{{ first_day.day }}</span><span>{{ last_day.day }}</span></div>
+        <div class="legend">
+          <span><span class="swatch" style="background:var(--accent)"></span>Unsubscribed</span>
+          <span><span class="swatch" style="background:color-mix(in srgb, var(--accent) 26%, transparent)"></span>Expired, not renewed</span>
+        </div>
+      {% else %}
+        <p class="adm-muted">No cancellations in the last 30 days.</p>
+      {% endif %}
+    </details>
+  </section>
+
+  <section class="adm-section">
     <h2>Availability <span class="adm-title-sub" style="font-weight:500;font-size:1rem;">· free slots per office &amp; type, ~15-min samples, last 7 days · a service is only polled while subscribed: "polled %" = coverage, "empty %" = scarcity within it</span></h2>
     {% if s.availability %}
       {# One collapsible block per city (collapsed by default), in the same

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -626,3 +626,17 @@ def test_admin_page_shows_the_last_deferral_and_its_wall(client):
     html = client.get("/admin?token=admin-tok").data.decode()
     assert "last 12:05 UTC, 1 against the" in html
     assert "daily wall" in html and "frees 2026-08-27 09:31 UTC" in html
+
+
+def test_admin_renders_subscriber_and_cancellation_charts(client):
+    from app.db import connect
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute(
+        "INSERT INTO subscriptions (email, city, filters_json, confirmed_at, "
+        " expires_at, deleted_at) VALUES ('x@example.com', 'leipzig', '{}', "
+        " datetime('now','-5 days'), datetime('now','+30 days'), datetime('now','-2 days'))")
+    conn.commit()
+    html = client.get("/admin?token=admin-tok").get_data(as_text=True)
+    assert "Subscribers" in html and "Cancellations" in html
+    assert "Expired, not renewed" in html
+    assert "1 people (1 unsubscribed, 0 expired)" in html

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
 
 from app.analytics import (availability_daily, availability_summary,
-                           prune_availability, record_availability, usage_daily)
+                           cancellations_daily, prune_availability,
+                           record_availability, subscribers_daily, usage_daily)
 from app.db import connect, init_schema
 from app.models import Slot
 
@@ -111,3 +112,39 @@ def test_usage_daily_buckets_signups(tmp_path):
     (d,) = usage_daily(conn)
     assert d["signups"] == 3 and d["confirmed"] == 2 and d["deleted"] == 0
     assert d["by_city"] == {"leipzig": 2, "dresden": 1}
+
+
+def _sub(conn, email, *, confirmed="-10 days", expires="+30 days", deleted=None):
+    conn.execute(
+        "INSERT INTO subscriptions (email, city, filters_json, created_at, "
+        " confirmed_at, expires_at, deleted_at) VALUES (?, 'leipzig', '{}', "
+        " COALESCE(datetime('now', ?), CURRENT_TIMESTAMP), datetime('now', ?), "
+        " datetime('now', ?), datetime('now', ?))",
+        (email, confirmed, confirmed, expires, deleted))
+
+
+def test_subscribers_daily_reconstructs_active_people_per_day(tmp_path):
+    conn = _conn(tmp_path)
+    _sub(conn, "a@example.com", confirmed="-10 days", deleted="-3 days")
+    _sub(conn, "A@example.com", confirmed="-1 days")            # same person
+    _sub(conn, "a@example.com", confirmed="-1 days")            # second sub
+    _sub(conn, "b@example.com", confirmed="-40 days", expires="-20 days")
+    _sub(conn, "c@example.com", confirmed=None)                 # never confirmed
+    days = subscribers_daily(conn, days=14)
+    assert [d["day"] for d in days] == sorted(d["day"] for d in days)
+    assert len(days) == 14
+    assert [d["people"] for d in days] == [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1]
+    assert days[-1]["subscriptions"] == 2 and days[-1]["people"] == 1
+
+
+def test_cancellations_daily_splits_unsubscribed_from_expired(tmp_path):
+    conn = _conn(tmp_path)
+    _sub(conn, "a@example.com", deleted="-3 days")                       # chose to leave
+    _sub(conn, "A@example.com", deleted="-3 days")                       # same person
+    _sub(conn, "b@example.com", expires="-20 days", deleted="-3 days")   # ran out
+    _sub(conn, "c@example.com", confirmed=None, deleted="-3 days")       # never subscribed
+    days = cancellations_daily(conn, days=7)
+    assert len(days) == 7
+    (d,) = [d for d in days if d["people"]]
+    assert (d["people"], d["subscriptions"], d["unsubscribed"], d["expired"]) == (2, 3, 1, 1)
+    assert all(d["people"] == 0 for d in days[:3] + days[4:])


### PR DESCRIPTION
Two new column charts on `/admin`, right under Usage, each over the last 30 UTC days.

**Subscribers** — distinct people with an active subscription at the end of each day. Reconstructed from `confirmed_at` / `deleted_at` / `expires_at`, no snapshot table and no new writes; the last point equals the headline "distinct subscribers" number. 30 days is where the record stays complete — housekeeping hard-purges deleted rows after that, so older points would undercount.

**Cancellations** — distinct people whose subscription ended each day, stacked into unsubscribed vs expired-unrenewed. The table has no reason column, so the split is inferred: `deleted_at` after `expires_at` is an expiry, earlier is a choice.

Quiet days are zero-filled (recursive CTE), so the axis has no holes. Rendering reuses the existing CSS bar chart; verified with headless-Chrome screenshots against a synthetic DB.
