### PR TITLE
feat(faq): say how many mails a subscription gets; count rejected webhook signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ which offices work for you, and receive an email the moment a matching
 slot is available on the city's official booking site. You then book it
 yourself there. We never book on your behalf.
 
+A subscription gets at most two mails in any 24 hours
+(`MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY`); slots that appear after that go into
+the next mail once the window frees. The FAQ on the site says so.
+
 For the Ausländerbehörde, booking additionally requires the personal
 Termin-Code from the office's letter — this service only tells you when a
 pickup slot is free.

--- a/app/admin.py
+++ b/app/admin.py
@@ -171,6 +171,10 @@ def summary_anomalies(s: dict, *, now: datetime) -> list[str]:
     for name in d.get("providers_silent") or []:
         out.append(f"no delivery feedback from {name} in "
                    f"{WEBHOOK_SILENT_HOURS}h — check its webhook")
+    for name in d.get("providers_rejecting") or []:
+        out.append(f"{name} delivery feedback rejected for a bad signature in "
+                   f"the last {WEBHOOK_SILENT_HOURS}h — the signing secret in "
+                   f".env does not match its dashboard")
 
     # 3. Signup volume deviates sharply from the trailing 7-day baseline — a
     #    press/Reddit surge, or an inflow that suddenly dried up.
@@ -363,7 +367,8 @@ def _deliverability(conn: sqlite3.Connection, cfg=None) -> dict:
     # cannot render during one.
     out: dict = {"configured": bool(getattr(cfg, "webhook_secret", "")),
                  "by_reason": {}, "providers": [], "providers_silent": [],
-                 "parse_errors": {}, "suppressed": 0, "watchlist": 0,
+                 "parse_errors": {}, "rejected": {}, "providers_rejecting": [],
+                 "suppressed": 0, "watchlist": 0,
                  "sent_30d": 0, "complaint_rate": None, "bounce_rate": None,
                  "complaint_30d": 0, "hard_bounce_30d": 0}
     try:
@@ -403,27 +408,54 @@ def _deliverability(conn: sqlite3.Connection, cfg=None) -> dict:
         # at the end of the fallback chain reports nothing because it sent
         # nothing, and flagging that every day teaches the reader to skip the
         # whole section.
-        sent = conn.execute(
-            "SELECT COUNT(*) AS n FROM sent_idempotency WHERE provider=? "
-            "AND sent_at > datetime('now', ?)",
+        # The last send is shown next to the count: a leg whose last send
+        # predates the day its dashboard was wired reads as "never reported"
+        # until that send ages out of the window, and the timestamp is what
+        # lets the reader tell that from a webhook that is really dead.
+        sent_row = conn.execute(
+            "SELECT COUNT(*) AS n, MAX(sent_at) AS last FROM sent_idempotency "
+            "WHERE provider=? AND sent_at > datetime('now', ?)",
             (name, f"-{WEBHOOK_SILENT_HOURS} hours"),
-        ).fetchone()["n"]
+        ).fetchone()
+        sent, last_sent = sent_row["n"], sent_row["last"]
         silent = bool(sent)
         if silent and last:
-            try:
-                silent = (datetime.utcnow() - datetime.fromisoformat(last)
-                          ) > timedelta(hours=WEBHOOK_SILENT_HOURS)
-            except ValueError:
-                silent = True
+            silent = _older_than(last, WEBHOOK_SILENT_HOURS)
         out["providers"].append({"name": name, "last_event_at": last,
-                                 "sent_recently": sent, "silent": silent})
-        if silent:
+                                 "sent_recently": sent,
+                                 "last_sent_at": last_sent, "silent": silent})
+        # A provider whose posts we are rejecting for a bad signature is
+        # silent by the numbers, but "the signing secret is wrong" is the
+        # diagnosis and "check its webhook" the symptom; one line, not two.
+        rej = conn.execute("SELECT value FROM meta WHERE key=?",
+                           (f"webhook_rejected_{name}",)).fetchone()
+        rej_at = conn.execute("SELECT value FROM meta WHERE key=?",
+                              (f"last_webhook_rejected_at_{name}",)).fetchone()
+        rejecting = False
+        if rej:
+            out["rejected"][name] = {"n": rej["value"],
+                                     "last": rej_at["value"] if rej_at else None}
+            rejecting = bool(rej_at) and not _older_than(rej_at["value"],
+                                                          WEBHOOK_SILENT_HOURS)
+        if rejecting:
+            out["providers_rejecting"].append(name)
+        elif silent:
             out["providers_silent"].append(name)
         err = conn.execute("SELECT value FROM meta WHERE key=?",
                            (f"webhook_errors_{name}",)).fetchone()
         if err:
             out["parse_errors"][name] = err["value"]
     return out
+
+
+def _older_than(stamp: str, hours: int) -> bool:
+    """True if a `meta` timestamp is more than `hours` old — or unreadable,
+    which for a liveness check is the same thing."""
+    try:
+        return (datetime.utcnow() - datetime.fromisoformat(stamp)
+                ) > timedelta(hours=hours)
+    except ValueError:
+        return True
 
 def stats(conn: sqlite3.Connection, cfg=None) -> dict:
     from app.mail import deferral_walls_today, last_deferral

--- a/app/templates/_parts.html
+++ b/app/templates/_parts.html
@@ -31,6 +31,16 @@
         No. It checks and sends you an email. Booking is on you, on the
         city's own site.
       </p>
+      {% if digest_cap %}
+      <h3>How many emails will I get?</h3>
+      <p>
+        At most {{ digest_cap }} in any 24 hours, so your inbox stays calm and
+        the mails stay out of the spam folder. Slots that turn up after that
+        go into the next mail once the window frees, and the city's booking
+        page is always open to you directly. For fewer mails, narrow the
+        weekdays and times in your subscription's settings.
+      </p>
+      {% endif %}
       <h3>Is this fair?</h3>
       <p>
         Fairer than the status quo. Without it, appointments go to whoever
@@ -50,6 +60,17 @@
         Nein. Es schaut nach und schickt dir eine Mail. Buchen musst du
         selbst, auf der Seite der Stadt.
       </p>
+      {% if digest_cap %}
+      <h3>Wie viele Mails bekomme ich?</h3>
+      <p>
+        Höchstens {{ digest_cap }} in 24 Stunden, damit dein Postfach ruhig
+        bleibt und die Mails nicht im Spam landen. Termine, die danach
+        auftauchen, kommen in die nächste Mail, sobald wieder eine frei ist;
+        die Terminseite der Stadt kannst du jederzeit selbst aufrufen. Für
+        weniger Mails grenzt du Wochentage und Uhrzeiten in den Einstellungen
+        deiner Anmeldung ein.
+      </p>
+      {% endif %}
       <h3>Ist das fair?</h3>
       <p>
         Fairer als der Status quo. Ohne das Tool bekommt die Termine, wer

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -309,10 +309,11 @@
               {%- if pr.silent %} <span class="adm-muted">· silent over 48h — check the webhook in the provider dashboard</span>{% endif %}
             {% elif pr.sent_recently %}
               <span class="quota-hot">never reported</span>
-              <span class="adm-muted">· {{ pr.sent_recently }} sent in 48h and no feedback — the webhook is not wired up</span>
+              <span class="adm-muted">· {{ pr.sent_recently }} sent in 48h, last {{ pr.last_sent_at }}, and no feedback — the webhook is not wired up, or was wired after that last send</span>
             {% else %}
               <span class="adm-muted">idle · nothing sent through this leg in 48h</span>
             {% endif %}
+            {%- if d.rejected.get(pr.name) %}  ·  <span class="quota-hot">{{ d.rejected[pr.name].n }} rejected for a bad signature</span> <span class="adm-muted">· last {{ d.rejected[pr.name].last }} — the signing secret in .env does not match the dashboard</span>{% endif %}
             {%- if d.parse_errors.get(pr.name) %}  ·  <span class="quota-hot">{{ d.parse_errors[pr.name] }} unreadable payloads</span>{% endif %}
           </td>
         </tr>

--- a/app/templates/cities.html
+++ b/app/templates/cities.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_parts.html" import city_grid, faq, banners %}
+{% from "_parts.html" import city_grid, faq, banners with context %}
 {% block content %}
   {{ banners(confirmed, error, lang) }}
 

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "_fields.html" import max_days_select, special_consent %}
-{% from "_parts.html" import city_grid, faq, banners %}
+{% from "_parts.html" import city_grid, faq, banners with context %}
 {% block content %}
   {{ banners(confirmed, error, lang) }}
 

--- a/app/web.py
+++ b/app/web.py
@@ -446,6 +446,25 @@ def _offered_sensitive(catalog) -> list[str]:
                   if catalog.is_sensitive(u))
 
 
+def _stamp_meta_now(conn, key: str) -> None:
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES (?, CURRENT_TIMESTAMP) "
+        "ON CONFLICT (key) DO UPDATE SET value=excluded.value, "
+        "updated_at=CURRENT_TIMESTAMP",
+        (key,),
+    )
+
+
+def _bump_meta_counter(conn, key: str) -> None:
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES (?, '1') "
+        "ON CONFLICT (key) DO UPDATE SET "
+        "value = CAST(CAST(meta.value AS INTEGER) + 1 AS TEXT), "
+        "updated_at = CURRENT_TIMESTAMP",
+        (key,),
+    )
+
+
 def _stamp_webhook_seen(conn, provider: str) -> None:
     """Remember when this provider last reached us, for any event at all.
 
@@ -454,12 +473,7 @@ def _stamp_webhook_seen(conn, provider: str) -> None:
     appearing to work, and the first symptom is a damaged sending reputation
     weeks later. /admin grades this timestamp so the silence is visible."""
     try:
-        conn.execute(
-            "INSERT INTO meta (key, value) VALUES (?, CURRENT_TIMESTAMP) "
-            "ON CONFLICT (key) DO UPDATE SET value=excluded.value, "
-            "updated_at=CURRENT_TIMESTAMP",
-            (f"last_webhook_at_{provider}",),
-        )
+        _stamp_meta_now(conn, f"last_webhook_at_{provider}")
     except Exception:
         log.exception("failed to stamp webhook receipt")
 
@@ -471,16 +485,31 @@ def _count_webhook_error(cfg, provider: str) -> None:
     stale against a provider's format change. This counter is what /admin
     reads."""
     try:
-        conn = connect(cfg.db_path)
-        conn.execute(
-            "INSERT INTO meta (key, value) VALUES (?, '1') "
-            "ON CONFLICT (key) DO UPDATE SET "
-            "value = CAST(CAST(meta.value AS INTEGER) + 1 AS TEXT), "
-            "updated_at = CURRENT_TIMESTAMP",
-            (f"webhook_errors_{provider}",),
-        )
+        _bump_meta_counter(connect(cfg.db_path), f"webhook_errors_{provider}")
     except Exception:
         log.exception("failed to record webhook parse error")
+
+def _count_webhook_rejection(cfg, provider: str) -> None:
+    """Record a post that carried the right URL secret but a bad signature.
+
+    Only Sweego signs, and a signature mismatch is the one failure that no
+    other measure can tell from silence: the dashboard is posting, the URL is
+    right, and the delivery is thrown away with a 403 that goes nowhere. A
+    misread `SWEEGO_WEBHOOK_SECRET` — the docs never settled its encoding, see
+    `webhooks._signing_keys` — would look exactly like a webhook nobody wired
+    up, for as long as nobody compared the provider's own delivery log with
+    /admin. The count and the stamp let /admin say "rejected" instead of
+    "never reported", and the ops summary raise it while it is fresh.
+
+    A wrong *URL* secret is deliberately not counted here: that path is
+    reachable by anyone who guesses a provider name, and a scanner must not be
+    able to paint a red line on the dashboard."""
+    try:
+        conn = connect(cfg.db_path)
+        _bump_meta_counter(conn, f"webhook_rejected_{provider}")
+        _stamp_meta_now(conn, f"last_webhook_rejected_at_{provider}")
+    except Exception:
+        log.exception("failed to record webhook rejection")
 
 def create_app() -> Flask:
     app = Flask(__name__,
@@ -532,7 +561,11 @@ def create_app() -> Flask:
                 "alternate_de": f"{base}{path}",
                 "alternate_en": f"{base}{path}?lang=en",
                 "indexable": indexable,
-                "og_image": f"{base}/og-image.png"}
+                "og_image": f"{base}/og-image.png",
+                # The FAQ promises the per-subscriber daily cap in words, so
+                # it reads the configured number rather than hard-coding one.
+                "digest_cap": app.config["TERMINE_CONFIG"]
+                .max_digests_per_subscriber_per_day}
 
     def _result_page(key: str, lang: str, *, status: int = 200,
                      action_url: str | None = None,
@@ -633,6 +666,10 @@ def create_app() -> Flask:
                     timestamp=request.headers.get("webhook-timestamp", ""),
                     signature=request.headers.get("webhook-signature", ""),
                     body=body, secret=cfg.sweego_webhook_secret):
+                _count_webhook_rejection(cfg, provider)
+                log.warning("webhook %s: bad signature on %d bytes — "
+                            "SWEEGO_WEBHOOK_SECRET does not match the "
+                            "dashboard", provider, len(body))
                 return "bad signature", 403
         payload = request.get_json(force=True, silent=True)
         if payload is None:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -306,6 +306,23 @@ A provider that has gone silent for 48h is flagged, because a rate of 0.00% with
 a dead webhook and a rate of 0.00% with a healthy one look identical in the
 numbers, and the first is the dangerous one.
 
+Two things that line cannot know on its own:
+
+- **"never reported" counts sends over the last 48h regardless of when the
+  dashboard was wired.** A fallback leg whose last send predates the webhook
+  reads as unwired until that send ages out of the window; the *last* timestamp
+  next to the count is what to compare against. Sweego, last in the chain, can
+  go days without sending once the per-subscriber cap holds the volume — its
+  webhook is then unverified, not broken. Verify it from the Sweego dashboard's
+  own delivery counters, or wait for its next real send.
+- **A post that carries the right URL secret but fails the signature** is
+  answered 403, logged (`bad signature`), and shown on `/admin` as *rejected for
+  a bad signature* (`webhook_rejected_sweego` / `last_webhook_rejected_at_sweego`
+  in `meta`; an ops-summary anomaly while the last one is under 48h old). That
+  is the diagnosis for a misread `SWEEGO_WEBHOOK_SECRET`, which would otherwise
+  be indistinguishable from a webhook nobody wired up. A wrong URL secret is
+  not counted — anyone can post one.
+
 ### Retention, and getting back off the list
 
 Retention splits by reason, and so does the way back.

--- a/tests/test_web_form.py
+++ b/tests/test_web_form.py
@@ -278,3 +278,16 @@ def test_form_omits_filter_script_without_map(client, tmp_path, monkeypatch):
     finally:
         catalog_mod.load_catalog.cache_clear()
     assert 'id="service-locations"' not in body
+
+def test_faq_tells_subscribers_about_the_daily_mail_cap(client, monkeypatch):
+    de = client.get("/leipzig?lang=de").data.decode()
+    en = client.get("/leipzig?lang=en").data.decode()
+    assert "Wie viele Mails bekomme ich?" in de
+    assert "Höchstens 2 in 24 Stunden" in de
+    assert "How many emails will I get?" in en
+    assert "At most 2 in any 24 hours" in en
+    # With the cap switched off there is nothing to promise.
+    monkeypatch.setenv("MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY", "0")
+    from app.web import create_app
+    off = create_app().test_client().get("/leipzig?lang=de").data.decode()
+    assert "Wie viele Mails bekomme ich?" not in off

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -934,3 +934,95 @@ def test_admin_renders_on_a_db_that_predates_the_suppression_table(client):
     r = c.get("/admin?token=" + "a" * 32)
     assert r.status_code == 200
     assert b"Deliverability" in r.data
+
+
+def test_a_rejected_sweego_signature_is_counted_not_silent(client, monkeypatch):
+    # A misread SWEEGO_WEBHOOK_SECRET is a 403 on every delivery. Without a
+    # count that is indistinguishable from a webhook nobody wired up.
+    c, conn = client
+    monkeypatch.setenv("SWEEGO_WEBHOOK_SECRET",
+                       base64.b64encode(b"k" * 32).decode())
+    from app.web import create_app
+    app = create_app()
+    app.config["TESTING"] = True
+    cl = app.test_client()
+    body = json.dumps({"event_type": "delivered",
+                       "recipient": "a@example.com"}).encode()
+    headers = {"webhook-id": "id1", "webhook-timestamp": "1769696506",
+               "webhook-signature": _sweego_sign(
+                   body, base64.b64encode(b"x" * 32).decode())}
+
+    def meta(key):
+        return conn.execute("SELECT value FROM meta WHERE key=?",
+                            (key,)).fetchone()
+
+    r = cl.post(f"/webhooks/sweego/{SECRET}", data=body, headers=headers,
+                content_type="application/json")
+    assert r.status_code == 403
+    assert meta("webhook_rejected_sweego")["value"] == "1"
+    assert meta("last_webhook_rejected_at_sweego") is not None
+    assert meta("last_webhook_at_sweego") is None  # a rejection is no receipt
+    # A wrong URL secret is scanner noise, not a signing-secret diagnosis:
+    # counting it would let anyone paint a red line on /admin.
+    r = cl.post("/webhooks/sweego/WRONG", data=body, headers=headers,
+                content_type="application/json")
+    assert r.status_code == 403
+    assert meta("webhook_rejected_sweego")["value"] == "1"
+
+
+def test_a_rejecting_provider_is_graded_as_rejected_not_never_reported(db):
+    from datetime import datetime
+    from app.admin import _deliverability, summary_anomalies
+
+    db.execute("INSERT INTO sent_idempotency (idem_key, provider) "
+               "VALUES ('k1', 'sweego')")
+    db.execute("INSERT INTO meta (key, value) VALUES "
+               "('webhook_rejected_sweego', '3')")
+    db.execute("INSERT INTO meta (key, value) VALUES "
+               "('last_webhook_rejected_at_sweego', datetime('now'))")
+    d = _deliverability(db, SimpleNamespace(webhook_secret=SECRET,
+                                            email_provider_order=("sweego",)))
+    pr = d["providers"][0]
+    assert pr["sent_recently"] == 1 and pr["last_sent_at"] is not None
+    assert pr["last_event_at"] is None
+    assert d["rejected"]["sweego"]["n"] == "3"
+    assert d["providers_rejecting"] == ["sweego"]
+    assert d["providers_silent"] == []  # the diagnosis replaces the symptom
+    lines = summary_anomalies({"deliverability": d}, now=datetime.utcnow())
+    assert any("sweego delivery feedback rejected for a bad signature" in ln
+               for ln in lines)
+    assert not any("no delivery feedback" in ln for ln in lines)
+
+
+def test_an_old_rejection_falls_back_to_the_silence_grading(db):
+    # A rejection from weeks ago is history; the live question is again
+    # whether anything came back for what was sent since.
+    from app.admin import _deliverability
+
+    db.execute("INSERT INTO sent_idempotency (idem_key, provider) "
+               "VALUES ('k1', 'sweego')")
+    db.execute("INSERT INTO meta (key, value) VALUES "
+               "('webhook_rejected_sweego', '3')")
+    db.execute("INSERT INTO meta (key, value) VALUES "
+               "('last_webhook_rejected_at_sweego', "
+               "datetime('now', '-10 days'))")
+    d = _deliverability(db, SimpleNamespace(webhook_secret=SECRET,
+                                            email_provider_order=("sweego",)))
+    assert d["rejected"]["sweego"]["n"] == "3"
+    assert d["providers_rejecting"] == []
+    assert d["providers_silent"] == ["sweego"]
+
+
+def test_admin_page_renders_the_last_send_and_the_rejection(client):
+    c, conn = client
+    conn.execute("INSERT INTO sent_idempotency (idem_key, provider) "
+                 "VALUES ('k1', 'sweego')")
+    conn.execute("INSERT INTO meta (key, value) VALUES "
+                 "('webhook_rejected_sweego', '2')")
+    conn.execute("INSERT INTO meta (key, value) VALUES "
+                 "('last_webhook_rejected_at_sweego', datetime('now'))")
+    conn.commit()
+    body = c.get("/admin?token=" + "a" * 32).data.decode()
+    assert "never reported" in body
+    assert "1 sent in 48h, last 20" in body
+    assert "2 rejected for a bad signature" in body


### PR DESCRIPTION
The per-subscriber daily cap (PR #68) was invisible to the people it applies
to. The FAQ on every city page now answers "Wie viele Mails bekomme ich?" in
both languages, reading MAX_DIGESTS_PER_SUBSCRIBER_PER_DAY rather than
hard-coding the number, and disappears when the cap is 0. The macro import
needs `with context` for the context-processor value to reach it.

/admin's "never reported · N sent in 48h" line cried wolf for Sweego: all 100
sends predated the moment its dashboard was wired, and Sweego has not sent
since. The line now shows the last send so the reader can compare it with
when the webhook went live.

A Sweego post with the right URL secret but a bad signature was a 403 that
logged nothing and counted nothing — a misread SWEEGO_WEBHOOK_SECRET was
indistinguishable from a webhook nobody wired up. It is now logged, counted
in meta (webhook_rejected_<p>, last_webhook_rejected_at_<p>), shown on
/admin as "rejected for a bad signature", and raised by the ops summary while
the last rejection is under 48h old; a rejecting provider replaces the
generic "silent" line rather than adding to it. A wrong URL secret is not
counted, since anyone can post one.
