### PR TITLE
fix(app): validate form ids, fail over on timeouts, sync catalogs off the poll loop

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 import sqlite3
 from datetime import datetime, timedelta
 
@@ -501,8 +502,10 @@ def stats(conn: sqlite3.Connection, cfg=None) -> dict:
     try:
         from app.repo import active_subscriptions
         from app.planning import build_plans
-        import os
-        max_cap = int(os.environ.get("MAX_PLANS_PER_CITY", "10"))
+        # The same cap the poller builds plans with. Only a caller without a
+        # Config at all (stats(conn)) falls back to the environment.
+        max_cap = (cfg.max_plans_per_city if cfg is not None
+                   else int(os.environ.get("MAX_PLANS_PER_CITY", "10")))
         subs = active_subscriptions(conn)
         plans = build_plans([(s.city, s.sub_filter) for s in subs],
                             max_plans_per_city=max_cap)

--- a/app/catalog.py
+++ b/app/catalog.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from functools import lru_cache
 from pathlib import Path
 
 from app.models import SeenKey, per_slot_key
@@ -186,24 +185,74 @@ class Catalog:
         """Localized display name for a location uuid; the raw uuid if unknown."""
         return _label_for(self.locations_for(lang), uuid)
 
-@lru_cache(maxsize=8)
+# Every file a tenant directory can hold. The cache signature below stats each
+# of them, so a rewrite of any one (catalog_sync's atomic replace, a hand edit)
+# is noticed on the next load.
+_CATALOG_FILES = ("appointment_type.json", "locations.json",
+                  "scraper_config.json", "appointment_type.en.json",
+                  "locations.en.json", "display.json",
+                  "service_locations.json")
+
+# city → (file signature, Catalog). A plain dict rather than lru_cache: the
+# cache must (a) hold every tenant — an lru_cache(maxsize=8) over 38 tenants
+# missed on nearly every call, re-reading and re-parsing up to seven JSON
+# files per miss, and the tenant switcher loads all of them per page view —
+# and (b) notice when catalog_sync rewrites a file. The poller runs the sync,
+# but the web workers are separate processes that never restart for it, so
+# "clear the cache after syncing" cannot reach them; a per-load stat of the
+# files (cheap, no parse) can. `load_catalog.cache_clear()` is kept for tests
+# that swap CATALOG_ROOT.
+_CACHE: dict[str, tuple[tuple, "Catalog"]] = {}
+
+
+def _signature(city_dir: Path) -> tuple:
+    sig = []
+    for name in _CATALOG_FILES:
+        try:
+            st = (city_dir / name).stat()
+            sig.append((name, st.st_mtime_ns, st.st_size))
+        except FileNotFoundError:
+            sig.append((name, None, None))
+    return tuple(sig)
+
+
 def load_catalog(city: str) -> Catalog:
     # A tenant slug arrives straight from a URL, so validate its shape before
     # it is joined onto a path: "../.." would walk out of the catalog root, and
-    # the lru_cache would then key on whatever was passed. Every tenant
-    # directory is lowercase letters, digits and hyphens (test_catalog asserts
-    # it), so anything else is not a city we have.
+    # the cache would then key on whatever was passed. Every tenant directory
+    # is lowercase letters, digits and hyphens (test_catalog asserts it), so
+    # anything else is not a city we have.
     if not _SLUG_RE.fullmatch(city or ""):
         raise CatalogError(f"Unknown city: {city}")
     city_dir = CATALOG_ROOT / city
     if not city_dir.is_dir():
         raise CatalogError(f"Unknown city: {city}")
+    sig = _signature(city_dir)
+    cached = _CACHE.get(city)
+    if cached is not None and cached[0] == sig:
+        return cached[1]
+    catalog = _read_catalog(city, city_dir)
+    _CACHE[city] = (sig, catalog)
+    return catalog
+
+
+load_catalog.cache_clear = _CACHE.clear  # type: ignore[attr-defined]
+
+
+def _read_catalog(city: str, city_dir: Path) -> Catalog:
     try:
-        ats = json.loads((city_dir / "appointment_type.json").read_text(encoding="utf-8"))
-        locs = json.loads((city_dir / "locations.json").read_text(encoding="utf-8"))
-        scfg = json.loads((city_dir / "scraper_config.json").read_text(encoding="utf-8"))
+        ats = _read_required_json(city_dir / "appointment_type.json")
+        locs = _read_required_json(city_dir / "locations.json")
+        scfg = _read_required_json(city_dir / "scraper_config.json")
     except FileNotFoundError as exc:
         raise CatalogError(f"Missing catalog file for {city}: {exc.filename}") from exc
+    except ValueError as exc:
+        # A required file that exists but does not parse is as much "not a
+        # tenant we can serve" as a missing one. Left as a JSONDecodeError it
+        # walked past every `except CatalogError` — the tenant switcher, the
+        # sitemap, /subscribe — and one hand-edited file took down every
+        # tenant's page instead of hiding the broken one.
+        raise CatalogError(f"Malformed catalog file for {city}: {exc}") from exc
     # English labels are optional: a city without an *.en.json simply falls
     # back to the German names everywhere (see Catalog.appointment_types_for).
     ats_en = _read_optional_json(city_dir / "appointment_type.en.json")
@@ -271,6 +320,16 @@ def available_cities() -> list[str]:
     """
     return sorted(d.name for d in CATALOG_ROOT.iterdir()
                   if d.is_dir() and (d / "scraper_config.json").is_file())
+
+
+def _read_required_json(path: Path) -> dict:
+    """A required catalog file. Raises FileNotFoundError or ValueError (a
+    JSONDecodeError is one); load_catalog turns both into CatalogError, naming
+    the file, so a broken tenant is skipped rather than fatal."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise ValueError(f"{path.name}: {exc}") from exc
 
 
 def _read_optional_json(path: Path) -> dict:

--- a/app/cycle.py
+++ b/app/cycle.py
@@ -6,7 +6,7 @@ from app.filters import matches
 from app.planning import build_plans
 from app.repo import (active_subscriptions, digests_in_window, has_seen_slot,
                       record_cap_hold, reset_digest_streak)
-from app.scrapers import get_scraper
+from app.scrapers import get_scraper, UnsupportedCity
 from app.http_session import CountingSession
 from app.models import SeenKey, Slot, per_slot_key
 from app.analytics import record_availability
@@ -199,6 +199,12 @@ def run_cycle(conn: sqlite3.Connection, *, max_plans_per_city: int,
             polled_ok.setdefault(p.city, set()).add(p.appointment_type)
             if slots_by_plan[p.key()]:
                 cities_with_any_slot.add(p.city)
+        except UnsupportedCity as exc:
+            # Not an upstream hiccup but a tenant nobody can poll — its
+            # subscribers would otherwise wait in silence until the parser
+            # canary fires hours later.
+            print(f"cycle {cycle_id}: no scraper for {exc}", flush=True)
+            slots_by_plan[p.key()] = []
         except Exception:
             slots_by_plan[p.key()] = []
         polls_delta[p.city] = polls_delta.get(p.city, 0) + 1

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import json
 import sqlite3
+import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 from app.config import load_config
@@ -32,7 +33,7 @@ def run_once(conn: sqlite3.Connection) -> None:
     _prune_availability(conn)
     _check_parser_canary(conn, cfg)
     _check_backup_health(conn, cfg)
-    _sync_catalogs(conn, cfg)
+    _start_catalog_sync(cfg)
     _send_summary_email(conn, cfg)
     conn.execute(
         "INSERT INTO meta (key,value) VALUES ('last_housekeeping_at', ?) "
@@ -355,6 +356,45 @@ def _check_backup_health(conn, cfg):
                   idem_key=_idem_key(0, [], f"backup-stale-{datetime.utcnow().date()}"))
     except Exception:
         pass
+
+_sync_thread: threading.Thread | None = None
+
+def _start_catalog_sync(cfg) -> None:
+    """Run _sync_catalogs on its own thread, with its own connection.
+
+    Housekeeping runs inline in the poller's single loop, and the sync walks
+    every tenant against its live portal — TEVIS sleeps half a second per
+    service, Smart-CJM drives a three-step wizard per service — so done inline
+    it stopped polling for minutes once a day, and nothing noticed: no cycle
+    failed, the canary saw nothing, a slot that came and went in that window
+    was simply never reported. The thread is a daemon (the sync writes
+    atomically, so a stop mid-run leaves no half file) and a run still going
+    when the next day's housekeeping fires is left alone rather than doubled.
+    """
+    global _sync_thread
+    if not cfg.catalog_sync_enabled:
+        return
+    if _sync_thread is not None and _sync_thread.is_alive():
+        print("catalog sync: previous run still in progress, skipping", flush=True)
+        return
+
+    def _run():
+        from app.db import connect
+        conn = connect(cfg.db_path)
+        try:
+            _sync_catalogs(conn, cfg)
+        except Exception as exc:
+            print(f"catalog sync failed: {exc!r}", flush=True)
+        finally:
+            conn.close()
+
+    _sync_thread = threading.Thread(target=_run, name="catalog-sync", daemon=True)
+    _sync_thread.start()
+
+def wait_for_catalog_sync(timeout: float | None = None) -> None:
+    """Block until the background sync (if any) is done. For tests."""
+    if _sync_thread is not None:
+        _sync_thread.join(timeout)
 
 def _sync_catalogs(conn, cfg):
     """Refresh per-city catalog files from live APIs. Alerts developer on drift.

--- a/app/mail.py
+++ b/app/mail.py
@@ -169,6 +169,35 @@ def _single_send_chain() -> list[tuple[str, Any]]:
         chain.append((name, call))
     return chain or [("mailjet", _call_mailjet)]
 
+# How long a 'pending' idempotency claim is believed. A send is a handful of
+# provider calls, each capped by a 30 s HTTP timeout, so a claim still pending
+# after this many minutes belongs to a process that died between claiming and
+# sending (a `docker compose restart` mid-call is enough). It used to count as
+# "already sent" until the 14-day prune — for a stable key such as the
+# confirmation's `confirm-<id>` that meant every retry short-circuited and the
+# sign-up was silently abandoned after 7 days.
+_STALE_CLAIM_MINUTES = 15
+
+def _claim(conn: sqlite3.Connection, idem_key: str) -> bool:
+    """Claim `idem_key` for sending. True when this call owns it: either the
+    key was never seen, or its only trace is a stale pending claim, which is
+    taken over (one conditional UPDATE, so two concurrent callers cannot both
+    win). False when the mail was sent, or a live claim is in flight."""
+    cur = conn.execute(
+        "INSERT OR IGNORE INTO sent_idempotency (idem_key, provider) "
+        "VALUES (?, 'pending')",
+        (idem_key,),
+    )
+    if cur.rowcount == 1:
+        return True
+    cur = conn.execute(
+        "UPDATE sent_idempotency SET sent_at=CURRENT_TIMESTAMP "
+        "WHERE idem_key=? AND provider='pending' "
+        "AND sent_at < datetime('now', ?)",
+        (idem_key, f"-{_STALE_CLAIM_MINUTES} minutes"),
+    )
+    return cur.rowcount == 1
+
 def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
          *, idem_key: str, unsub_url: str | None = None,
          reply_to: str | None = None) -> None:
@@ -179,8 +208,9 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
     Order: claim the idempotency row FIRST (atomic INSERT OR IGNORE), then
     attempt sends. If every configured provider fails the claim is rolled back
     so a retry can proceed. If the process dies between claim and successful
-    send, the row remains with provider='pending' and the next call
-    short-circuits — preventing a double-send on crash recovery.
+    send, the row remains with provider='pending' and a call within
+    _STALE_CLAIM_MINUTES short-circuits — preventing a double-send on crash
+    recovery — while a later one takes the claim over and sends.
     """
     from app.repo import is_suppressed
 
@@ -194,23 +224,29 @@ def send(conn: sqlite3.Connection, to: str, subject: str, body: str,
     # coincidence of WHERE clauses, not a guarantee.
     if is_suppressed(conn, to):
         return
-    cur = conn.execute(
-        "INSERT OR IGNORE INTO sent_idempotency (idem_key, provider) "
-        "VALUES (?, 'pending')",
-        (idem_key,),
-    )
-    if cur.rowcount == 0:
-        return  # already claimed by an earlier call
+    if not _claim(conn, idem_key):
+        return  # already sent, or claimed by a call still in flight
+    provider = None
+    last_error = "no provider configured"
     try:
-        # Fail over on ANY provider error (4xx incl. 401/403 account blocks,
-        # and 5xx/429), not just transient ones — a blocked account returns
-        # 401, and that's exactly when the fallback must engage.
-        for provider, call in _single_send_chain():  # never empty: mailjet is the last resort
-            resp = call(to, subject, body, unsub_url, reply_to)
+        # Fail over on ANY provider error: a 4xx (incl. 401/403 account
+        # blocks), a 5xx/429, or the call not completing at all — a timeout or
+        # connection error is the provider being down just as much as a 503,
+        # and it used to escape this loop and skip the fallback chain.
+        for name, call in _single_send_chain():  # never empty: mailjet is the last resort
+            try:
+                resp = call(to, subject, body, unsub_url, reply_to)
+            except Exception as exc:
+                last_error = f"{name}: {exc!r}"
+                print(f"mail: {name} raised {exc!r}; trying next provider",
+                      flush=True)
+                continue
             if resp.status_code < 400:
+                provider = name
                 break
-        if resp.status_code >= 400:
-            raise MailFailed(f"provider failed; last status {resp.status_code}")
+            last_error = f"{name}: status {resp.status_code}"
+        if provider is None:
+            raise MailFailed(f"every provider failed; last: {last_error}")
     except Exception:
         conn.execute("DELETE FROM sent_idempotency WHERE idem_key=?", (idem_key,))
         raise
@@ -494,14 +530,9 @@ def send_batch(conn: sqlite3.Connection, items: list[Outgoing], cfg) -> BatchRes
                 # Never claimed, never sent, never retried: the address is out.
                 result.undeliverable.add(it.idem_key)
                 continue
-            cur = conn.execute(
-                "INSERT OR IGNORE INTO sent_idempotency (idem_key, provider) "
-                "VALUES (?, 'pending')",
-                (it.idem_key,),
-            )
-            if cur.rowcount == 1:
+            if _claim(conn, it.idem_key):
                 pending.append(it)
-            # rowcount 0 → already sent/claimed by an earlier cycle: skip.
+            # else: already sent, or claimed by a cycle still in flight.
 
     remaining = list(pending)
     refused: list[Outgoing] = []

--- a/app/ratelimit.py
+++ b/app/ratelimit.py
@@ -6,19 +6,45 @@ from collections import deque
 class IPRateLimiter:
     """In-memory sliding-window per-IP counter. Per-process state; with N
     gunicorn workers the effective limit is N*limit. Acceptable for a
-    soft bot deterrent. Do NOT use for security-critical decisions."""
+    soft bot deterrent. Do NOT use for security-critical decisions.
+
+    Keys are swept every `sweep_every` hits: a key whose newest event is older
+    than the longest window seen can never influence a verdict again, and
+    without the sweep every distinct client IP for the life of the worker
+    stayed in the dict — scanner traffic from many source addresses made it
+    grow without bound.
+    """
+    sweep_every = 1000
+
     def __init__(self):
         self._events: dict[str, deque] = {}
+        self._hits = 0
+        self._max_window = 0
 
     def hit(self, key: str, limit: int, window_seconds: int) -> bool:
         now = time.time()
-        dq = self._events.setdefault(key, deque())
+        self._max_window = max(self._max_window, window_seconds)
+        self._hits += 1
+        if self._hits % self.sweep_every == 0:
+            self._sweep(now)
+        dq = self._events.get(key)
+        if dq is None:
+            dq = self._events[key] = deque()
         while dq and now - dq[0] > window_seconds:
             dq.popleft()
         if len(dq) >= limit:
             return False
         dq.append(now)
         return True
+
+    def _sweep(self, now: float) -> None:
+        stale = [k for k, dq in self._events.items()
+                 if not dq or now - dq[-1] > self._max_window]
+        for k in stale:
+            del self._events[k]
+
+    def tracked_keys(self) -> int:
+        return len(self._events)
 
 GLOBAL_IP_LIMITER = IPRateLimiter()
 

--- a/app/scrapers/__init__.py
+++ b/app/scrapers/__init__.py
@@ -8,12 +8,17 @@ This is the only contract. Modules MUST NOT define classes or expect to
 be instantiated — `get_scraper(city)` returns the module itself, and the
 caller invokes `module.poll(plan, http=http)`. When adding a new city
 (e.g., Hamburg ODControls), create `app/scrapers/<vendor>.py` with this
-free function signature, then add an entry to `_REGISTRY` below.
+free function signature and add it to `_VENDORS` below. Cities are not
+listed here: `get_scraper(city)` reads `vendor` from the tenant's
+scraper_config.json, so a new catalog directory polls the moment it exists.
+(The old per-city registry had to be edited by hand, and a tenant left out of
+it signed people up and silently never polled — leipzig-abh shipped that way.)
 """
 from __future__ import annotations
 from types import ModuleType
 from typing import Protocol
 import requests
+from app.catalog import CatalogError, load_catalog
 from app.models import PollPlan, Slot
 from app.scrapers import smartcjm, tevis
 
@@ -24,61 +29,20 @@ class ScraperProtocol(Protocol):
 class UnsupportedCity(Exception):
     pass
 
-_REGISTRY: dict[str, ModuleType] = {
-    "leipzig": smartcjm,
-    "leipzig-abh": smartcjm,
-    "dresden": tevis,
-    "bochum": smartcjm,
-    # Bochum Straßenverkehrsamt (today the Büro für Kfz-Angelegenheiten),
-    # added 2026-08 on an r/bochum request: two calendars on the same
-    # Smart-CJM host as the Bürgerbüro, Mandant /m/kfz-angelegenheiten/,
-    # no locations step (one office each).
-    "bochum-fuehrerschein": smartcjm,
-    "bochum-kfz": smartcjm,
-    "bonn": smartcjm,
-    # TEVIS wave 2026-07 (vendor survey Tier 1): per-city config lives in
-    # catalog/<slug>/; all share the Dresden scraper.
-    "augsburg": tevis,
-    "bottrop": tevis,
-    "braunschweig": tevis,
-    "darmstadt": tevis,
-    "duesseldorf": tevis,
-    "hagen": tevis,
-    "ingolstadt": tevis,
-    "kaiserslautern": tevis,
-    "kassel": tevis,
-    "kiel": tevis,
-    "ludwigshafen": tevis,
-    "luebeck": tevis,
-    "mainz": tevis,
-    "moenchengladbach": tevis,
-    "moers": tevis,
-    "muenster": tevis,
-    "neuss": tevis,
-    "nuernberg": tevis,
-    "oberhausen": tevis,
-    "oldenburg": tevis,
-    "paderborn": tevis,
-    "remscheid": tevis,
-    "saarbruecken": tevis,
-    "salzgitter": tevis,
-    "trier": tevis,
-    # Münster Fachämter, added 2026-08 at the city's own request: separate
-    # Mandanten (md) on the same TEVIS instance as the Bürgeramt, so one
-    # tenant each. The Gesundheitsamt (md 23) is deliberately absent — its
-    # single Anliegen is STI counselling, i.e. Art. 9 GDPR data, and waits for
-    # the explicit-consent flow.
-    "muenster-einbuergerung": tevis,
-    "muenster-energieberatung": tevis,
-    "muenster-gewerbe": tevis,
-    "muenster-kfz": tevis,
-    "muenster-rente": tevis,
-    "muenster-standesamt": tevis,
+_VENDORS: dict[str, ModuleType] = {
+    "smartcjm": smartcjm,
+    "tevis": tevis,
 }
 
 def get_scraper(city: str) -> ModuleType:
-    """Return the scraper module for `city`. The module's `poll(plan, http)`
-    is the only attribute the caller may rely on."""
-    if city not in _REGISTRY:
-        raise UnsupportedCity(city)
-    return _REGISTRY[city]
+    """Return the scraper module for `city`, by the vendor its catalog
+    declares. The module's `poll(plan, http)` is the only attribute the caller
+    may rely on."""
+    try:
+        vendor = load_catalog(city).scraper_config.get("vendor")
+    except CatalogError as exc:
+        raise UnsupportedCity(f"{city}: {exc}") from exc
+    module = _VENDORS.get(vendor)
+    if module is None:
+        raise UnsupportedCity(f"{city}: unknown vendor {vendor!r}")
+    return module

--- a/app/web.py
+++ b/app/web.py
@@ -237,6 +237,34 @@ _RESULT_MESSAGES: dict[str, dict] = {
                "No appointment type was selected. Please go back and choose "
                "the type you need."),
     },
+    "unknown_type": {
+        "kind": "error",
+        "de": ("Anliegen unbekannt", "Dieses Anliegen gibt es hier nicht",
+               "Das gewählte Anliegen wird für diese Stadt nicht angeboten. "
+               "Bitte gehe zurück und wähle eines aus der Liste."),
+        "en": ("Unknown appointment type", "We don't offer that appointment type",
+               "The appointment type you chose isn't offered for this city. "
+               "Please go back and pick one from the list."),
+    },
+    "unknown_location": {
+        "kind": "error",
+        "de": ("Standort unbekannt", "Diesen Standort gibt es hier nicht",
+               "Mindestens einer der gewählten Standorte wird für diese Stadt "
+               "nicht angeboten. Bitte gehe zurück und wähle aus der Liste."),
+        "en": ("Unknown location", "We don't offer that location",
+               "At least one of the locations you chose isn't offered for "
+               "this city. Please go back and pick from the list."),
+    },
+    "invalid_time": {
+        "kind": "error",
+        "de": ("Zeitfenster ungültig", "Bitte überprüfe das Zeitfenster",
+               "Die Uhrzeiten müssen im Format HH:MM angegeben sein, und der "
+               "Beginn darf nicht nach dem Ende liegen. Bitte gehe zurück und "
+               "korrigiere die Angaben."),
+        "en": ("Invalid time window", "Please check the time window",
+               "Times must be given as HH:MM, and the start can't be after "
+               "the end. Please go back and correct them."),
+    },
 }
 
 
@@ -303,8 +331,72 @@ _OG_CITY_DESC = {
 
 
 def _parse_hhmm(s: str) -> time_cls:
-    h, m = s.split(":")
-    return time_cls(int(h), int(m))
+    """'HH:MM' (a trailing ':SS' is tolerated) → time. Raises ValueError on
+    anything else, including out-of-range hours; the caller turns that into a
+    400 rather than letting it surface as a 500."""
+    parts = (s or "").strip().split(":")
+    if len(parts) not in (2, 3):
+        raise ValueError(f"not HH:MM: {s!r}")
+    return time_cls(int(parts[0]), int(parts[1]))
+
+
+class _FormError(Exception):
+    """A rejected sign-up/manage form; `key` names the result page."""
+    def __init__(self, key: str):
+        super().__init__(key)
+        self.key = key
+
+
+def _filter_from_form(form, catalog) -> tuple[Filter, bool]:
+    """The Filter a sign-up or manage form asks for, validated against the
+    tenant's catalog. Returns (filter, is_sensitive); raises _FormError.
+
+    Every id has to be one the catalog offers. The form only ever posts those,
+    so a miss is a hand-built request — and it used to be stored anyway: an
+    unknown appointment_type became a PollPlan the poller sent upstream every
+    cycle, interpolated raw into the vendor's request, and each distinct junk
+    value counted toward MAX_PLANS_PER_CITY until real visitors were told the
+    wait-list was full.
+    """
+    atype = form.get("appointment_type", "").strip()
+    if not atype:
+        raise _FormError("missing_type")
+    if atype not in catalog.appointment_types.values():
+        raise _FormError("unknown_type")
+    # Special-category services (Art. 9 GDPR) need the separate explicit
+    # consent on top of the double opt-in. Enforced here rather than in the
+    # form because the box is hidden by script while an ordinary service is
+    # selected — and because a POST need never have rendered the page.
+    sensitive = catalog.is_sensitive(atype)
+    if sensitive and form.get("consent_special") != "1":
+        raise _FormError("consent_required")
+    all_locs = form.get("all_locations") == "1"
+    loc_list = form.getlist("locations")
+    if not all_locs and loc_list:
+        known = set(catalog.locations.values())
+        if any(loc not in known for loc in loc_list):
+            raise _FormError("unknown_location")
+    locations = "all" if all_locs or not loc_list else loc_list
+    weekdays = [int(d) for d in form.getlist("weekdays")
+                if d.isdigit() and 1 <= int(d) <= 7]
+    if not weekdays:
+        weekdays = [1, 2, 3, 4, 5, 6, 7]
+    try:
+        start = _parse_hhmm(form.get("time_start") or "00:00")
+        end = _parse_hhmm(form.get("time_end") or "23:59")
+    except ValueError:
+        raise _FormError("invalid_time") from None
+    if start > end:
+        # An empty window can never match; nobody means to ask for one.
+        raise _FormError("invalid_time")
+    return Filter(
+        appointment_types=[atype],
+        locations=locations,
+        weekdays=weekdays,
+        time_window_start=start,
+        time_window_end=end,
+        max_days_ahead=_parse_max_days(form.get("max_days_ahead")),
+    ), sensitive
 
 
 def _parse_max_days(raw: str | None) -> int | None:
@@ -826,37 +918,16 @@ def create_app() -> Flask:
         # An unknown city used to be stored anyway — a subscription no poller
         # would ever match — and since the redirect below builds "/{city}", it
         # also let a posted form choose the Location header.
-        if not _is_tenant(city):
-            return _result_page("unknown_city", lang, status=400)
-        atype = request.form.get("appointment_type", "").strip()
-        if not atype:
-            return _result_page("missing_type", lang, status=400)
-        # Special-category services (Art. 9 GDPR) need the separate explicit
-        # consent on top of the double opt-in. Enforced here rather than in the
-        # form because the box is hidden by script while an ordinary service is
-        # selected — and because a POST need never have rendered the page.
         try:
-            sensitive = load_catalog(city).is_sensitive(atype)
+            catalog = load_catalog(city) if city else None
         except CatalogError:
-            sensitive = False
-        if sensitive and request.form.get("consent_special") != "1":
-            return _result_page("consent_required", lang, status=400)
-        all_locs = request.form.get("all_locations") == "1"
-        loc_list = request.form.getlist("locations")
-        locations = "all" if all_locs or not loc_list else loc_list
-        weekdays = [int(d) for d in request.form.getlist("weekdays") if d.isdigit()]
-        if not weekdays:
-            weekdays = [1, 2, 3, 4, 5, 6, 7]
-        ts = request.form.get("time_start", "00:00")
-        te = request.form.get("time_end", "23:59")
-        f = Filter(
-            appointment_types=[atype],
-            locations=locations,
-            weekdays=weekdays,
-            time_window_start=_parse_hhmm(ts),
-            time_window_end=_parse_hhmm(te),
-            max_days_ahead=_parse_max_days(request.form.get("max_days_ahead")),
-        )
+            catalog = None
+        if catalog is None:
+            return _result_page("unknown_city", lang, status=400)
+        try:
+            f, sensitive = _filter_from_form(request.form, catalog)
+        except _FormError as err:
+            return _result_page(err.key, lang, status=400)
         # 5. plan-cap overflow check + insert atomically (spec 3.2.6).
         conn = connect(cfg.db_path)
         with transaction(conn):
@@ -962,52 +1033,53 @@ def create_app() -> Flask:
         conn = connect(cfg.db_path)
         if request.method == "POST":
             owner = conn.execute(
-                "SELECT city, language FROM subscriptions WHERE id=?",
+                "SELECT city, language FROM subscriptions "
+                "WHERE id=? AND deleted_at IS NULL",
                 (sub_id,)).fetchone()
-            lang = owner["language"] if owner else "de"
-            atype = request.form.get("appointment_type", "").strip()
-            if not atype:
-                return _result_page("missing_type", lang, status=400)
-            # Editing a filter is a second way to select a special-category
-            # service, so it carries the same Art. 9 consent gate as sign-up.
+            if not owner:
+                return _result_page("not_found",
+                                    request.args.get("lang", "de"), status=404)
+            lang = owner["language"]
             try:
-                sensitive = load_catalog(owner["city"]).is_sensitive(atype) if owner else False
+                catalog = load_catalog(owner["city"])
             except CatalogError:
-                sensitive = False
-            if sensitive and request.form.get("consent_special") != "1":
-                return _result_page("consent_required", lang, status=400)
-            all_locs = request.form.get("all_locations") == "1"
-            loc_list = request.form.getlist("locations")
-            locations = "all" if all_locs or not loc_list else loc_list
-            weekdays = [int(d) for d in request.form.getlist("weekdays") if d.isdigit()] or [1, 2, 3, 4, 5, 6, 7]
-            ts = request.form.get("time_start", "00:00")
-            te = request.form.get("time_end", "23:59")
-            f = Filter(appointment_types=[atype], locations=locations,
-                       weekdays=weekdays,
-                       time_window_start=_parse_hhmm(ts),
-                       time_window_end=_parse_hhmm(te),
-                       max_days_ahead=_parse_max_days(
-                           request.form.get("max_days_ahead")))
-            # Clear the cadence state along with the filter: both signals were
-            # measured against the OLD filter, and keeping them would leave
-            # someone who just narrowed a firehose down to one scarce office
-            # stuck on the slow cadence their previous filter earned.
-            conn.execute("UPDATE subscriptions SET filters_json=?, "
-                         "last_match_count=NULL, consecutive_digests=0 "
-                         "WHERE id=?",
-                         (f.to_json(), sub_id))
-            from app.repo import set_special_consent
-            set_special_consent(conn, sub_id, sensitive)
-            if sensitive:
-                # Switching into a special-category service also pulls the
-                # expiry in to the shorter retention — never pushes it out, so
-                # this can't be used to extend an ordinary subscription.
-                short = ttl_days_for(cfg, True)
-                conn.execute(
-                    "UPDATE subscriptions SET expires_at=datetime('now', ?) "
-                    "WHERE id=? AND expires_at > datetime('now', ?)",
-                    (f"+{short} days", sub_id, f"+{short} days"),
-                )
+                return _result_page("unknown_city", lang, status=400)
+            # Editing a filter is a second way to pick a service, so it gets
+            # the same validation and Art. 9 consent gate as sign-up.
+            try:
+                f, sensitive = _filter_from_form(request.form, catalog)
+            except _FormError as err:
+                return _result_page(err.key, lang, status=400)
+            with transaction(conn):
+                # The same cap check as /subscribe, minus this subscription's
+                # own current plan, which the new filter replaces. Without it
+                # the manage form was a way past the wait-list: a sign-up for
+                # a plan already being polled, then an edit to any other.
+                existing = [(s.city, s.sub_filter)
+                            for s in active_subscriptions(conn) if s.id != sub_id]
+                if would_exceed_cap(existing, owner["city"], f,
+                                    max_plans_per_city=cfg.max_plans_per_city):
+                    return _result_page("waitlist_full", lang, status=503)
+                # Clear the cadence state along with the filter: both signals
+                # were measured against the OLD filter, and keeping them would
+                # leave someone who just narrowed a firehose down to one scarce
+                # office stuck on the slow cadence their previous filter earned.
+                conn.execute("UPDATE subscriptions SET filters_json=?, "
+                             "last_match_count=NULL, consecutive_digests=0 "
+                             "WHERE id=?",
+                             (f.to_json(), sub_id))
+                from app.repo import set_special_consent
+                set_special_consent(conn, sub_id, sensitive)
+                if sensitive:
+                    # Switching into a special-category service also pulls the
+                    # expiry in to the shorter retention — never pushes it out,
+                    # so this can't be used to extend an ordinary subscription.
+                    short = ttl_days_for(cfg, True)
+                    conn.execute(
+                        "UPDATE subscriptions SET expires_at=datetime('now', ?) "
+                        "WHERE id=? AND expires_at > datetime('now', ?)",
+                        (f"+{short} days", sub_id, f"+{short} days"),
+                    )
             back_label = ("Zurück zu den Einstellungen" if lang == "de"
                           else "Back to your settings")
             return _result_page("updated", lang,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -640,3 +640,25 @@ def test_admin_renders_subscriber_and_cancellation_charts(client):
     assert "Subscribers" in html and "Cancellations" in html
     assert "Expired, not renewed" in html
     assert "1 people (1 unsubscribed, 0 expired)" in html
+
+
+def test_stats_plan_counts_use_the_loaded_config_cap(tmp_path, monkeypatch):
+    """stats() used to re-read MAX_PLANS_PER_CITY from the environment and
+    ignore the Config it was handed, so its plan counts could disagree with
+    what the poller actually builds."""
+    from datetime import time
+    from types import SimpleNamespace
+    from app.repo import insert_pending, confirm
+    from app.models import Filter
+    monkeypatch.delenv("MAX_PLANS_PER_CITY", raising=False)
+    conn = connect(str(tmp_path / "c.db")); init_schema(conn)
+    for loc in (["1"], ["2"]):
+        f = Filter(appointment_types=["A"], locations=loc, weekdays=[1],
+                   time_window_start=time(0, 0), time_window_end=time(23, 59))
+        sid = insert_pending(conn, email=f"{loc[0]}@example.com", city="dresden",
+                             language="de", filter_=f, ttl_days=90)
+        confirm(conn, sid)
+    cfg = SimpleNamespace(max_plans_per_city=1)
+    # Two distinct plans over a cap of one collapse to a single "all" plan.
+    assert stats(conn, cfg)["current_plan_count_by_city"]["dresden"] == 1
+    assert stats(conn)["current_plan_count_by_city"]["dresden"] == 2

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from app.catalog import load_catalog, CatalogError, Catalog
 
@@ -228,3 +229,72 @@ def test_shipped_bochum_kfz_tenants_protect_the_shared_host():
         assert len(cat.locations) == 1
     fs = load_catalog("bochum-fuehrerschein")
     assert fs.scraper_config["max_plans"] > len(fs.appointment_types)
+
+
+# ---------- a broken tenant is skipped, not fatal ----------
+
+def _write_tenant(root, slug):
+    city = root / slug
+    city.mkdir()
+    (city / "scraper_config.json").write_text(json.dumps(
+        {"vendor": "tevis", "base_url": "https://x", "md": 1, "mdt": 2}),
+        encoding="utf-8")
+    (city / "appointment_type.json").write_text(json.dumps({"Perso": "1"}),
+                                                encoding="utf-8")
+    (city / "locations.json").write_text(json.dumps({"Amt": "9"}),
+                                         encoding="utf-8")
+    return city
+
+
+def test_malformed_required_file_is_a_catalog_error(tmp_path, monkeypatch):
+    """A JSONDecodeError used to walk past every `except CatalogError`, so one
+    hand-edited file took down every tenant's page and the sitemap."""
+    from app import catalog as catalog_mod
+    city = _write_tenant(tmp_path, "broken")
+    (city / "appointment_type.json").write_text('{"Perso": "1",}',
+                                                encoding="utf-8")
+    monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", tmp_path)
+    catalog_mod.load_catalog.cache_clear()
+    try:
+        with pytest.raises(CatalogError, match="appointment_type.json"):
+            catalog_mod.load_catalog("broken")
+    finally:
+        catalog_mod.load_catalog.cache_clear()
+
+
+def test_rewritten_catalog_file_is_noticed_without_a_cache_clear(tmp_path, monkeypatch):
+    """catalog_sync rewrites files in the poller; the web workers are other
+    processes, so the cache has to notice on its own."""
+    import os
+    from app import catalog as catalog_mod
+    city = _write_tenant(tmp_path, "livecity")
+    monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", tmp_path)
+    catalog_mod.load_catalog.cache_clear()
+    try:
+        assert catalog_mod.load_catalog("livecity").appointment_types == {"Perso": "1"}
+        path = city / "appointment_type.json"
+        path.write_text(json.dumps({"Perso": "1", "Reisepass": "2"}),
+                        encoding="utf-8")
+        # Same second as the first write is possible; force a distinct mtime.
+        st = path.stat()
+        os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+        assert catalog_mod.load_catalog("livecity").appointment_types == {
+            "Perso": "1", "Reisepass": "2"}
+    finally:
+        catalog_mod.load_catalog.cache_clear()
+
+
+def test_every_tenant_loads_from_one_cache(monkeypatch):
+    """lru_cache(maxsize=8) over 38 tenants missed on nearly every call."""
+    from app import catalog as catalog_mod
+    from app.catalog import available_cities
+    catalog_mod.load_catalog.cache_clear()
+    cities = available_cities()
+    for c in cities:
+        load_catalog(c)
+    calls = []
+    monkeypatch.setattr(catalog_mod, "_read_catalog",
+                        lambda *a, **k: calls.append(a) or (_ for _ in ()).throw(AssertionError("re-read")))
+    for c in cities:
+        load_catalog(c)
+    assert calls == []

--- a/tests/test_housekeeping_catalog_sync.py
+++ b/tests/test_housekeeping_catalog_sync.py
@@ -2,7 +2,7 @@ from datetime import time
 from unittest.mock import patch
 import pytest
 from app.db import connect, init_schema
-from app.housekeeping import run_once
+from app.housekeeping import run_once, wait_for_catalog_sync
 
 
 def _env(monkeypatch, **overrides):
@@ -45,6 +45,7 @@ def test_housekeeping_runs_catalog_sync_when_flag_on(db, monkeypatch):
          patch("app.catalog_sync.sync_city") as sync_city:
         sync_city.return_value = {"service_drift": {}, "location_drift": {}}
         run_once(db)
+        wait_for_catalog_sync()
         assert sync_city.called
         # Should be called once per city directory under catalog/; leipzig is the
         # only one shipped today.
@@ -65,6 +66,7 @@ def test_housekeeping_alerts_developer_when_catalog_drift_detected(db, monkeypat
     with patch("app.mail.send") as mail_send, \
          patch("app.catalog_sync.sync_city", side_effect=fake_sync):
         run_once(db)
+        wait_for_catalog_sync()
         # mail.send must have been called at least once with the dev email
         # and a subject mentioning catalog drift.
         drift_calls = [c for c in mail_send.call_args_list
@@ -79,3 +81,27 @@ def test_housekeeping_swallows_catalog_sync_exception(db, monkeypatch):
     with patch("app.mail.send"), \
          patch("app.catalog_sync.sync_city", side_effect=RuntimeError("boom")):
         run_once(db)  # must not raise
+        wait_for_catalog_sync()
+
+
+def test_housekeeping_does_not_wait_for_the_catalog_sync(db, monkeypatch):
+    """The sync walks every tenant's live portal and takes minutes; run_once
+    is called inline from the poll loop, so it must hand the sync off and
+    return, or polling stops for the duration."""
+    import threading
+    _env(monkeypatch, CATALOG_SYNC_ENABLED="1")
+    release = threading.Event()
+    started = threading.Event()
+
+    def slow_sync(city, http, alert_fn, catalog_root=None):
+        started.set()
+        release.wait(5)
+        return {"service_drift": {}, "location_drift": {}}
+
+    with patch("app.mail.send"), \
+         patch("app.catalog_sync.sync_city", side_effect=slow_sync):
+        run_once(db)
+        assert started.wait(5)
+        # run_once has returned while the first city is still syncing.
+        release.set()
+        wait_for_catalog_sync(5)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -377,3 +377,73 @@ def test_failed_send_does_not_bump_counter(db, monkeypatch):
         with pytest.raises(MailFailed):
             send(db, "a@x.com", "s", "b", idem_key="cnt4")
     assert _day_count(db, "mailjet") == 0
+
+
+# ---------- failover on a provider that never answers ----------
+
+def test_failover_to_brevo_when_mailjet_raises(db, brevo_configured):
+    """A timeout or connection error is the provider being down just as much
+    as a 503, and it used to escape the loop: the claim was released and the
+    caller got the exception while Brevo sat idle."""
+    import requests
+    with patch("app.mail._call_mailjet", side_effect=requests.Timeout("slow")), \
+         patch("app.mail._call_brevo", return_value=_ok()) as bv:
+        send(db, "a@example.com", "s", "b", idem_key=_idem_key(1, [], "c"))
+    bv.assert_called_once()
+    row = db.execute("SELECT provider FROM sent_idempotency").fetchone()
+    assert row["provider"] == "brevo"
+
+
+def test_raises_when_every_provider_raises(db, brevo_configured):
+    import requests
+    with patch("app.mail._call_mailjet", side_effect=requests.Timeout("slow")), \
+         patch("app.mail._call_brevo", side_effect=requests.ConnectionError("down")):
+        with pytest.raises(MailFailed):
+            send(db, "a@example.com", "s", "b", idem_key=_idem_key(1, [], "c"))
+    assert db.execute("SELECT COUNT(*) AS n FROM sent_idempotency").fetchone()["n"] == 0
+
+
+# ---------- a claim orphaned by a crash ----------
+
+def test_stale_pending_claim_is_taken_over(db):
+    """A process killed between claiming and sending leaves provider='pending'.
+    For a stable key (confirm-<id>) that used to mean 'already sent' until the
+    14-day prune — every retry short-circuited and the mail never went."""
+    key = _idem_key(7, [], "confirm-7")
+    db.execute("INSERT INTO sent_idempotency (idem_key, provider, sent_at) "
+               "VALUES (?, 'pending', datetime('now', '-1 hour'))", (key,))
+    with patch("app.mail._call_mailjet", return_value=_ok()) as mj:
+        send(db, "a@example.com", "s", "b", idem_key=key)
+    mj.assert_called_once()
+    row = db.execute("SELECT provider FROM sent_idempotency WHERE idem_key=?",
+                     (key,)).fetchone()
+    assert row["provider"] == "mailjet"
+
+
+def test_fresh_pending_claim_is_respected(db):
+    """Within the stale window a pending row is a send in flight elsewhere."""
+    key = _idem_key(7, [], "confirm-7")
+    db.execute("INSERT INTO sent_idempotency (idem_key, provider) "
+               "VALUES (?, 'pending')", (key,))
+    with patch("app.mail._call_mailjet", return_value=_ok()) as mj:
+        send(db, "a@example.com", "s", "b", idem_key=key)
+    mj.assert_not_called()
+
+
+def test_send_batch_takes_over_a_stale_pending_claim(db, monkeypatch):
+    from types import SimpleNamespace
+    from app.mail import send_batch, Outgoing
+    monkeypatch.setenv("MAILJET_API_KEY", "m")
+    monkeypatch.setenv("MAILJET_API_SECRET", "m")
+    monkeypatch.setenv("MAILJET_FROM_EMAIL", "x@x")
+    monkeypatch.setenv("MAILJET_FROM_NAME", "x")
+    cfg = SimpleNamespace(mailjet_daily_quota=200, mailjet_hourly_quota=200,
+                          mailjet_monthly_quota=6000,
+                          email_provider_order=("mailjet",),
+                          max_send_failures_per_address=3)
+    key = _idem_key(7, [], "confirm-7")
+    db.execute("INSERT INTO sent_idempotency (idem_key, provider, sent_at) "
+               "VALUES (?, 'pending', datetime('now', '-1 hour'))", (key,))
+    with patch("app.mail._call_mailjet_batch", return_value=200):
+        result = send_batch(db, [Outgoing("a@example.com", "s", "b", key)], cfg)
+    assert key in result.delivered

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,30 @@
+"""IPRateLimiter must not grow by one entry per client address forever."""
+from app import ratelimit as rl
+
+
+def test_stale_keys_are_swept(monkeypatch):
+    clock = [1_000_000.0]
+    monkeypatch.setattr(rl.time, "time", lambda: clock[0])
+    lim = rl.IPRateLimiter()
+    lim.sweep_every = 50
+    for i in range(200):
+        assert lim.hit(f"ip:203.0.113.{i}", 5, 3600)
+    assert lim.tracked_keys() == 200
+    # Everything above is older than the window now; the next sweep drops it.
+    clock[0] += 3601
+    for i in range(50):
+        lim.hit(f"ip:198.51.100.{i}", 5, 3600)
+    assert lim.tracked_keys() <= 50
+
+
+def test_sweep_keeps_keys_that_still_count(monkeypatch):
+    clock = [1_000_000.0]
+    monkeypatch.setattr(rl.time, "time", lambda: clock[0])
+    lim = rl.IPRateLimiter()
+    lim.sweep_every = 10
+    assert lim.hit("ip:a", 1, 3600)
+    clock[0] += 1800
+    for _ in range(20):
+        lim.hit("ip:b", 100, 3600)
+    # "a" is inside its window and still over its limit: not swept, still blocked.
+    assert not lim.hit("ip:a", 1, 3600)

--- a/tests/test_scraper_dispatch.py
+++ b/tests/test_scraper_dispatch.py
@@ -8,3 +8,40 @@ def test_get_scraper_leipzig():
 def test_get_scraper_unknown():
     with pytest.raises(UnsupportedCity):
         get_scraper("atlantis")
+
+
+def test_dispatch_follows_the_catalog_vendor(tmp_path, monkeypatch):
+    """A new catalog directory polls without any registry edit."""
+    import json
+    from app import catalog as catalog_mod
+    from app.scrapers import smartcjm, tevis
+    for slug, vendor in (("newtown", "tevis"), ("othertown", "smartcjm")):
+        city = tmp_path / slug
+        city.mkdir()
+        (city / "scraper_config.json").write_text(json.dumps({"vendor": vendor}))
+        (city / "appointment_type.json").write_text("{}")
+        (city / "locations.json").write_text("{}")
+    monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", tmp_path)
+    catalog_mod.load_catalog.cache_clear()
+    try:
+        assert get_scraper("newtown") is tevis
+        assert get_scraper("othertown") is smartcjm
+    finally:
+        catalog_mod.load_catalog.cache_clear()
+
+
+def test_unknown_vendor_is_unsupported(tmp_path, monkeypatch):
+    import json
+    from app import catalog as catalog_mod
+    city = tmp_path / "vois"
+    city.mkdir()
+    (city / "scraper_config.json").write_text(json.dumps({"vendor": "vois"}))
+    (city / "appointment_type.json").write_text("{}")
+    (city / "locations.json").write_text("{}")
+    monkeypatch.setattr(catalog_mod, "CATALOG_ROOT", tmp_path)
+    catalog_mod.load_catalog.cache_clear()
+    try:
+        with pytest.raises(UnsupportedCity, match="vois"):
+            get_scraper("vois")
+    finally:
+        catalog_mod.load_catalog.cache_clear()

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -48,7 +48,10 @@ def test_subscribe_redirect_returns_to_the_city_and_language(client):
     """The post-subscribe banner has to land back on the tenant that was just
     signed up for — the root is the city picker, not anyone's form."""
     from unittest.mock import patch
-    form = _form("bob@example.com") | {"city": "bonn", "lang": "en"}
+    # A real Bonn service: the id has to be one the tenant's catalog offers.
+    form = _form("bob@example.com") | {
+        "city": "bonn", "lang": "en",
+        "appointment_type": "f9fc18f3-c5db-4d9d-9168-942d44063ca6"}
     with patch("app.web._send_confirmation_email", return_value=True):
         r = client.post("/subscribe", data=form,
                         headers={"X-Forwarded-For": "203.0.113.9"})
@@ -273,3 +276,75 @@ def test_a_complaint_block_is_never_lifted_by_signing_up(client, tmp_path):
                     headers={"X-Forwarded-For": "198.51.100.9"})
     assert r.status_code == 403
     assert is_suppressed(conn, email)
+
+
+# ---------- the form's ids have to be the catalog's ----------
+
+def test_subscribe_rejects_a_service_the_catalog_does_not_offer(client):
+    """An unknown appointment_type used to be stored anyway: it became a
+    PollPlan sent upstream every cycle and counted toward the city's plan cap."""
+    from unittest.mock import patch
+    form = _form("junk@example.com") | {"appointment_type": "x&services=y"}
+    with patch("app.web._send_confirmation_email", return_value=True) as send:
+        r = client.post("/subscribe", data=form,
+                        headers={"X-Forwarded-For": "203.0.113.50"})
+    assert r.status_code == 400
+    assert "Anliegen unbekannt" in r.get_data(as_text=True)
+    send.assert_not_called()
+
+
+def test_subscribe_rejects_a_location_the_catalog_does_not_offer(client):
+    from unittest.mock import patch
+    form = _form("loc@example.com") | {"all_locations": "0",
+                                       "locations": ["not-an-office"]}
+    with patch("app.web._send_confirmation_email", return_value=True) as send:
+        r = client.post("/subscribe", data=form,
+                        headers={"X-Forwarded-For": "203.0.113.51"})
+    assert r.status_code == 400
+    assert "Standort unbekannt" in r.get_data(as_text=True)
+    send.assert_not_called()
+
+
+def test_subscribe_accepts_a_location_the_catalog_offers(client):
+    from unittest.mock import patch
+    from app.catalog import load_catalog
+    office = next(iter(load_catalog("leipzig").locations.values()))
+    form = _form("loc2@example.com") | {"all_locations": "0",
+                                        "locations": [office]}
+    with patch("app.web._send_confirmation_email", return_value=True):
+        r = client.post("/subscribe", data=form,
+                        headers={"X-Forwarded-For": "203.0.113.52"})
+    assert r.status_code == 302
+
+
+# One address per case: the per-IP limiter is a session-wide singleton at
+# 2/hour in this fixture (see test_web_tests_global_ip_limiter in the wiki).
+@pytest.mark.parametrize("start,end,ip", [
+    ("25:00", "23:59", "203.0.113.60"), ("abc", "23:59", "203.0.113.61"),
+    ("09:00", "08:00", "203.0.113.62"), ("9", "17:00", "203.0.113.63")])
+def test_subscribe_rejects_a_malformed_time_window(client, start, end, ip):
+    """These used to raise inside _parse_hhmm and surface as a 500."""
+    from unittest.mock import patch
+    form = _form("time@example.com") | {"time_start": start, "time_end": end}
+    with patch("app.web._send_confirmation_email", return_value=True) as send:
+        r = client.post("/subscribe", data=form,
+                        headers={"X-Forwarded-For": ip})
+    assert r.status_code == 400
+    assert "Zeitfenster" in r.get_data(as_text=True)
+    send.assert_not_called()
+
+
+def test_subscribe_drops_weekdays_outside_the_week(client):
+    import os
+    from unittest.mock import patch
+    from app.db import connect
+    from app.models import Filter
+    form = _form("days@example.com") | {"weekdays": ["0", "3", "8"]}
+    with patch("app.web._send_confirmation_email", return_value=True):
+        r = client.post("/subscribe", data=form,
+                        headers={"X-Forwarded-For": "203.0.113.54"})
+    assert r.status_code == 302
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT filters_json FROM subscriptions WHERE email=?",
+                       ("days@example.com",)).fetchone()
+    assert Filter.from_json(row["filters_json"]).weekdays == [3]

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -303,3 +303,69 @@ def test_datenschutz_states_the_configured_terms(client):
     en = c.get("/datenschutz?lang=en").data.decode()
     assert "expire automatically 90 days after sign-up" in en
     assert "paused for 14 days" in en
+
+
+# ---------- /manage POST validates like /subscribe ----------
+
+LEIPZIG_SERVICE = "29cd0a26-fe7a-4d65-88cd-1e05fd749c71"
+
+
+def test_manage_post_rejects_a_service_the_catalog_does_not_offer(client):
+    c, sid = client
+    r = c.post(f"/manage/{_sign(sid, 'manage')}",
+               data={"appointment_type": "junk", "all_locations": "1"})
+    assert r.status_code == 400
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT filters_json FROM subscriptions WHERE id=?",
+                       (sid,)).fetchone()
+    assert Filter.from_json(row["filters_json"]).appointment_types == ["A"]
+
+
+def test_manage_post_rejects_a_malformed_time_window(client):
+    c, sid = client
+    r = c.post(f"/manage/{_sign(sid, 'manage')}",
+               data={"appointment_type": LEIPZIG_SERVICE, "all_locations": "1",
+                     "time_start": "25:00", "time_end": "23:59"})
+    assert r.status_code == 400
+
+
+def test_manage_post_updates_a_valid_filter(client):
+    c, sid = client
+    r = c.post(f"/manage/{_sign(sid, 'manage')}",
+               data={"appointment_type": LEIPZIG_SERVICE, "all_locations": "1",
+                     "time_start": "08:00", "time_end": "12:00"})
+    assert r.status_code == 200
+    conn = connect(os.environ["DB_PATH"])
+    row = conn.execute("SELECT filters_json FROM subscriptions WHERE id=?",
+                       (sid,)).fetchone()
+    f = Filter.from_json(row["filters_json"])
+    assert f.appointment_types == [LEIPZIG_SERVICE]
+    assert f.time_window_start == time(8, 0)
+
+
+def test_manage_post_honours_the_plan_cap(client):
+    """The manage form was a way past the wait-list: sign up for a plan
+    already polled, then edit into any other."""
+    from unittest.mock import patch
+    c, sid = client
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("UPDATE subscriptions SET confirmed_at=datetime('now') WHERE id=?", (sid,))
+    with patch("app.web.would_exceed_cap", return_value=True) as cap:
+        r = c.post(f"/manage/{_sign(sid, 'manage')}",
+                   data={"appointment_type": LEIPZIG_SERVICE, "all_locations": "1"})
+    assert r.status_code == 503
+    # Its own current plan is not counted against it.
+    existing = cap.call_args.args[0]
+    assert existing == []
+    row = conn.execute("SELECT filters_json FROM subscriptions WHERE id=?",
+                       (sid,)).fetchone()
+    assert Filter.from_json(row["filters_json"]).appointment_types == ["A"]
+
+
+def test_manage_post_for_a_deleted_subscription_is_not_found(client):
+    c, sid = client
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("UPDATE subscriptions SET deleted_at=datetime('now') WHERE id=?", (sid,))
+    r = c.post(f"/manage/{_sign(sid, 'manage')}",
+               data={"appointment_type": LEIPZIG_SERVICE, "all_locations": "1"})
+    assert r.status_code == 404

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -510,7 +510,8 @@ def test_signing_up_again_does_not_lift_a_complaint(db):
 def _signup(c, email, ip):
     return c.post("/subscribe",
                   data={"email": email, "city": "leipzig",
-                        "appointment_type": "A", "all_locations": "1",
+                        "appointment_type": "29cd0a26-fe7a-4d65-88cd-1e05fd749c71",
+                        "all_locations": "1",
                         "lang": "de"},
                   headers={"X-Forwarded-For": ip})
 


### PR DESCRIPTION
Closes the ten findings of the 2026-08-27 review of `app/`.

**Correctness**
- `/subscribe` and `/manage` validate `appointment_type` and `locations` against the tenant catalog. An unknown id used to become a `PollPlan` sent upstream every cycle and counted toward `MAX_PLANS_PER_CITY`. `/manage` POST now runs the same cap check as `/subscribe` (minus the subscription's own plan) and answers 404 for a deleted subscription.
- A malformed time window (`25:00`, `abc`, start after end) is a 400, not a 500; weekdays outside 1..7 are dropped. Both routes share `_filter_from_form`.
- `mail.send` fails over on a `requests` exception (timeout, connection error), not only on an HTTP status ≥ 400.
- A `pending` idempotency claim older than 15 minutes is a crash artifact and is taken over, so a stable key (`confirm-<id>`) no longer means "already sent" until the 14-day prune.
- The daily catalog sync runs on its own thread with its own connection; inline it stalled polling for minutes across 38 tenants.
- A malformed required catalog JSON is a `CatalogError`, so one broken tenant is skipped instead of taking every page down.

**Efficiency / maintenance**
- `load_catalog` keeps every tenant and re-reads a file when its mtime/size changes, so `catalog_sync`'s rewrites reach the web workers without a restart. `cache_clear()` is kept for tests.
- `IPRateLimiter` sweeps keys that can no longer affect a verdict.
- `get_scraper` dispatches on the catalog's `vendor`; the hand-maintained per-city registry is gone, and `run_cycle` logs a tenant no scraper can serve.
- `admin.stats` uses `cfg.max_plans_per_city` instead of re-reading the environment.

Tests: one or more per finding; 660 pass, ruff clean. Two existing tests posted a foreign service id (Leipzig's against Bonn, a literal `"A"`) and now use real ids.
