### PR TITLE
Name the subscription's end date at sign-up; auto-deploy on merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,78 @@
+# Auto-deploy: every push to main (i.e. every squash-merge) redeploys the VPS.
+# The command it runs is the Redeploy step of docs/DEPLOY.md — that file stays
+# the runbook; change the command there and here together.
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Deploys queue rather than overlap; a newer push deploys after, never during.
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check secrets are configured
+        env:
+          KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          TARGET: ${{ secrets.DEPLOY_SSH_TARGET }}
+        run: |
+          missing=""
+          [ -n "$KEY" ] || missing="$missing DEPLOY_SSH_KEY"
+          [ -n "$TARGET" ] || missing="$missing DEPLOY_SSH_TARGET"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repository secret(s):$missing — see docs/DEPLOY.md, 'Auto-deploy secrets'."
+            exit 1
+          fi
+
+      - name: Prepare SSH
+        env:
+          KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          echo "IdentityFile ~/.ssh/id_deploy" >> ~/.ssh/config
+          if [ -n "$KNOWN_HOSTS" ]; then
+            printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+            echo "StrictHostKeyChecking yes" >> ~/.ssh/config
+          else
+            # Trust-on-first-use: fine for a fresh runner, but a pinned
+            # DEPLOY_KNOWN_HOSTS (ssh-keyscan output) is the safer setup.
+            echo "StrictHostKeyChecking accept-new" >> ~/.ssh/config
+          fi
+
+      - name: Pull and rebuild on the VPS
+        env:
+          TARGET: ${{ secrets.DEPLOY_SSH_TARGET }}
+        run: |
+          ssh "$TARGET" 'cd ~/termine-notifier && git pull --ff-only && docker compose up -d --build'
+
+      - name: Verify the VPS runs this commit
+        env:
+          TARGET: ${{ secrets.DEPLOY_SSH_TARGET }}
+        run: |
+          deployed=$(ssh "$TARGET" 'cd ~/termine-notifier && git rev-parse HEAD')
+          if [ "$deployed" != "$GITHUB_SHA" ]; then
+            echo "::error::VPS checkout is at $deployed, expected $GITHUB_SHA"
+            exit 1
+          fi
+
+      - name: Verify /healthz
+        # The apex is the health check; www and termine.jakubwaller.eu only
+        # redirect, so probing them reports a healthy deploy as a failure.
+        run: |
+          sleep 10
+          out=$(curl -fsS --retry 5 --retry-delay 5 --retry-all-errors https://buergerwecker.de/healthz)
+          [ "$out" = "ok" ] || { echo "::error::healthz said: $out"; exit 1; }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,14 @@ jobs:
         env:
           KEY: ${{ secrets.DEPLOY_SSH_KEY }}
           KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          PORT: ${{ secrets.DEPLOY_SSH_PORT }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
           echo "IdentityFile ~/.ssh/id_deploy" >> ~/.ssh/config
+          echo "Port ${PORT:-22}" >> ~/.ssh/config
           if [ -n "$KNOWN_HOSTS" ]; then
             printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
             echo "StrictHostKeyChecking yes" >> ~/.ssh/config

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -127,11 +127,12 @@ def _checkin_mail(lang: str, *, city: str | None, expires_at: str,
                   grace_days: int, renew_url: str, unsub_url: str,
                   manage_url: str) -> tuple[str, str]:
     """Subject and plain-text body of the still-looking check-in."""
+    from app.i18n import format_date
     stop = datetime.fromisoformat(expires_at[:19]).date()
     resume_until = stop + timedelta(days=grace_days)
+    fmt = lambda d: format_date(d, lang)  # noqa: E731
     if lang == "en":
         where = f" in {city}" if city else ""
-        fmt = lambda d: f"{d.day} {d.strftime('%B %Y')}"  # noqa: E731
         subj = f"Still looking for an appointment{where}?"
         body = (
             f"Still looking for an appointment{where}?\n"
@@ -146,7 +147,6 @@ def _checkin_mail(lang: str, *, city: str | None, expires_at: str,
         )
     else:
         where = f" in {city}" if city else ""
-        fmt = lambda d: d.strftime("%d.%m.%Y")  # noqa: E731
         subj = f"Suchst du noch einen Termin{where}?"
         body = (
             f"Suchst du noch einen Termin{where}?\n"

--- a/app/i18n/__init__.py
+++ b/app/i18n/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import json
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
 
@@ -15,3 +16,10 @@ def t(lang: str, key: str, **kwargs) -> str:
     bundle = load(lang)
     template = bundle.get(key, key)
     return template.format(**kwargs)
+
+def format_date(d: date, lang: str) -> str:
+    """One date format per language, shared by every page and mail that names
+    a subscription's end date, so they can never disagree about the same day."""
+    if lang == "en":
+        return f"{d.day} {d.strftime('%B %Y')}"
+    return d.strftime("%d.%m.%Y")

--- a/app/templates/_parts.html
+++ b/app/templates/_parts.html
@@ -41,6 +41,14 @@
         weekdays and times in your subscription's settings.
       </p>
       {% endif %}
+      <h3>How long does my subscription run?</h3>
+      <p>
+        {{ ttl_days }} days. The exact end date is shown right after you
+        confirm, and again in the email with your management link. Shortly
+        before the end we ask by email whether you're still looking — one
+        click extends your subscription by another {{ ttl_days }} days; if
+        you don't reply, it ends automatically.
+      </p>
       <h3>Is this fair?</h3>
       <p>
         Fairer than the status quo. Without it, appointments go to whoever
@@ -71,6 +79,14 @@
         deiner Anmeldung ein.
       </p>
       {% endif %}
+      <h3>Wie lange läuft meine Anmeldung?</h3>
+      <p>
+        {{ ttl_days }} Tage. Das genaue Enddatum siehst du direkt nach der
+        Bestätigung und in der E-Mail mit deinem Verwaltungs-Link. Kurz vor
+        dem Ende fragen wir per E-Mail, ob du noch suchst — ein Klick
+        verlängert um weitere {{ ttl_days }} Tage, ohne Antwort endet die
+        Anmeldung automatisch.
+      </p>
       <h3>Ist das fair?</h3>
       <p>
         Fairer als der Status quo. Ohne das Tool bekommt die Termine, wer

--- a/app/templates/confirmed.html
+++ b/app/templates/confirmed.html
@@ -24,4 +24,18 @@
       Filter jederzeit ändern oder dich abmelden.
     {% endif %}
   </p>
+
+  {% if expires %}
+  <p>
+    {% if lang == 'en' %}
+      Your subscription runs until <strong>{{ expires }}</strong>. Shortly
+      before that we'll email you to ask whether you're still looking — one
+      click extends it, no reply ends it automatically.
+    {% else %}
+      Deine Anmeldung läuft bis zum <strong>{{ expires }}</strong>. Kurz
+      vorher fragen wir per E-Mail, ob du noch suchst — ein Klick verlängert
+      sie dann, ohne Antwort endet sie automatisch.
+    {% endif %}
+  </p>
+  {% endif %}
 {% endblock %}

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -5,6 +5,27 @@
     {% if lang == 'en' %}Manage your subscription{% else %}Abonnement verwalten{% endif %}
   </h1>
 
+  {% if expires %}
+  <p>
+    {% if lang == 'en' %}
+      {% if expired %}
+        This subscription expired on {{ expires }} — notifications are paused.
+      {% else %}
+        This subscription runs until {{ expires }}. Shortly before that we'll
+        email you to ask whether you're still looking.
+      {% endif %}
+    {% else %}
+      {% if expired %}
+        Diese Anmeldung ist am {{ expires }} abgelaufen — Benachrichtigungen
+        pausieren.
+      {% else %}
+        Diese Anmeldung läuft bis zum {{ expires }}. Kurz vorher fragen wir
+        per E-Mail, ob du noch suchst.
+      {% endif %}
+    {% endif %}
+  </p>
+  {% endif %}
+
   {% set current_type = current.appointment_types[0] if current.appointment_types else "" %}
   {% set all_locations = (current.locations == "all") %}
   {% set selected_loc_set = current.locations if not all_locations else [] %}

--- a/app/web.py
+++ b/app/web.py
@@ -6,7 +6,7 @@ import os
 import re
 import time as time_mod
 from collections import Counter
-from datetime import time as time_cls
+from datetime import datetime, time as time_cls
 from urllib.parse import urlencode
 from html import escape
 from pathlib import Path
@@ -21,6 +21,7 @@ from app.repo import (insert_pending, active_subscriptions, confirm,
                       soft_delete, suppression_reason, clear_delivery_block)
 from app.ratelimit import GLOBAL_IP_LIMITER, email_rate_limit_ok
 from app.tokens import sign, verify, InvalidToken
+from app.i18n import format_date
 from app.planning import would_exceed_cap
 from app.mail import send as mail_send, _idem_key
 from app.webhooks import (PARSERS, apply_events, check_secret,
@@ -416,10 +417,21 @@ def _send_confirmation_email(conn, sub_id: int, email: str, lang: str,
     return send_confirmation_now(conn, sub_id, email, lang, city, cfg)
 
 
+def _end_date(expires_at: str | None, lang: str) -> str | None:
+    """A subscription's end date, formatted for the language; None if gone."""
+    if not expires_at:
+        return None
+    return format_date(datetime.fromisoformat(expires_at[:19]).date(), lang)
+
+
 def _send_manage_link_email(conn, sub_id: int, cfg) -> None:
-    """Sends a separate email with the /manage link - NEVER in digests."""
+    """Sends a separate email with the /manage link - NEVER in digests.
+
+    Also the durable copy of the end date: the confirmed page shows it once
+    and is gone, this mail stays in the inbox (user ask, 2026-08-31 — a term
+    that ends silently reads as the service having died)."""
     row = conn.execute(
-        "SELECT email, language, city FROM subscriptions WHERE id=?",
+        "SELECT email, language, city, expires_at FROM subscriptions WHERE id=?",
         (sub_id,),
     ).fetchone()
     if not row:
@@ -430,13 +442,23 @@ def _send_manage_link_email(conn, sub_id: int, cfg) -> None:
     url = f"{cfg.public_base_url}/manage/{tok}"
     city_name = city_display_name(row["city"], row["language"])
     suffix = f" ({city_name})" if city_name else ""
+    end = _end_date(row["expires_at"], row["language"])
     if row["language"] == "de":
         body = (f"Dein Verwaltungs-Link: {url}\nMit diesem Link kannst du deine "
                 f"Einstellungen jederzeit ändern oder dich abmelden.")
+        if end:
+            body += (f"\n\nDeine Anmeldung läuft bis zum {end}. Kurz vorher "
+                     f"fragen wir per E-Mail, ob du noch suchst — ein Klick "
+                     f"verlängert sie dann, ohne Antwort endet sie automatisch.")
         subj = f"Verwaltungs-Link{suffix}"
     else:
         body = (f"Your management link: {url}\nUse it any time to change your "
                 f"settings or unsubscribe.")
+        if end:
+            body += (f"\n\nYour subscription runs until {end}. Shortly before "
+                     f"that we'll email you to ask whether you're still "
+                     f"looking — one click extends it, no reply ends it "
+                     f"automatically.")
         subj = f"Management link{suffix}"
     key = _idem_key(sub_id, [], f"manage-link-{sub_id}")
     mail_send(conn, row["email"], subj, body, idem_key=key)
@@ -654,10 +676,13 @@ def create_app() -> Flask:
                 "alternate_en": f"{base}{path}?lang=en",
                 "indexable": indexable,
                 "og_image": f"{base}/og-image.png",
-                # The FAQ promises the per-subscriber daily cap in words, so
-                # it reads the configured number rather than hard-coding one.
+                # The FAQ promises the per-subscriber daily cap and the
+                # subscription term in words, so it reads the configured
+                # numbers rather than hard-coding them.
                 "digest_cap": app.config["TERMINE_CONFIG"]
-                .max_digests_per_subscriber_per_day}
+                .max_digests_per_subscriber_per_day,
+                "ttl_days": app.config["TERMINE_CONFIG"]
+                .subscription_ttl_days}
 
     def _result_page(key: str, lang: str, *, status: int = 200,
                      action_url: str | None = None,
@@ -984,8 +1009,8 @@ def create_app() -> Flask:
                                 request.args.get("lang", "de"), status=400)
         conn = connect(cfg.db_path)
         confirm(conn, sub_id)
-        row = conn.execute("SELECT language FROM subscriptions WHERE id=?",
-                           (sub_id,)).fetchone()
+        row = conn.execute("SELECT language, expires_at FROM subscriptions "
+                           "WHERE id=?", (sub_id,)).fetchone()
         lang = row["language"] if row else "de"
         # The management-link email is a convenience, NOT part of confirmation.
         # The subscription is already confirmed above (autocommit), so a
@@ -999,6 +1024,8 @@ def create_app() -> Flask:
                 sub_id,
             )
         return render_template("confirmed.html", lang=lang,
+                               expires=_end_date(row["expires_at"], lang)
+                               if row else None,
                                kofi_url=cfg.kofi_url), 200
 
     # POST is the RFC 8058 one-click unsubscribe mail clients send to the
@@ -1091,8 +1118,12 @@ def create_app() -> Flask:
                                 status=404)
         catalog = load_catalog(row["city"])
         lang = row["language"]
+        expired = (datetime.fromisoformat(row["expires_at"][:19])
+                   < datetime.utcnow())
         return render_template("manage.html",
                                lang=lang, city=row["city"],
+                               expires=_end_date(row["expires_at"], lang),
+                               expired=expired,
                                appointment_types=catalog.appointment_types_for(lang),
                                locations=catalog.locations_for(lang), token=token,
                                sensitive_services=_offered_sensitive(catalog),

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -30,7 +30,28 @@
 
 ## Redeploy
 
-The normal path after a merge to `main`. The VPS holds a clone of this repo at
+Every push to `main` (i.e. every squash-merge) deploys automatically:
+`.github/workflows/deploy.yml` runs the command below over SSH, checks the VPS
+checkout is at the pushed commit, and probes `/healthz`. Watch the Deploy run
+go green instead of deploying by hand; the manual path below remains the
+fallback when the action is red or the secrets aren't set.
+
+### Auto-deploy secrets
+
+Three repository secrets (Settings → Secrets and variables → Actions):
+
+- `DEPLOY_SSH_KEY` — private key whose public half is in the VPS user's
+  `~/.ssh/authorized_keys`. Make a dedicated one rather than reusing your own:
+  `ssh-keygen -t ed25519 -f deploy_key -N "" -C buergerwecker-deploy`, then
+  `ssh-copy-id -i deploy_key.pub vps` and paste the contents of `deploy_key`.
+- `DEPLOY_SSH_TARGET` — `user@host` of the VPS.
+- `DEPLOY_KNOWN_HOSTS` (optional but recommended) — output of
+  `ssh-keyscan <host>`, pinning the VPS host key. Without it the workflow
+  trusts the host key on first use, every run.
+
+### Manual redeploy
+
+The fallback path after a merge to `main`. The VPS holds a clone of this repo at
 `~/termine-notifier` (containers `termine-notifier-web-1`, `-poller-1`, `-backup-1`):
 
 ```bash

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -45,9 +45,10 @@ Three repository secrets (Settings → Secrets and variables → Actions):
   `ssh-keygen -t ed25519 -f deploy_key -N "" -C buergerwecker-deploy`, then
   `ssh-copy-id -i deploy_key.pub vps` and paste the contents of `deploy_key`.
 - `DEPLOY_SSH_TARGET` — `user@host` of the VPS.
+- `DEPLOY_SSH_PORT` (optional) — sshd port when it isn't 22.
 - `DEPLOY_KNOWN_HOSTS` (optional but recommended) — output of
-  `ssh-keyscan <host>`, pinning the VPS host key. Without it the workflow
-  trusts the host key on first use, every run.
+  `ssh-keyscan -p <port> <host>`, pinning the VPS host key. Without it the
+  workflow trusts the host key on first use, every run.
 
 ### Manual redeploy
 

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -67,6 +67,72 @@ def test_confirm_survives_manage_link_email_failure(client):
     assert b"best\xc3\xa4tigt" in r.data.lower()  # "bestätigt"
 
 
+def _expected_end_date(sid, lang="de"):
+    from datetime import datetime
+    from app.i18n import format_date
+    conn = connect(os.environ["DB_PATH"])
+    exp = conn.execute("SELECT expires_at FROM subscriptions WHERE id=?",
+                       (sid,)).fetchone()["expires_at"]
+    return format_date(datetime.fromisoformat(exp[:19]).date(), lang)
+
+
+def test_confirm_page_states_the_end_date(client):
+    """The user ask of 2026-08-31: a term that ends silently reads as the
+    service having died, so the end date is named at the start."""
+    from unittest.mock import patch
+    c, sid = client
+    with patch("app.web._send_manage_link_email"):
+        r = c.get(f"/confirm/{_sign(sid, 'confirm')}")
+    assert r.status_code == 200
+    html = r.data.decode()
+    assert _expected_end_date(sid) in html
+    assert "läuft bis zum" in html
+
+
+def test_manage_link_email_states_the_end_date(client):
+    from unittest.mock import patch
+    c, sid = client
+    with patch("app.web.mail_send") as ms:
+        r = c.get(f"/confirm/{_sign(sid, 'confirm')}")
+    assert r.status_code == 200
+    body = ms.call_args.args[3]
+    assert "Verwaltungs-Link" in ms.call_args.args[2]
+    assert f"läuft bis zum {_expected_end_date(sid)}" in body
+
+
+def test_manage_page_states_the_end_date(client):
+    c, sid = client
+    r = c.get(f"/manage/{_sign(sid, 'manage')}")
+    assert r.status_code == 200
+    html = r.data.decode()
+    assert f"läuft bis zum {_expected_end_date(sid)}" in html
+
+
+def test_manage_page_says_expired_when_paused(client):
+    """An expired-but-in-grace subscription must not claim to still run."""
+    c, sid = client
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("UPDATE subscriptions SET expires_at=datetime('now','-1 day') "
+                 "WHERE id=?", (sid,))
+    r = c.get(f"/manage/{_sign(sid, 'manage')}")
+    assert r.status_code == 200
+    html = r.data.decode()
+    assert "abgelaufen" in html
+    assert "läuft bis zum" not in html
+
+
+def test_faq_states_the_configured_term(client):
+    """"Every couple of weeks" is exactly what confused a subscriber; the FAQ
+    names the configured number of days instead."""
+    c, _sid = client
+    de = c.get("/").data.decode()
+    assert "Wie lange läuft meine Anmeldung?" in de
+    assert "90 Tage" in de
+    en = c.get("/?lang=en").data.decode()
+    assert "How long does my subscription run?" in en
+    assert "90 days" in en
+
+
 def test_unsubscribe_soft_deletes(client):
     from unittest.mock import patch
     c, sid = client


### PR DESCRIPTION
A subscriber's term ended silently and read as the service having died (contact-form mail, 2026-08-31): the FAQ only promised a check-in "every couple of weeks", and nothing named the concrete date — his term expired just before PR #70 shipped the check-in mail.

**End date at sign-up**
- The confirmed page, the manage-link email (the durable copy in the inbox) and the manage page state the exact end date and what the check-in mail will do; the manage page says "abgelaufen am X" while a subscription is paused in its grace window.
- New FAQ entry answers "Wie lange läuft meine Anmeldung?" with the configured `SUBSCRIPTION_TTL_DAYS`.
- Date formatting is shared via `app.i18n.format_date`, so the check-in mail and the sign-up flow can never disagree about the same date.

**Auto-deploy**
- `.github/workflows/deploy.yml`: every push to `main` SSHes to the VPS, runs the DEPLOY.md redeploy command, verifies the VPS checkout is at the pushed commit, and probes `/healthz` for the literal `ok`. Deploys queue via a concurrency group; missing secrets fail loudly with a pointer to the runbook; nonstandard sshd port supported via `DEPLOY_SSH_PORT`.
- DEPLOY.md documents the secrets and keeps the manual path as the fallback.

Tests: 665 passed (`pytest -m "not live"`), `ruff check .` clean. The merge of this PR is the first live run of the Deploy workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wab1sLDYGMP1ceLsGKMa4N)_