### PR TITLE
Deploy: repair a line-broken key paste, fail readably on a bad one

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,8 +42,29 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          printf '%s\n' "$KEY" > ~/.ssh/id_deploy
+          printf '%s\n' "$KEY" | tr -d '\r' > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
+          # A key pasted from a phone often arrives with its line breaks
+          # collapsed to spaces; rebuild the PEM line structure if so.
+          python3 - << 'PY'
+          import os, re
+          p = os.path.expanduser("~/.ssh/id_deploy")
+          raw = open(p).read()
+          lines = raw.strip().splitlines()
+          if len(lines) <= 3 or any(len(ln) > 100 for ln in lines):
+              m = re.match(r"\s*(-----BEGIN [A-Z0-9 ]+-----)(.*?)(-----END [A-Z0-9 ]+-----)\s*$",
+                           raw, re.S)
+              if m:
+                  body = "".join(m.group(2).split())
+                  wrapped = [body[i:i + 70] for i in range(0, len(body), 70)]
+                  open(p, "w").write("\n".join([m.group(1), *wrapped, m.group(3)]) + "\n")
+          PY
+          # Fail here with a readable message rather than at ssh time with
+          # libcrypto noise (seen on the first live run, 2026-08-31).
+          if ! ssh-keygen -y -P '' -f ~/.ssh/id_deploy > /dev/null 2> /tmp/keyerr; then
+            echo "::error::DEPLOY_SSH_KEY is not a usable private key ($(tail -1 /tmp/keyerr)). Either it is passphrase-protected — make an unencrypted deploy key instead — or the paste lost characters; paste the whole file including the BEGIN/END lines."
+            exit 1
+          fi
           echo "IdentityFile ~/.ssh/id_deploy" >> ~/.ssh/config
           echo "Port ${PORT:-22}" >> ~/.ssh/config
           if [ -n "$KNOWN_HOSTS" ]; then


### PR DESCRIPTION
The first live Deploy run (33364896237) died at ssh time with `Load key: error in libcrypto` — the `DEPLOY_SSH_KEY` secret, pasted from a phone, is not a parseable PEM. The prepare step now:

- strips CR characters,
- rebuilds the PEM line structure when a paste collapsed the key to one line (verified byte-identical roundtrip against flattened and CRLF variants),
- validates the key with `ssh-keygen -y` up front, so a passphrase-protected or truncated key fails with a message naming the problem instead of libcrypto noise at ssh time.

If the secret's key is passphrase-protected rather than flattened, this run will now say so explicitly and the secret needs an unencrypted deploy key.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wab1sLDYGMP1ceLsGKMa4N)_