### PR TITLE
feat(scripts): mail the cohort whose term expired before the check-in existed

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -412,6 +412,28 @@ after that.
 The Datenschutz page reads all three periods from config, so it cannot promise a term the
 deploy no longer keeps.
 
+### One-off: apology mail for terms that expired before the check-in existed
+
+Terms that ended before the check-in shipped (2026-08-26, PR #70) expired silently — digests just
+stopped, and to the subscriber that looks like the service dying. `scripts/notify_silent_expired.py`
+mails the still-renewable part of that cohort once: an apology, the `/renew` link they never got,
+and the unsubscribe link. It selects confirmed, never-asked (`reminder_sent_at IS NULL`), expired
+subscriptions still inside `EXPIRED_GRACE_DAYS`; anyone already soft-deleted is left alone.
+
+Sends go through the same quota-aware batch path as digests, so the run cannot blow the daily
+pool: what does not fit is deferred and the report says so. Delivered subscribers get the
+once-per-term latch stamped, so re-running only retries the unsent rest. Dry run first:
+
+```bash
+ssh vps 'cd ~/termine-notifier && docker compose run --rm poller \
+    python scripts/notify_silent_expired.py --db /data/app.db'
+ssh vps 'cd ~/termine-notifier && docker compose run --rm poller \
+    python scripts/notify_silent_expired.py --db /data/app.db --send'
+```
+
+The cohort shrinks to nothing on its own as the grace windows close, so this script retires
+itself — after mid-September 2026 a dry run reporting 0 is the expected result.
+
 ## Polling cadence
 
 The poller wakes once a minute, but each tenant can set

--- a/scripts/notify_silent_expired.py
+++ b/scripts/notify_silent_expired.py
@@ -1,0 +1,195 @@
+"""One-off apology mail for subscriptions that expired without a warning.
+
+The still-looking check-in shipped 2026-08-26 (PR #70). Every term that ended
+before that expired the old way: digests just stopped, no mail at all — the
+subscriber's picture is a service that died (that is exactly how the first
+affected person read it). Anyone still inside EXPIRED_GRACE_DAYS is one
+`/renew` click away from turning the digests back on, but never received the
+link. This sends it, once, with the apology.
+
+Cohort: confirmed, not deleted, `reminder_sent_at IS NULL` (this term was
+never asked), expired, and still inside the grace window. Anyone past the
+grace window is left alone — their `/renew` deadline has passed and
+housekeeping deletes them on its own schedule. Anyone whose expiry lies ahead
+is the check-in's job, not this script's.
+
+Delivery goes through `send_batch`, so the run respects every provider's
+remaining quota: what does not fit is deferred with its idempotency claim
+released, and a later run picks it up. Delivered subscriptions get
+`reminder_sent_at` stamped — the same once-per-term latch the check-in uses,
+which `/renew` clears — so a re-run only retries what has not gone out.
+
+Dry run by default; `--send` sends.
+
+    docker compose run --rm poller \
+        python scripts/notify_silent_expired.py --db /data/app.db
+    docker compose run --rm poller \
+        python scripts/notify_silent_expired.py --db /data/app.db --send
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from datetime import datetime, timedelta
+
+# Running `python scripts/notify_silent_expired.py` puts *this* directory on
+# sys.path, not the repo root, so `app` would not import — and the poller image
+# has no installed copy to fall back on (see backfill_day_keys.py).
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.catalog import city_display_name  # noqa: E402
+from app.config import load_config  # noqa: E402
+from app.db import connect  # noqa: E402
+from app.i18n import format_date  # noqa: E402
+from app.mail import Outgoing, _idem_key, send_batch  # noqa: E402
+from app.tokens import sign  # noqa: E402
+
+
+def cohort(conn, cfg) -> list:
+    return conn.execute(
+        "SELECT id, email, language, city, expires_at FROM subscriptions "
+        "WHERE deleted_at IS NULL AND confirmed_at IS NOT NULL "
+        "AND reminder_sent_at IS NULL "
+        "AND expires_at < CURRENT_TIMESTAMP "
+        "AND expires_at >= datetime('now', ?) "
+        "ORDER BY expires_at",
+        (f"-{cfg.expired_grace_days} days",),
+    ).fetchall()
+
+
+def _apology_mail(lang: str, *, city: str | None, expires_at: str,
+                  grace_days: int, renew_url: str,
+                  unsub_url: str) -> tuple[str, str]:
+    stop = datetime.fromisoformat(expires_at[:19]).date()
+    resume_until = stop + timedelta(days=grace_days)
+    fmt = lambda d: format_date(d, lang)  # noqa: E731
+    where = f" in {city}" if city else ""
+    if lang == "en":
+        subj = "Your notifications expired, sorry"
+        body = (
+            f"Your appointment notifications{where} expired on {fmt(stop)}. "
+            f"There was no warning beforehand, that was our mistake. Sorry! "
+            f"By now a mail asks before the term runs out.\n"
+            f"\n"
+            f"Still looking?\n"
+            f"\n"
+            f"Yes, keep looking: {renew_url}\n"
+            f"No, I've got one: {unsub_url}\n"
+            f"\n"
+            f"Until {fmt(resume_until)} the first link switches the "
+            f"notifications back on. After that your sign-up is deleted.\n"
+        )
+    else:
+        subj = "Deine Benachrichtigungen sind ausgelaufen, sorry"
+        body = (
+            f"Deine Termin-Benachrichtigungen{where} sind am {fmt(stop)} "
+            f"ausgelaufen. Eine Vorwarnung gab es nicht, das war unser "
+            f"Fehler. Sorry! Inzwischen kommt vorher eine Mail mit der "
+            f"Frage, ob du noch suchst.\n"
+            f"\n"
+            f"Suchst du noch?\n"
+            f"\n"
+            f"Ja, weiter suchen: {renew_url}\n"
+            f"Nein, ich habe einen: {unsub_url}\n"
+            f"\n"
+            f"Bis {fmt(resume_until)} kannst du die Benachrichtigungen mit "
+            f"dem ersten Link wieder einschalten. Danach wird deine "
+            f"Anmeldung gelöscht.\n"
+        )
+    return subj, body
+
+
+def _outgoing(cfg, row) -> Outgoing:
+    lang = "en" if row["language"] == "en" else "de"
+    links = {}
+    for purpose in ("renew", "unsubscribe"):
+        tok = sign(row["id"], purpose,
+                   primary=cfg.token_secret_primary,
+                   previous=cfg.token_secret_previous)
+        links[purpose] = f"{cfg.public_base_url}/{purpose}/{tok}"
+    subj, body = _apology_mail(
+        lang, city=city_display_name(row["city"], lang),
+        expires_at=row["expires_at"], grace_days=cfg.expired_grace_days,
+        renew_url=links["renew"], unsub_url=links["unsubscribe"])
+    # The expiry date in the key for the same reason the check-in carries it:
+    # it names the term. Stable across runs, so a re-run inside the
+    # sent_idempotency retention cannot double-send; the cohort's grace-window
+    # bound is shorter than that retention, so no run can outlive the record.
+    return Outgoing(to=row["email"], subject=subj, body=body,
+                    idem_key=_idem_key(row["id"], [],
+                                       f"expiry-apology-{row['id']}"
+                                       f"-{row['expires_at'][:10]}"),
+                    unsub_url=links["unsubscribe"])
+
+
+def run(conn, cfg, *, send: bool) -> dict:
+    rows = cohort(conn, cfg)
+    stats = {"cohort": len(rows), "delivered": 0, "deferred": 0,
+             "undeliverable": 0, "marked": 0, "by_provider": {}}
+    if not rows:
+        return stats
+    for row in rows:
+        grace_end = (datetime.fromisoformat(row["expires_at"][:19])
+                     + timedelta(days=cfg.expired_grace_days))
+        print(f"  #{row['id']:<5} {row['city']:<20} lang={row['language']} "
+              f"expired {row['expires_at'][:10]}, "
+              f"renewable until {grace_end.date()}")
+    if not send:
+        return stats
+
+    items = [_outgoing(cfg, row) for row in rows]
+    result = send_batch(conn, items, cfg)
+    stats["delivered"] = len(result.delivered)
+    stats["deferred"] = result.deferred
+    stats["undeliverable"] = len(result.undeliverable)
+    stats["by_provider"] = result.sent_by_provider
+
+    # Stamp the once-per-term latch by what sent_idempotency records, not by
+    # this run's return value: if a previous run died between sending and
+    # stamping, its mail is on record and this run must not count the
+    # subscriber as unasked forever.
+    for row, item in zip(rows, items):
+        sent_row = conn.execute(
+            "SELECT provider FROM sent_idempotency WHERE idem_key=?",
+            (item.idem_key,)).fetchone()
+        if sent_row and sent_row["provider"] != "pending":
+            cur = conn.execute(
+                "UPDATE subscriptions SET reminder_sent_at=CURRENT_TIMESTAMP "
+                "WHERE id=? AND reminder_sent_at IS NULL", (row["id"],))
+            stats["marked"] += cur.rowcount
+    return stats
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db", required=True, help="path to app.db")
+    ap.add_argument("--send", action="store_true",
+                    help="send the mails (default: report the cohort only)")
+    args = ap.parse_args(argv)
+
+    cfg = load_config()
+    conn = connect(args.db)
+    # The live poller writes to this DB while the script runs; wait out a held
+    # write lock rather than dying on it (connect's default is 5s).
+    conn.execute("PRAGMA busy_timeout=30000")
+    stats = run(conn, cfg, send=args.send)
+
+    print(f"cohort (expired unwarned, still renewable): {stats['cohort']}")
+    if not args.send:
+        print("dry run — nothing sent. Re-run with --send.")
+        return 0
+    by = ", ".join(f"{k}: {v}" for k, v in stats["by_provider"].items())
+    print(f"delivered:     {stats['delivered']}" + (f" ({by})" if by else ""))
+    print(f"deferred:      {stats['deferred']}")
+    print(f"undeliverable: {stats['undeliverable']}")
+    print(f"latch stamped: {stats['marked']}")
+    if stats["deferred"]:
+        print("\nDeferred mails hit a provider quota wall; their claims are "
+              "released. Re-run this script once the window frees (check "
+              "/admin → Email quota) — it retries exactly the unsent rest.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_notify_silent_expired.py
+++ b/tests/test_notify_silent_expired.py
@@ -1,0 +1,182 @@
+"""The one-off apology mail for terms that expired before the check-in existed.
+
+Pre-PR-#70 expiries got no warning: digests just stopped. The script mails the
+still-renewable part of that cohort once — renew link, unsubscribe link, an
+apology — through the quota-aware batch path, and stamps the same once-per-term
+latch the check-in uses so nobody is asked twice.
+"""
+import pathlib
+import subprocess
+import sys
+from datetime import time
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from scripts.notify_silent_expired import cohort, run  # noqa: E402
+
+from app.config import load_config  # noqa: E402
+from app.db import connect, init_schema  # noqa: E402
+from app.models import Filter  # noqa: E402
+from app.repo import confirm, insert_pending  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("RENEWAL_REMINDER_DAYS_BEFORE", "10")
+    monkeypatch.setenv("SUBSCRIPTION_TTL_DAYS", "90")
+    monkeypatch.setenv("EXPIRED_GRACE_DAYS", "14")
+    monkeypatch.setenv("TOKEN_SECRET_PRIMARY", "x"*32)
+    monkeypatch.setenv("TOKEN_SECRET_PREVIOUS", "")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://x")
+    monkeypatch.setenv("MAILJET_API_KEY", "m"); monkeypatch.setenv("MAILJET_API_SECRET", "m")
+    monkeypatch.setenv("MAILJET_FROM_EMAIL", "x@x"); monkeypatch.setenv("MAILJET_FROM_NAME", "x")
+    monkeypatch.setenv("MAILJET_HOURLY_QUOTA", "200")
+    monkeypatch.setenv("MAILJET_DAILY_QUOTA", "200")
+    monkeypatch.setenv("ADMIN_TOKEN", "a"*32)
+    monkeypatch.setenv("DEDUP_WINDOW_HOURS", "24"); monkeypatch.setenv("RATE_LIMIT_MINUTES", "15")
+    monkeypatch.setenv("MAX_PLANS_PER_CITY", "10"); monkeypatch.setenv("PARSER_CANARY_THRESHOLD_HOURS", "2")
+    monkeypatch.setenv("SUBSCRIBE_RATELIMIT_PER_IP_PER_HOUR", "99")
+    monkeypatch.setenv("SUBSCRIBE_RATELIMIT_PER_EMAIL_PER_DAY", "99")
+    monkeypatch.setenv("DEVELOPER_EMAIL", "dev@x"); monkeypatch.setenv("KOFI_URL", "https://k")
+    monkeypatch.setenv("WEBHOOK_SECRET", "w"*32)
+    conn = connect(db_path); init_schema(conn)
+    return conn
+
+
+def _f():
+    return Filter(appointment_types=["A"], locations="all", weekdays=[1,2,3,4,5,6,7],
+                  time_window_start=time(0,0), time_window_end=time(23,59))
+
+
+def _sub(db, email="a@example.com", lang="de", expired_days_ago=3,
+         confirmed=True):
+    sid = insert_pending(db, email=email, city="leipzig", language=lang,
+                         filter_=_f(), ttl_days=90)
+    if confirmed:
+        confirm(db, sid)
+    db.execute("UPDATE subscriptions SET expires_at=datetime('now', ?) "
+               "WHERE id=?", (f"{-expired_days_ago:+d} days", sid))
+    return sid
+
+
+def test_cohort_is_expired_unwarned_and_still_renewable(db):
+    inside = _sub(db, "in@example.com", expired_days_ago=3)
+    _sub(db, "future@example.com", expired_days_ago=-30)       # check-in's job
+    _sub(db, "gone@example.com", expired_days_ago=20)          # grace over
+    _sub(db, "pending@example.com", confirmed=False)           # never confirmed
+    asked = _sub(db, "asked@example.com", expired_days_ago=3)  # check-in sent
+    db.execute("UPDATE subscriptions SET reminder_sent_at=CURRENT_TIMESTAMP "
+               "WHERE id=?", (asked,))
+    deleted = _sub(db, "deleted@example.com", expired_days_ago=3)
+    db.execute("UPDATE subscriptions SET deleted_at=CURRENT_TIMESTAMP "
+               "WHERE id=?", (deleted,))
+    rows = cohort(db, load_config())
+    assert [r["id"] for r in rows] == [inside]
+
+
+def test_dry_run_reports_and_sends_nothing(db):
+    _sub(db)
+    with patch("app.mail._call_mailjet_batch") as mb:
+        stats = run(db, load_config(), send=False)
+    assert stats["cohort"] == 1 and stats["delivered"] == 0
+    mb.assert_not_called()
+    row = db.execute("SELECT reminder_sent_at FROM subscriptions").fetchone()
+    assert row["reminder_sent_at"] is None
+    assert db.execute("SELECT COUNT(*) AS n FROM sent_idempotency"
+                      ).fetchone()["n"] == 0
+
+
+def test_send_delivers_apology_with_both_links_and_stamps_latch(db):
+    from datetime import datetime, timedelta
+    sid = _sub(db, expired_days_ago=3)
+    sent_items = []
+    def _capture(items):
+        sent_items.extend(items)
+        return 200
+    with patch("app.mail._call_mailjet_batch", side_effect=_capture):
+        stats = run(db, load_config(), send=True)
+    assert stats == {"cohort": 1, "delivered": 1, "deferred": 0,
+                     "undeliverable": 0, "marked": 1,
+                     "by_provider": {"mailjet": 1}}
+    (item,) = sent_items
+    assert item.to == "a@example.com"
+    assert "sorry" in item.subject
+    assert "https://x/renew/" in item.body
+    assert "https://x/unsubscribe/" in item.body
+    assert item.unsub_url.startswith("https://x/unsubscribe/")
+    # Both dates: when it stopped, and until when the renew link revives it.
+    expires = db.execute("SELECT expires_at FROM subscriptions WHERE id=?",
+                         (sid,)).fetchone()["expires_at"]
+    stop = datetime.fromisoformat(expires[:19]).date()
+    assert stop.strftime("%d.%m.%Y") in item.body
+    assert (stop + timedelta(days=14)).strftime("%d.%m.%Y") in item.body
+    row = db.execute("SELECT reminder_sent_at FROM subscriptions WHERE id=?",
+                     (sid,)).fetchone()
+    assert row["reminder_sent_at"] is not None
+
+
+def test_english_subscriber_gets_the_english_mail(db):
+    _sub(db, lang="en")
+    sent_items = []
+    def _capture(items):
+        sent_items.extend(items)
+        return 200
+    with patch("app.mail._call_mailjet_batch", side_effect=_capture):
+        run(db, load_config(), send=True)
+    (item,) = sent_items
+    assert "Still looking?" in item.body
+    assert "Yes, keep looking: https://x/renew/" in item.body
+
+
+def test_second_send_run_mails_nobody(db):
+    _sub(db)
+    with patch("app.mail._call_mailjet_batch", return_value=200) as mb:
+        run(db, load_config(), send=True)
+        stats = run(db, load_config(), send=True)
+    assert mb.call_count == 1
+    assert stats["cohort"] == 0 and stats["delivered"] == 0
+
+
+def test_over_quota_defers_without_stamping_so_a_rerun_retries(db, monkeypatch):
+    monkeypatch.setenv("MAILJET_HOURLY_QUOTA", "0")
+    monkeypatch.setenv("MAILJET_DAILY_QUOTA", "0")
+    sid = _sub(db)
+    with patch("app.mail._call_mailjet_batch") as mb:
+        stats = run(db, load_config(), send=True)
+    mb.assert_not_called()
+    assert stats["deferred"] == 1 and stats["marked"] == 0
+    assert db.execute("SELECT reminder_sent_at FROM subscriptions WHERE id=?",
+                      (sid,)).fetchone()["reminder_sent_at"] is None
+    # The quota frees; the rerun delivers what was deferred.
+    monkeypatch.setenv("MAILJET_HOURLY_QUOTA", "200")
+    monkeypatch.setenv("MAILJET_DAILY_QUOTA", "200")
+    with patch("app.mail._call_mailjet_batch", return_value=200):
+        stats = run(db, load_config(), send=True)
+    assert stats["delivered"] == 1 and stats["marked"] == 1
+
+
+def test_suppressed_address_is_left_alone(db):
+    sid = _sub(db)
+    db.execute("INSERT INTO email_suppressions (email, reason) "
+               "VALUES ('a@example.com', 'bounce')")
+    with patch("app.mail._call_mailjet_batch") as mb:
+        stats = run(db, load_config(), send=True)
+    mb.assert_not_called()
+    assert stats["undeliverable"] == 1 and stats["marked"] == 0
+    assert db.execute("SELECT reminder_sent_at FROM subscriptions WHERE id=?",
+                      (sid,)).fetchone()["reminder_sent_at"] is None
+
+
+def test_runs_as_a_plain_script_from_a_foreign_cwd(tmp_path):
+    """Guards the sys.path bootstrap: module-scope imports run before main."""
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "notify_silent_expired.py"),
+         "--help"],
+        cwd=tmp_path, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Everyone whose term ended before the check-in shipped (PR #70, 2026-08-26) stopped getting digests with no warning. The ones still inside EXPIRED_GRACE_DAYS can revive their subscription with one /renew click but never got the link.

scripts/notify_silent_expired.py selects that cohort (confirmed, reminder_sent_at IS NULL, expired, still in grace), prints it as a dry run, and with --send mails each person once: an apology, the renew link, the unsubscribe link. Delivery goes through send_batch so provider quotas hold; deferred mail is picked up by re-running. Delivered subscribers get reminder_sent_at stamped, read back from sent_idempotency so a crashed run does not re-send.

Already soft-deleted subscriptions are left alone. Runbook section in DEPLOY.md, ships in the poller image via the existing scripts/ COPY.