### PR TITLE
fix(scripts): don't invite back people who already signed up again

### DIFF
--- a/scripts/notify_silent_expired.py
+++ b/scripts/notify_silent_expired.py
@@ -47,12 +47,21 @@ from app.tokens import sign  # noqa: E402
 
 
 def cohort(conn, cfg) -> list:
+    # The NOT EXISTS drops anyone who already signed up again for the same
+    # city: their old row still matches, but reviving it next to the new one
+    # would double their digests — and the person plainly needs no invitation
+    # back. NOCASE because a re-signup can spell the address differently.
     return conn.execute(
         "SELECT id, email, language, city, expires_at FROM subscriptions "
         "WHERE deleted_at IS NULL AND confirmed_at IS NOT NULL "
         "AND reminder_sent_at IS NULL "
         "AND expires_at < CURRENT_TIMESTAMP "
         "AND expires_at >= datetime('now', ?) "
+        "AND NOT EXISTS ("
+        "  SELECT 1 FROM subscriptions s2 "
+        "  WHERE s2.email = subscriptions.email COLLATE NOCASE "
+        "  AND s2.city = subscriptions.city AND s2.id != subscriptions.id "
+        "  AND s2.deleted_at IS NULL AND s2.expires_at > CURRENT_TIMESTAMP) "
         "ORDER BY expires_at",
         (f"-{cfg.expired_grace_days} days",),
     ).fetchall()

--- a/tests/test_notify_silent_expired.py
+++ b/tests/test_notify_silent_expired.py
@@ -80,6 +80,20 @@ def test_cohort_is_expired_unwarned_and_still_renewable(db):
     assert [r["id"] for r in rows] == [inside]
 
 
+def test_someone_who_signed_up_again_is_not_invited_back(db):
+    """Reviving the old row next to the new one would double their digests;
+    the re-signup also means the apology's call to action is moot."""
+    _sub(db, "back@example.com", expired_days_ago=3)
+    _sub(db, "Back@example.com", expired_days_ago=-90)  # fresh term, same city
+    other_city = _sub(db, "elsewhere@example.com", expired_days_ago=3)
+    sid = insert_pending(db, email="elsewhere@example.com", city="dresden",
+                         language="de", filter_=_f(), ttl_days=90)
+    confirm(db, sid)
+    rows = cohort(db, load_config())
+    # A live subscription in a DIFFERENT city does not cover the expired one.
+    assert [r["id"] for r in rows] == [other_city]
+
+
 def test_dry_run_reports_and_sends_nothing(db):
     _sub(db)
     with patch("app.mail._call_mailjet_batch") as mb:


### PR DESCRIPTION
Reviving the old row next to the new one would double their digests, and
whoever came back on their own needs no apology mail.
