### PR TITLE
Add FUNDING.yml (Ko-fi sponsor button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: jakubwaller


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with the Ko-fi handle so the repository page shows GitHub's Sponsor button pointing at ko-fi.com/jakubwaller. No code changes.

After merging, check Settings → General → Features → Sponsorships is ticked, otherwise the button stays hidden.