### PR TITLE
content(faq): the tool reserves nothing

### DIFF
--- a/app/templates/_parts.html
+++ b/app/templates/_parts.html
@@ -52,7 +52,9 @@
       <h3>Is this fair?</h3>
       <p>
         Fairer than the status quo. Without it, appointments go to whoever
-        hits F5 all day or pays a slot reseller. This is free and the
+        hits F5 all day or pays a slot reseller. This tool reserves nothing:
+        a free slot stays on the city's page for everyone, you just don't
+        have to refresh it all day. It is free and the
         <a href="https://github.com/jakubwaller/buergerwecker">code is
         public</a> (AGPLv3).
       </p>
@@ -91,7 +93,9 @@
       <p>
         Fairer als der Status quo. Ohne das Tool bekommt die Termine, wer
         den ganzen Tag F5 drückt oder einen Termin-Weiterverkäufer bezahlt.
-        Das hier ist kostenlos und der
+        Das Tool reserviert nichts: Ein freier Termin bleibt auf der Seite
+        der Stadt, für alle, du musst die Seite nur nicht mehr den ganzen Tag
+        neu laden. Das hier ist kostenlos und der
         <a href="https://github.com/jakubwaller/buergerwecker">Code ist
         öffentlich</a> (AGPLv3).
       </p>


### PR DESCRIPTION
The fairness answer now says what it rests on: a free slot stays on the city's page for everyone, the tool only saves the refreshing. Same in DE and EN. No test change, the FAQ tests check the headings only.