### PR TITLE
Confirmation mail: say who is writing and that the link is the action

### DIFF
--- a/app/confirmations.py
+++ b/app/confirmations.py
@@ -17,8 +17,8 @@ from app.tokens import sign
 _TEXT = {
     "de": {
         "subject": "Bitte bestätige deine Anmeldung bei Bürgerwecker",
-        "signed_up_city": "du hast dich gerade auf {host} für Terminbenachrichtigungen in {city} angemeldet.",
-        "signed_up": "du hast dich gerade auf {host} für Terminbenachrichtigungen angemeldet.",
+        "signed_up_city": "du hast dich auf {host} für Terminbenachrichtigungen in {city} angemeldet.",
+        "signed_up": "du hast dich auf {host} für Terminbenachrichtigungen angemeldet.",
         "body": (
             "Hallo,\n\n{signed_up}\n\n"
             "Klick auf diesen Link, um die Anmeldung zu bestätigen:\n\n{url}\n\n"
@@ -30,8 +30,8 @@ _TEXT = {
     },
     "en": {
         "subject": "Please confirm your Bürgerwecker sign-up",
-        "signed_up_city": "you just signed up on {host} for appointment notifications in {city}.",
-        "signed_up": "you just signed up on {host} for appointment notifications.",
+        "signed_up_city": "you signed up on {host} for appointment notifications in {city}.",
+        "signed_up": "you signed up on {host} for appointment notifications.",
         "body": (
             "Hello,\n\n{signed_up}\n\n"
             "Click this link to confirm your sign-up:\n\n{url}\n\n"

--- a/app/confirmations.py
+++ b/app/confirmations.py
@@ -8,9 +8,40 @@ marks a sign-up as done so it isn't re-sent.
 """
 from __future__ import annotations
 import sqlite3
+from urllib.parse import urlsplit
 from app.mail import send_batch, Outgoing, _idem_key
 from app.repo import set_confirmation_sent, pending_confirmations
 from app.tokens import sign
+
+
+_TEXT = {
+    "de": {
+        "subject": "Bitte bestätige deine Anmeldung bei Bürgerwecker",
+        "signed_up_city": "du hast dich gerade auf {host} für Terminbenachrichtigungen in {city} angemeldet.",
+        "signed_up": "du hast dich gerade auf {host} für Terminbenachrichtigungen angemeldet.",
+        "body": (
+            "Hallo,\n\n{signed_up}\n\n"
+            "Klick auf diesen Link, um die Anmeldung zu bestätigen:\n\n{url}\n\n"
+            "Erst danach bekommst du eine Mail, sobald ein passender Termin frei "
+            "wird. Falls der Link nicht anklickbar ist, kopiere ihn in die "
+            "Adresszeile deines Browsers.\n\n"
+            "Wenn du dich nicht angemeldet hast, ignoriere diese Mail einfach.\n\n"
+            "Bürgerwecker\n"),
+    },
+    "en": {
+        "subject": "Please confirm your Bürgerwecker sign-up",
+        "signed_up_city": "you just signed up on {host} for appointment notifications in {city}.",
+        "signed_up": "you just signed up on {host} for appointment notifications.",
+        "body": (
+            "Hello,\n\n{signed_up}\n\n"
+            "Click this link to confirm your sign-up:\n\n{url}\n\n"
+            "Only then will you get an email as soon as a matching slot opens "
+            "up. If the link is not clickable, copy it into your browser's "
+            "address bar.\n\n"
+            "If you did not sign up, just ignore this email.\n\n"
+            "Bürgerwecker\n"),
+    },
+}
 
 
 def build_confirmation(sub_id: int, email: str, lang: str, city: str,
@@ -20,17 +51,16 @@ def build_confirmation(sub_id: int, email: str, lang: str, city: str,
                primary=cfg.token_secret_primary,
                previous=cfg.token_secret_previous)
     url = f"{cfg.public_base_url}/confirm/{tok}"
+    host = urlsplit(cfg.public_base_url).netloc or cfg.public_base_url
     city_name = city_display_name(city, lang)
-    if lang == "en":
-        subject = (f"Confirmation needed ({city_name})" if city_name
-                   else "Confirmation needed")
-        body = (f"Please confirm your subscription for {city_name}: {url}"
-                if city_name else f"Please confirm your subscription: {url}")
-    else:
-        subject = (f"Bestätigung benötigt ({city_name})" if city_name
-                   else "Bestätigung benötigt")
-        body = (f"Bitte bestätige dein Abonnement für {city_name}: {url}"
-                if city_name else f"Bitte bestätige dein Abonnement: {url}")
+    t = _TEXT["en" if lang == "en" else "de"]
+    # Say who is writing, why, and that the link is the action. The old
+    # one-liner ("Bitte bestätige dein Abonnement: <url>") read as a request
+    # to answer, and people replied to it instead of clicking.
+    subject = f"{t['subject']} ({city_name})" if city_name else t["subject"]
+    signed_up = (t["signed_up_city"].format(host=host, city=city_name)
+                 if city_name else t["signed_up"].format(host=host))
+    body = t["body"].format(signed_up=signed_up, url=url)
     # Stable per-subscription key: a deferred send and its later retry share it,
     # so the idempotency layer never double-sends a confirmation.
     return Outgoing(to=email, subject=subject, body=body,

--- a/tests/test_confirmations.py
+++ b/tests/test_confirmations.py
@@ -101,15 +101,19 @@ def test_retry_abandons_stale_signups(db):
 def test_confirmation_says_to_click_and_puts_the_link_on_its_own_line(lang, click, own):
     # A bare "Bitte bestätige dein Abonnement: <url>" got answered by reply
     # mail instead of a click (twice, by 2026-09-04).
-    item = build_confirmation(7, "a@example.com", lang, "leipzig", _cfg())
+    item = build_confirmation(7, "a@example.com", lang, "leipzig",
+                              _cfg(public_base_url="https://site.example"))
     assert item.to == "a@example.com"
     assert "Leipzig" in item.subject
     assert click in item.body
     assert own in item.body
-    assert "https://x/confirm/" in item.body
-    url_lines = [ln for ln in item.body.splitlines() if ln.startswith("https://x/confirm/")]
+    assert "https://site.example/confirm/" in item.body
+    url_lines = [ln for ln in item.body.splitlines()
+                 if ln.startswith("https://site.example/confirm/")]
     assert len(url_lines) == 1 and " " not in url_lines[0]
-    assert "Leipzig" in item.body and "x" in item.body   # who, where, from which site
+    # who signed up where: the city, and the site as a host, not the URL
+    assert "Leipzig" in item.body
+    assert " site.example " in item.body
 
 
 def test_confirmation_without_a_city_name_still_reads_whole():

--- a/tests/test_confirmations.py
+++ b/tests/test_confirmations.py
@@ -5,7 +5,8 @@ import pytest
 from app.db import connect, init_schema
 from app.models import Filter
 from app.repo import insert_pending, confirm, pending_confirmations
-from app.confirmations import send_confirmation_now, send_pending_confirmations
+from app.confirmations import (build_confirmation, send_confirmation_now,
+                               send_pending_confirmations)
 
 
 @pytest.fixture
@@ -91,3 +92,28 @@ def test_retry_abandons_stale_signups(db):
     with patch("app.mail._call_mailjet_batch", return_value=200) as mb:
         send_pending_confirmations(db, _cfg())
     mb.assert_not_called()
+
+
+@pytest.mark.parametrize("lang, click, own", [
+    ("de", "Klick auf diesen Link", "Wenn du dich nicht angemeldet hast"),
+    ("en", "Click this link", "If you did not sign up"),
+])
+def test_confirmation_says_to_click_and_puts_the_link_on_its_own_line(lang, click, own):
+    # A bare "Bitte bestätige dein Abonnement: <url>" got answered by reply
+    # mail instead of a click (twice, by 2026-09-04).
+    item = build_confirmation(7, "a@example.com", lang, "leipzig", _cfg())
+    assert item.to == "a@example.com"
+    assert "Leipzig" in item.subject
+    assert click in item.body
+    assert own in item.body
+    assert "https://x/confirm/" in item.body
+    url_lines = [ln for ln in item.body.splitlines() if ln.startswith("https://x/confirm/")]
+    assert len(url_lines) == 1 and " " not in url_lines[0]
+    assert "Leipzig" in item.body and "x" in item.body   # who, where, from which site
+
+
+def test_confirmation_without_a_city_name_still_reads_whole():
+    item = build_confirmation(7, "a@example.com", "de", "no-such-city", _cfg())
+    assert "(" not in item.subject
+    assert "in None" not in item.body and "{" not in item.body
+    assert "Klick auf diesen Link" in item.body

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -69,7 +69,7 @@ def test_full_flow(env):
             "website":"",
         })
         assert r.status_code in (200, 302)
-    assert any("Bestätigung" in s for _, s in sent_mails)
+    assert any("bestätig" in s.lower() for _, s in sent_mails)
 
     # 2. confirm
     conn = connect(env)


### PR DESCRIPTION
The double-opt-in mail was one bare line: `Bitte bestätige dein Abonnement für <Stadt>: <url>`. It never said "Link" or "klicken", so it read as a request to answer, and twice now a subscriber replied "hiermit bestätige ich" by mail instead of clicking. In the 2026-08-31 snapshot 51 of 331 sign-ups from the last 30 days never confirmed.

New body (German; English mirrors it):

```
Betreff: Bitte bestätige deine Anmeldung bei Bürgerwecker (Münster)

Hallo,

du hast dich gerade auf buergerwecker.de für Terminbenachrichtigungen in Münster angemeldet.

Klick auf diesen Link, um die Anmeldung zu bestätigen:

https://buergerwecker.de/confirm/<token>

Erst danach bekommst du eine Mail, sobald ein passender Termin frei wird. Falls der Link nicht anklickbar ist, kopiere ihn in die Adresszeile deines Browsers.

Wenn du dich nicht angemeldet hast, ignoriere diese Mail einfach.

Bürgerwecker
```

- Site host comes from `PUBLIC_BASE_URL`, city name from the tenant's `display.json`; without a city name the sentence still reads whole.
- Token format unchanged, no `TOKEN_VERSION` bump.
- Tests: body says to click, URL is alone on its own line, no-city fallback; the e2e flow's subject check now matches the new subject.

Target to watch after deploy: the never-confirmed share of sign-ups (15% in the 08-31 snapshot).