### PR TITLE
Say what each mail means: confirmed, still subscribed, any office

### DIFF
--- a/app/digest.py
+++ b/app/digest.py
@@ -153,6 +153,10 @@ def render_digest_text(sub: Subscription, slots: list[Slot], *,
     elif catalog is not None and len(catalog.locations) <= 1:
         lines.append(t(lang, "digest.book_instructions_service_only",
                        services=services))
+    elif f.locations == "all":
+        # "Alle Standorte" is our label, not a choice on the city's site.
+        lines.append(t(lang, "digest.book_instructions_any_location",
+                       services=services))
     else:
         lines.append(t(lang, "digest.book_instructions",
                        services=services, locations=locations))

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -21,7 +21,8 @@ def run_once(conn: sqlite3.Connection) -> None:
     _soft_delete_expired(conn, cfg)
     _send_renewal_reminders(conn, cfg)
     _send_heartbeats(conn, cfg, milestone_days=30, milestone_col="heartbeat_30d_at")
-    _send_heartbeats(conn, cfg, milestone_days=60, milestone_col="heartbeat_60d_at")
+    _send_heartbeats(conn, cfg, milestone_days=60, milestone_col="heartbeat_60d_at",
+                     not_right_after="heartbeat_30d_at")
     _prune_seen_slots(conn)
     _prune_idempotency(conn)
     _prune_deferrals(conn)
@@ -196,8 +197,16 @@ def _heartbeat_mail(lang: str, *, city: str | None, days: int,
             f"Bürgerwecker\n")
     return subj, body
 
-def _send_heartbeats(conn, cfg, *, milestone_days: int, milestone_col: str):
+def _send_heartbeats(conn, cfg, *, milestone_days: int, milestone_col: str,
+                     not_right_after: str | None = None):
     from app.catalog import city_display_name
+    # A row eligible for the 60-day mail is eligible for the 30-day one too,
+    # so when both are overdue (housekeeping skipped the day-30 window) the
+    # pass before this one has just stamped `not_right_after`. Two heartbeats
+    # a second apart, one saying "30 Tage", one "60 Tage", read as a bug;
+    # wait a day instead — the 60-day mail then follows on its own.
+    gap = (f"AND {not_right_after} < datetime('now','-1 day') "
+           if not_right_after else "")
     # Send to subscribers who are past the milestone age AND haven't been
     # notified recently. "Recently" = within the milestone window, so a
     # subscriber notified once 5 days after signup still gets a heartbeat
@@ -206,7 +215,7 @@ def _send_heartbeats(conn, cfg, *, milestone_days: int, milestone_col: str):
         f"SELECT id, email, language, city FROM subscriptions "
         f"WHERE deleted_at IS NULL AND confirmed_at IS NOT NULL "
         f"AND expires_at > CURRENT_TIMESTAMP "
-        f"AND {milestone_col} IS NULL "
+        f"AND {milestone_col} IS NULL {gap}"
         f"AND (last_notified_at IS NULL "
         f"     OR last_notified_at < datetime('now','-{milestone_days} days')) "
         f"AND confirmed_at < datetime('now','-{milestone_days} days')"

--- a/app/housekeeping.py
+++ b/app/housekeeping.py
@@ -162,13 +162,48 @@ def _checkin_mail(lang: str, *, city: str | None, expires_at: str,
         )
     return subj, body
 
+def _heartbeat_mail(lang: str, *, city: str | None, days: int,
+                    manage_url: str, unsub_url: str) -> tuple[str, str]:
+    """"Still subscribed, nothing matched" — says what the silence means and
+    that a narrower filter is the usual reason, with each link labelled."""
+    if lang == "en":
+        where = f" in {city}" if city else ""
+        for_city = f" for {city}" if city else ""
+        subj = f"No matching appointments yet{where}"
+        body = (
+            f"Hello,\n\n"
+            f"you are still signed up with Bürgerwecker{for_city}. In the last "
+            f"{days} days no appointment matched your filter, so we had "
+            f"nothing to send. As soon as one opens up, you will get an "
+            f"email.\n\n"
+            f"Filter too narrow? Change days, times or locations here:\n\n"
+            f"{manage_url}\n\n"
+            f"Unsubscribe: {unsub_url}\n\n"
+            f"Bürgerwecker\n")
+    else:
+        where = f" in {city}" if city else ""
+        for_city = f" für {city}" if city else ""
+        subj = f"Noch keine passenden Termine{where}"
+        body = (
+            f"Hallo,\n\n"
+            f"du bist bei Bürgerwecker weiterhin{for_city} angemeldet. In den "
+            f"letzten {days} Tagen war kein Termin frei, der zu deinem Filter "
+            f"passt, deshalb kam keine Mail. Sobald einer auftaucht, bekommst "
+            f"du eine.\n\n"
+            f"Zu eng gefiltert? Tage, Zeiten oder Standorte hier ändern:\n\n"
+            f"{manage_url}\n\n"
+            f"Abmelden: {unsub_url}\n\n"
+            f"Bürgerwecker\n")
+    return subj, body
+
 def _send_heartbeats(conn, cfg, *, milestone_days: int, milestone_col: str):
+    from app.catalog import city_display_name
     # Send to subscribers who are past the milestone age AND haven't been
     # notified recently. "Recently" = within the milestone window, so a
     # subscriber notified once 5 days after signup still gets a heartbeat
     # at day 30 if no further notifications happened in between.
     rows = conn.execute(
-        f"SELECT id, email, language FROM subscriptions "
+        f"SELECT id, email, language, city FROM subscriptions "
         f"WHERE deleted_at IS NULL AND confirmed_at IS NOT NULL "
         f"AND expires_at > CURRENT_TIMESTAMP "
         f"AND {milestone_col} IS NULL "
@@ -185,13 +220,10 @@ def _send_heartbeats(conn, cfg, *, milestone_days: int, milestone_col: str):
                          primary=cfg.token_secret_primary,
                          previous=cfg.token_secret_previous)
         unsub_url = f"{cfg.public_base_url}/unsubscribe/{unsub_tok}"
-        body = (f"Du bist weiterhin abonniert — dein Filter passt einfach noch nicht. "
-                f"Hier verwalten: {manage_url}"
-                if row["language"] == "de" else
-                f"You're still subscribed — your filter just hasn't matched yet. "
-                f"Manage here: {manage_url}")
-        subj = ("Abo-Update" if row["language"] == "de"
-                else "Subscription check-in")
+        subj, body = _heartbeat_mail(
+            "en" if row["language"] == "en" else "de",
+            city=city_display_name(row["city"], row["language"]),
+            days=milestone_days, manage_url=manage_url, unsub_url=unsub_url)
         from app.db import transaction
         try:
             with transaction(conn):

--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -11,6 +11,7 @@
   "digest.book_link": "Zur Terminbuchung: {url}",
   "digest.book_instructions": "Wähle dort zuerst das Anliegen „{services}“, dann den Standort „{locations}“.",
   "digest.book_instructions_service_only": "Wähle dort das Anliegen „{services}“.",
+  "digest.book_instructions_any_location": "Wähle dort zuerst das Anliegen „{services}“, dann einen Standort deiner Wahl.",
   "digest.no_deeplink_note": "(Ein Direktlink zu einzelnen Terminen ist bei der Terminvergabe-Software der Stadt leider technisch nicht möglich.)",
   "digest.burst_warning": "Freie Termine sind oft schnell vergriffen — am besten gleich buchen.",
   "digest.no_repeat_note": "Hinweis: Jede E-Mail enthält nur neue Termine seit deiner letzten Benachrichtigung. Früher gemeldete Termine können ebenfalls noch frei sein.",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -11,6 +11,7 @@
   "digest.book_link": "Book here: {url}",
   "digest.book_instructions": "There, first select the service “{services}”, then the location “{locations}”.",
   "digest.book_instructions_service_only": "There, select the service “{services}”.",
+  "digest.book_instructions_any_location": "There, first select the service “{services}”, then whichever location suits you.",
   "digest.no_deeplink_note": "(The city's booking software unfortunately does not support direct links to individual appointments.)",
   "digest.burst_warning": "Open appointments are often taken quickly — book right away if one fits.",
   "digest.no_repeat_note": "Note: each email only lists appointments that are new since your last notification. Previously reported ones may still be available.",

--- a/app/web.py
+++ b/app/web.py
@@ -443,23 +443,36 @@ def _send_manage_link_email(conn, sub_id: int, cfg) -> None:
     city_name = city_display_name(row["city"], row["language"])
     suffix = f" ({city_name})" if city_name else ""
     end = _end_date(row["expires_at"], row["language"])
+    # Arrives the second after the confirm click, when the reader expects
+    # "Anmeldung bestätigt" — so say that first, then the link, then the
+    # term. "Verwaltungs-Link" stays as a word: the FAQ calls it that.
     if row["language"] == "de":
-        body = (f"Dein Verwaltungs-Link: {url}\nMit diesem Link kannst du deine "
-                f"Einstellungen jederzeit ändern oder dich abmelden.")
+        where = f" in {city_name}" if city_name else ""
+        body = (f"Hallo,\n\n"
+                f"deine Anmeldung ist aktiv. Sobald ein passender Termin{where} "
+                f"frei wird, bekommst du eine Mail.\n\n"
+                f"Dein Verwaltungs-Link, mit dem du deine Einstellungen "
+                f"jederzeit ändern oder dich abmelden kannst:\n\n{url}\n")
         if end:
-            body += (f"\n\nDeine Anmeldung läuft bis zum {end}. Kurz vorher "
-                     f"fragen wir per E-Mail, ob du noch suchst — ein Klick "
-                     f"verlängert sie dann, ohne Antwort endet sie automatisch.")
-        subj = f"Verwaltungs-Link{suffix}"
+            body += (f"\nDeine Anmeldung läuft bis zum {end}. Kurz vorher "
+                     f"fragen wir per E-Mail, ob du noch suchst. Ein Klick "
+                     f"verlängert sie, ohne Antwort endet sie automatisch.\n")
+        body += "\nBürgerwecker\n"
+        subj = f"Anmeldung bestätigt{suffix}"
     else:
-        body = (f"Your management link: {url}\nUse it any time to change your "
-                f"settings or unsubscribe.")
+        where = f" in {city_name}" if city_name else ""
+        body = (f"Hello,\n\n"
+                f"your sign-up is active. As soon as a matching appointment"
+                f"{where} opens up, you will get an email.\n\n"
+                f"Your management link, to change your settings or "
+                f"unsubscribe at any time:\n\n{url}\n")
         if end:
-            body += (f"\n\nYour subscription runs until {end}. Shortly before "
+            body += (f"\nYour subscription runs until {end}. Shortly before "
                      f"that we'll email you to ask whether you're still "
-                     f"looking — one click extends it, no reply ends it "
-                     f"automatically.")
-        subj = f"Management link{suffix}"
+                     f"looking. One click extends it, no reply ends it "
+                     f"automatically.\n")
+        body += "\nBürgerwecker\n"
+        subj = f"Sign-up confirmed{suffix}"
     key = _idem_key(sub_id, [], f"manage-link-{sub_id}")
     mail_send(conn, row["email"], subj, body, idem_key=key)
 

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -163,6 +163,23 @@ def test_digest_instructions_drop_location_for_single_location_tenant():
     assert "dann den Standort" not in line
 
 
+def test_digest_instructions_do_not_name_our_all_locations_label():
+    """"Alle Standorte" is the digest's own label for an unfiltered choice; the
+    city's site has no such entry, so the instruction must not tell people to
+    pick it."""
+    sub = _sub("de", appointment_types=["svc-A"], locations="all")
+    slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA")]
+    text = _render(sub, slots, catalog=_cat())
+    line = next(ln for ln in text.splitlines() if ln.startswith("Wähle dort"))
+    assert "„Alle Standorte“" not in line
+    assert "Standort deiner Wahl" in line
+    assert "Alle Standorte" in text            # the selection header still says it
+    text_en = _render(_sub("en", appointment_types=["svc-A"], locations="all"),
+                      slots, catalog=_cat())
+    assert "“All locations”" not in text_en
+    assert "whichever location suits you" in text_en
+
+
 def test_digest_en_booking_link_carries_lang_param():
     sub = _sub("en", appointment_types=["svc-A"], locations=["loc-1"])
     slots = [Slot("2026-06-12", "09:20", "loc-1", "svc-A", "tA")]

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -79,7 +79,7 @@ def test_full_flow(env):
     with _patch_mail():
         r = c.get(f"/confirm/{tok}")
     assert r.status_code in (200, 302)
-    assert any("Verwaltungs-Link" in s or "Management link" in s for _, s in sent_mails)
+    assert any("Anmeldung bestätigt" in s or "Sign-up confirmed" in s for _, s in sent_mails)
 
     # 3. run a polling cycle with a synthetic slot
     from app.cycle import run_cycle

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -270,6 +270,28 @@ def test_heartbeat_says_what_the_silence_means(db):
     assert "Abmelden: https://x/unsubscribe/" in body
 
 
+def test_overdue_subscriber_gets_one_heartbeat_per_run_not_two(db):
+    """Confirmed 70 days ago with nothing sent: eligible for both milestones,
+    but two mails a second apart claiming "30 Tage" and "60 Tage" read as a
+    bug. The 60-day pass waits a day after the 30-day stamp."""
+    sid = insert_pending(db, email="a@x.com", city="leipzig", language="de",
+                         filter_=_f(), ttl_days=90)
+    confirm(db, sid)
+    db.execute("UPDATE subscriptions SET confirmed_at=datetime('now','-70 days') "
+               "WHERE id=?", (sid,))
+    with patch("app.mail.send") as send:
+        run_once(db)
+    (call,) = _mails_to(send, "a@x.com")
+    assert "In den letzten 30 Tagen" in call.args[3]
+    # A day later the 60-day one follows.
+    db.execute("UPDATE subscriptions SET heartbeat_30d_at=datetime('now','-2 days') "
+               "WHERE id=?", (sid,))
+    with patch("app.mail.send") as send:
+        run_once(db)
+    (call,) = _mails_to(send, "a@x.com")
+    assert "In den letzten 60 Tagen" in call.args[3]
+
+
 def test_paused_subscription_gets_no_heartbeat(db):
     """The 30-day "you're still subscribed" heartbeat must not go to someone
     whose subscription has expired and is only waiting out the grace."""

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -254,6 +254,22 @@ def test_checkin_in_english(db):
     assert "Yes, keep looking: https://x/renew/" in call.args[3]
 
 
+def test_heartbeat_says_what_the_silence_means(db):
+    sid = insert_pending(db, email="a@x.com", city="leipzig", language="de",
+                         filter_=_f(), ttl_days=90)
+    confirm(db, sid)
+    db.execute("UPDATE subscriptions SET confirmed_at=datetime('now','-40 days') "
+               "WHERE id=?", (sid,))
+    with patch("app.mail.send") as send:
+        run_once(db)
+    (call,) = _mails_to(send, "a@x.com")
+    assert call.args[2] == "Noch keine passenden Termine in Leipzig"
+    body = call.args[3]
+    assert "In den letzten 30 Tagen war kein Termin frei" in body
+    assert "\n\nhttps://x/manage/" in body
+    assert "Abmelden: https://x/unsubscribe/" in body
+
+
 def test_paused_subscription_gets_no_heartbeat(db):
     """The 30-day "you're still subscribed" heartbeat must not go to someone
     whose subscription has expired and is only waiting out the grace."""

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -96,7 +96,9 @@ def test_manage_link_email_states_the_end_date(client):
         r = c.get(f"/confirm/{_sign(sid, 'confirm')}")
     assert r.status_code == 200
     body = ms.call_args.args[3]
-    assert "Verwaltungs-Link" in ms.call_args.args[2]
+    assert ms.call_args.args[2].startswith("Anmeldung bestätigt")
+    assert "deine Anmeldung ist aktiv" in body
+    assert "Verwaltungs-Link" in body          # the FAQ calls it that
     assert f"läuft bis zum {_expected_end_date(sid)}" in body
 
 


### PR DESCRIPTION
Follow-up to #85, from the same audit of all subscriber-facing mails. The digest and the still-looking check-in were fine; these three were not.

**Management-link mail** (sent on confirm). It lands the second after the confirm click, when the reader expects "Anmeldung bestätigt", but was titled "Verwaltungs-Link (<Stadt>)" and opened with a bare URL, never saying the subscription is active. Now:

```
Betreff: Anmeldung bestätigt (Münster)

Hallo,

deine Anmeldung ist aktiv. Sobald ein passender Termin in Münster frei wird, bekommst du eine Mail.

Dein Verwaltungs-Link, mit dem du deine Einstellungen jederzeit ändern oder dich abmelden kannst:

https://buergerwecker.de/manage/<token>

Deine Anmeldung läuft bis zum 4. Oktober 2026. Kurz vorher fragen wir per E-Mail, ob du noch suchst. Ein Klick verlängert sie, ohne Antwort endet sie automatisch.

Bürgerwecker
```

**Heartbeat** (30/60 days without a match). "Abo-Update" with one line became "Noch keine passenden Termine in <Stadt>": says what the silence means, that a narrower filter is the usual reason, with labelled manage and unsubscribe links. The heartbeat query now selects the city for the display name.

**Digest.** With all offices selected the instruction said "dann den Standort „Alle Standorte“", which is our label, not a choice on the city's site. New i18n key `digest.book_instructions_any_location`: "dann einen Standort deiner Wahl" / "then whichever location suits you". Single-location tenants and redacted digests are unchanged.

No token or idempotency-key changes. Tests cover each new body; the two existing assertions on the old subject were updated.