### PR TITLE
Confirm route: refuse a stale link instead of confirming a dead sign-up

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -1053,7 +1053,7 @@ def create_app() -> Flask:
             "SELECT language, city, expires_at, deleted_at, confirmed_at, "
             "expires_at < CURRENT_TIMESTAMP AS expired "
             "FROM subscriptions WHERE id=?", (sub_id,)).fetchone()
-        lang = row["language"] if row else request.args.get("lang", "de")
+        lang = request.args.get("lang") or (row["language"] if row else "de")
         # Confirm tokens never expire, so this is where a stale link is
         # caught: a purged or unsubscribed row gets the not-found page, a
         # row whose term ran out unconfirmed gets "sign up again" — never a
@@ -1062,9 +1062,14 @@ def create_app() -> Flask:
             return _result_page("not_found", lang, status=404)
         if row["expired"] and row["confirmed_at"] is None:
             q = "?lang=en" if lang == "en" else ""
+            try:
+                load_catalog(row["city"])
+                again = f"/{row['city']}{q}"
+            except CatalogError:       # city since decommissioned
+                again = f"/{q}"
             return _result_page(
                 "signup_expired", lang, status=410,
-                action_url=f"/{row['city']}{q}",
+                action_url=again,
                 action_label="Sign up again" if lang == "en" else "Neu anmelden")
         if row["expired"]:
             renew = sign(sub_id, "renew", primary=cfg.token_secret_primary,

--- a/app/web.py
+++ b/app/web.py
@@ -125,6 +125,21 @@ _RESULT_MESSAGES: dict[str, dict] = {
                "The link is malformed or no longer valid. Please use the most "
                "recent link from your email."),
     },
+    # A confirm link clicked after the sign-up's term ran out. The row is
+    # still there (soft-delete comes EXPIRED_GRACE_DAYS after expiry) but the
+    # poller already ignores it, so "bestätigt, läuft bis <past date>" would
+    # promise mail that never comes. Signing up again is the way back.
+    "signup_expired": {
+        "kind": "error",
+        "de": ("Anmeldung abgelaufen", "Diese Anmeldung ist abgelaufen",
+               "Der Bestätigungslink blieb zu lange ungenutzt, die Anmeldung "
+               "ist inzwischen beendet. Wenn du noch einen Termin suchst, "
+               "melde dich einfach neu an. Das dauert eine Minute."),
+        "en": ("Sign-up expired", "This sign-up has expired",
+               "The confirmation link went unused for too long and the "
+               "sign-up has since ended. If you are still looking for an "
+               "appointment, just sign up again. It takes a minute."),
+    },
     "not_found": {
         "kind": "error",
         "de": ("Nicht gefunden", "Abonnement nicht gefunden",
@@ -1021,10 +1036,24 @@ def create_app() -> Flask:
             return _result_page("invalid_token",
                                 request.args.get("lang", "de"), status=400)
         conn = connect(cfg.db_path)
+        row = conn.execute(
+            "SELECT language, city, expires_at, deleted_at, "
+            "expires_at < CURRENT_TIMESTAMP AS expired "
+            "FROM subscriptions WHERE id=?", (sub_id,)).fetchone()
+        lang = row["language"] if row else request.args.get("lang", "de")
+        # Confirm tokens never expire, so this is where a stale link is
+        # caught: a purged or unsubscribed row gets the not-found page, a
+        # row whose term ran out unconfirmed gets "sign up again" — never a
+        # confirmation of something the poller no longer looks at.
+        if row is None or row["deleted_at"] is not None:
+            return _result_page("not_found", lang, status=404)
+        if row["expired"]:
+            q = "?lang=en" if lang == "en" else ""
+            return _result_page(
+                "signup_expired", lang, status=410,
+                action_url=f"/{row['city']}{q}",
+                action_label="Sign up again" if lang == "en" else "Neu anmelden")
         confirm(conn, sub_id)
-        row = conn.execute("SELECT language, expires_at FROM subscriptions "
-                           "WHERE id=?", (sub_id,)).fetchone()
-        lang = row["language"] if row else "de"
         # The management-link email is a convenience, NOT part of confirmation.
         # The subscription is already confirmed above (autocommit), so a
         # mail-provider failure must never turn this into a 500 — log it and
@@ -1037,8 +1066,7 @@ def create_app() -> Flask:
                 sub_id,
             )
         return render_template("confirmed.html", lang=lang,
-                               expires=_end_date(row["expires_at"], lang)
-                               if row else None,
+                               expires=_end_date(row["expires_at"], lang),
                                kofi_url=cfg.kofi_url), 200
 
     # POST is the RFC 8058 one-click unsubscribe mail clients send to the

--- a/app/web.py
+++ b/app/web.py
@@ -140,6 +140,19 @@ _RESULT_MESSAGES: dict[str, dict] = {
                "sign-up has since ended. If you are still looking for an "
                "appointment, just sign up again. It takes a minute."),
     },
+    # Same link, but the person did confirm back then and the term has since
+    # run out (grace window, row not yet soft-deleted). "Ungenutzt" would be
+    # untrue for them, and /renew still revives the row — offer that.
+    "subscription_expired": {
+        "kind": "error",
+        "de": ("Anmeldung abgelaufen", "Diese Anmeldung ist abgelaufen",
+               "Die Laufzeit deiner Anmeldung ist vorbei, die "
+               "Benachrichtigungen haben aufgehört. Suchst du noch? Ein Klick "
+               "schaltet sie wieder ein."),
+        "en": ("Subscription expired", "This subscription has expired",
+               "Your subscription's term is over and notifications have "
+               "stopped. Still looking? One click switches them back on."),
+    },
     "not_found": {
         "kind": "error",
         "de": ("Nicht gefunden", "Abonnement nicht gefunden",
@@ -1037,7 +1050,7 @@ def create_app() -> Flask:
                                 request.args.get("lang", "de"), status=400)
         conn = connect(cfg.db_path)
         row = conn.execute(
-            "SELECT language, city, expires_at, deleted_at, "
+            "SELECT language, city, expires_at, deleted_at, confirmed_at, "
             "expires_at < CURRENT_TIMESTAMP AS expired "
             "FROM subscriptions WHERE id=?", (sub_id,)).fetchone()
         lang = row["language"] if row else request.args.get("lang", "de")
@@ -1047,12 +1060,19 @@ def create_app() -> Flask:
         # confirmation of something the poller no longer looks at.
         if row is None or row["deleted_at"] is not None:
             return _result_page("not_found", lang, status=404)
-        if row["expired"]:
+        if row["expired"] and row["confirmed_at"] is None:
             q = "?lang=en" if lang == "en" else ""
             return _result_page(
                 "signup_expired", lang, status=410,
                 action_url=f"/{row['city']}{q}",
                 action_label="Sign up again" if lang == "en" else "Neu anmelden")
+        if row["expired"]:
+            renew = sign(sub_id, "renew", primary=cfg.token_secret_primary,
+                         previous=cfg.token_secret_previous)
+            return _result_page(
+                "subscription_expired", lang, status=410,
+                action_url=f"/renew/{renew}",
+                action_label="Keep looking" if lang == "en" else "Weiter suchen")
         confirm(conn, sub_id)
         # The management-link email is a convenience, NOT part of confirmation.
         # The subscription is already confirmed above (autocommit), so a

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -90,6 +90,19 @@ def test_confirm_link_after_the_term_ran_out_says_sign_up_again(
     ms.assert_not_called()
 
 
+def test_expired_signup_for_a_decommissioned_city_sends_people_to_the_picker(client):
+    c, sid = client
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("UPDATE subscriptions SET city='atlantis', "
+                 "expires_at=datetime('now','-1 day') WHERE id=?", (sid,))
+    r = c.get(f"/confirm/{_sign(sid, 'confirm')}?lang=en")
+    assert r.status_code == 410
+    html = r.get_data(as_text=True)
+    assert "sign-up has expired" in html          # ?lang wins, as on /renew
+    assert 'href="/?lang=en"' in html
+    assert 'href="/atlantis' not in html
+
+
 def test_old_confirm_link_on_a_confirmed_expired_subscription_offers_renew(client):
     """Confirmed weeks ago, term over, grace window still open: the person is
     not told their link "blieb ungenutzt" — they get the renew link that

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -90,6 +90,32 @@ def test_confirm_link_after_the_term_ran_out_says_sign_up_again(
     ms.assert_not_called()
 
 
+def test_old_confirm_link_on_a_confirmed_expired_subscription_offers_renew(client):
+    """Confirmed weeks ago, term over, grace window still open: the person is
+    not told their link "blieb ungenutzt" — they get the renew link that
+    revives the row, and it works."""
+    from unittest.mock import patch
+    c, sid = client
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("UPDATE subscriptions SET confirmed_at=datetime('now','-30 days'), "
+                 "expires_at=datetime('now','-1 day') WHERE id=?", (sid,))
+    with patch("app.web._send_manage_link_email") as ms:
+        r = c.get(f"/confirm/{_sign(sid, 'confirm')}")
+    assert r.status_code == 410
+    html = r.get_data(as_text=True)
+    assert "Laufzeit deiner Anmeldung ist vorbei" in html
+    assert "ungenutzt" not in html
+    ms.assert_not_called()
+    import re
+    href = re.search(r'href="(/renew/[^"]+)"', html).group(1)
+    r2 = c.get(href)
+    assert r2.status_code == 200
+    assert "Wir suchen weiter" in r2.get_data(as_text=True)
+    expired = conn.execute("SELECT expires_at < CURRENT_TIMESTAMP FROM subscriptions "
+                           "WHERE id=?", (sid,)).fetchone()[0]
+    assert not expired
+
+
 def test_confirm_survives_manage_link_email_failure(client):
     """A failure sending the (secondary) management-link email must NOT turn a
     successful confirmation into a 500. The subscription is already confirmed;

--- a/tests/test_token_routes.py
+++ b/tests/test_token_routes.py
@@ -46,6 +46,50 @@ def test_confirm_marks_subscription_confirmed(client):
         r2 = c.get(f"/confirm/{tok}")
     assert r2.status_code in (200, 302)
 
+def _confirmed_at(sid):
+    conn = connect(os.environ["DB_PATH"])
+    return conn.execute("SELECT confirmed_at FROM subscriptions WHERE id=?",
+                        (sid,)).fetchone()[0]
+
+
+def test_confirm_link_on_an_unsubscribed_signup_is_not_found(client):
+    from unittest.mock import patch
+    c, sid = client
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("UPDATE subscriptions SET deleted_at=CURRENT_TIMESTAMP WHERE id=?",
+                 (sid,))
+    with patch("app.web._send_manage_link_email") as ms:
+        r = c.get(f"/confirm/{_sign(sid, 'confirm')}")
+    assert r.status_code == 404
+    assert "existiert nicht mehr" in r.get_data(as_text=True)
+    assert _confirmed_at(sid) is None
+    ms.assert_not_called()
+
+
+@pytest.mark.parametrize("lang, expect_text, expect_href", [
+    ("de", "Anmeldung ist abgelaufen", 'href="/leipzig"'),
+    ("en", "sign-up has expired", 'href="/leipzig?lang=en"'),
+])
+def test_confirm_link_after_the_term_ran_out_says_sign_up_again(
+        client, lang, expect_text, expect_href):
+    """Confirm tokens never expire, and an unconfirmed row outlives its term
+    for EXPIRED_GRACE_DAYS before the soft-delete. Confirming it then would
+    show "läuft bis <past date>" and mail a promise the poller never keeps."""
+    from unittest.mock import patch
+    c, sid = client
+    conn = connect(os.environ["DB_PATH"])
+    conn.execute("UPDATE subscriptions SET language=?, "
+                 "expires_at=datetime('now','-1 day') WHERE id=?", (lang, sid))
+    with patch("app.web._send_manage_link_email") as ms:
+        r = c.get(f"/confirm/{_sign(sid, 'confirm')}")
+    assert r.status_code == 410
+    html = r.get_data(as_text=True)
+    assert expect_text in html
+    assert expect_href in html
+    assert _confirmed_at(sid) is None
+    ms.assert_not_called()
+
+
 def test_confirm_survives_manage_link_email_failure(client):
     """A failure sending the (secondary) management-link email must NOT turn a
     successful confirmation into a 500. The subscription is already confirmed;


### PR DESCRIPTION
Closes the hole the #86 review flagged. Confirm tokens never expire and `confirm_route` only guarded on `confirmed_at IS NULL`, so a weeks-old link on a sign-up whose term had run out, or that was already unsubscribed, still confirmed it, rendered "läuft bis <past date>", and sent the "deine Anmeldung ist aktiv" mail for a row the poller no longer looks at.

Now the route loads the row before confirming:

- deleted or purged row: the existing not-found page, 404
- `expires_at` in the past: new `signup_expired` result page ("Diese Anmeldung ist abgelaufen ... melde dich einfach neu an") with a "Neu anmelden" button to the city page, 410, language-aware

Neither path touches `confirmed_at` or sends the management-link mail. The expiry check is done in SQL against `CURRENT_TIMESTAMP`, the same clock housekeeping uses. Confirmed rows in the grace window are covered too: re-clicking their confirm link now says expired instead of "bestätigt, läuft bis <yesterday>".

Tests: unsubscribed sign-up, expired sign-up in both languages (page text, button href, no confirm, no mail); the existing double-click idempotency test still passes.